### PR TITLE
Draw upstream's own icons in the page templates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3458,6 +3458,42 @@ Still open from this pass:
       All 165 were loaded and checked in a real browser (see the hydration sweep above): none
       throws, none fails to hydrate, and every image the example blocks reference renders
 
+### Page-template icons — real glyphs, and the `IconType` that blocked them (2026-08-10)
+
+The 43 page templates drew the **wrong pictures**. 69 documented substitutions across **37 of
+43** files mapped upstream's ~85 distinct Heroicons onto core's **28-name semantic registry** —
+`PlusIcon` → `check` (×8, so "Add" buttons drew a checkmark), `StarIcon` → `check` (rating stars
+drew checkmarks), `PencilSquareIcon` → `copy`, `SparklesIcon` → `wrench`, `FolderIcon` → `menu`.
+The same upstream icon was mapped inconsistently across files (`LockClosedIcon` reached `stop`,
+`eyeSlash` _and_ `warning`). Styles were never involved: the class oracle read 0 mismatches
+before and after.
+
+**The header comments blamed the wrong thing.** They asserted Heroicons "has no Svelte build".
+The real blocker was one line of core: `IconType = Component<SVGAttributes<SVGSVGElement>>`, the
+literal translation of upstream's `ComponentType<SVGProps<SVGSVGElement>>`. Component props are
+contravariant and the element parameter reaches `DOMAttributes<T>`'s handlers, so **every** real
+Svelte icon package failed it — measured, not assumed: `@fvilers/heroicons-svelte` on the element
+parameter, `@lucide/svelte` (already this repo's theme dependency) on a narrowed `name`,
+`svelte-heros-v2` on a narrowed `focusable`, `heroicons-svelte` on being Svelte 4 classes.
+`@heroicons/react` accepts the _full_ `SVGProps` and only adds optional extras, which is why
+upstream's type admits its own icon set and ours admitted nothing. `IconType` is now a bare
+`Component`, which is the call shadcn-svelte makes for the same reason.
+
+- **All 149 icon sites now draw upstream's glyph.** `@fvilers/heroicons-svelte` mirrors
+  `@heroicons/react`'s entry points (`24/outline`, `20/solid`, `24/solid`) _and_ its `XxxIcon`
+  export names, so the imports are upstream's with the package name changed. `theme-showcase` is
+  the one page upstream draws with Lucide, and it uses `@lucide/svelte` for the same reason.
+  Both are `packages/cli` devDependencies — the templates are CLI assets, so resolution has to
+  work from that path, and upstream's arrangement is the same (its sandbox declares
+  `@heroicons/react`; its CLI declares nothing)
+- **One export name differs**: heroicons-react's `Squares2X2Icon` is `Squares2x2Icon` here
+- **Three `Selector.startIcon`s in `theme-showcase`** went through the `Snippet` arm, so
+  `INVENTORY_FILTERS` became `$derived.by` — a snippet does not exist while `<script>` runs
+- [ ] **Templates are not typechecked, and this is how the substitutions survived.**
+      Mutation-checked: a deliberate type error in a template produces **0** `svelte-check`
+      errors, because `assets/` is outside every tsconfig include. It matters more now that
+      templates import real packages — a scaffolded app _does_ typecheck what it received
+
 ### After launch
 
 - [x] **The shell is fully dogfooded** — palette and outline in batch 9, then frame, header and

--- a/packages/cli/assets/templates/pages/ai-chat-landing/+page.svelte
+++ b/packages/cli/assets/templates/pages/ai-chat-landing/+page.svelte
@@ -2,14 +2,13 @@
 	Ported from upstream's `assets/templates/pages/ai-chat-landing/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons, which has no Svelte build, so every icon is a
-	registry substitution: `MagnifyingGlassIcon` → `search` and `ClockIcon` →
-	`clock` are true matches; the rest are stand-ins with no registry glyph —
-	`Cog6ToothIcon` → `wrench`, `AtSymbolIcon` → `moreHorizontal`, `SparklesIcon`
-	→ `info`, `PencilSquareIcon` → `copy`, `CodeBracketIcon` → `chevronsRight`,
-	`LockClosedIcon` → `eyeSlash`, `LightBulbIcon` → `warning`. `SparklesIcon`
-	and `LightBulbIcon` land on `info`/`warning` purely for shape; both read as
-	status glyphs they are not. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's three `CSSProperties` consts become `style` strings under the same
 	names and key order, because Svelte's `style` prop is a string.
@@ -50,6 +49,7 @@
 		type ChatComposerTrigger,
 		type SearchableItem
 	} from '@astryx-svelte/core';
+	import { AtSymbolIcon, Cog6ToothIcon, SparklesIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	// Fill the content area so the greeting and composer stay vertically centered.
 	const pageStyle = 'min-height: 100%;';
@@ -331,7 +331,7 @@
 	</ChatComposerDrawer>
 {/snippet}
 
-{#snippet referenceIcon()}<Icon icon="moreHorizontal" size="sm" />{/snippet}
+{#snippet referenceIcon()}<Icon icon={AtSymbolIcon} size="sm" />{/snippet}
 
 {#snippet headerActions()}
 	<DropdownMenu
@@ -357,7 +357,7 @@
 
 {#snippet activeModeIcon()}<Icon icon={activeMode.icon} size="sm" />{/snippet}
 {#snippet activeModeLabel()}{activeMode.label}{/snippet}
-{#snippet settingsIcon()}<Icon icon="wrench" size="sm" />{/snippet}
+{#snippet settingsIcon()}<Icon icon={Cog6ToothIcon} size="sm" />{/snippet}
 {#snippet settingsLabel()}Settings{/snippet}
 
 {#snippet footerActions()}
@@ -423,7 +423,7 @@
 			<!-- Greeting -->
 			<VStack gap={1}>
 				<HStack gap={2} vAlign="center">
-					<Icon icon="info" size="md" color="accent" />
+					<Icon icon={SparklesIcon} size="md" color="accent" />
 					<Text type="large" as="h2">Hi, Andrew</Text>
 				</HStack>
 				<Text type="display-2" as="h1">Where should we start?</Text>

--- a/packages/cli/assets/templates/pages/ai-chat/+page.svelte
+++ b/packages/cli/assets/templates/pages/ai-chat/+page.svelte
@@ -2,13 +2,13 @@
 	Ported from upstream's `assets/templates/pages/ai-chat/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons, which has no Svelte build, so every icon is a
-	registry substitution: `XMarkIcon` → `close` and `ChevronRightIcon` →
-	`chevronRight` are true matches, `ClipboardDocumentIcon` → `copy` is near
-	enough; the rest are stand-ins with no registry glyph — `DocumentTextIcon` →
-	`menu` (ruled lines, but it reads as a hamburger), `ShareIcon` →
-	`externalLink`, `AtSymbolIcon` → `moreHorizontal`, `PaperClipIcon` →
-	`arrowUp`. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `CSSProperties` consts become `style` strings under the same names
 	and key order, because Svelte's `style` prop is a string; that includes
@@ -73,6 +73,15 @@
 		VStack,
 		useResizable
 	} from '@astryx-svelte/core';
+	import {
+		AtSymbolIcon,
+		ChevronRightIcon,
+		ClipboardDocumentIcon,
+		DocumentTextIcon,
+		PaperClipIcon,
+		ShareIcon,
+		XMarkIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	// Below this width the split-pane collapses to a single chat column. Shared by
 	// the CSS container query and the JS check in openArtifact so they can't drift.
@@ -228,9 +237,9 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
 
 <!-- Artifact subviews -->
 
-{#snippet copyIcon()}<Icon icon="copy" size="sm" />{/snippet}
-{#snippet shareIcon()}<Icon icon="externalLink" size="sm" />{/snippet}
-{#snippet closeIcon()}<Icon icon="close" size="sm" />{/snippet}
+{#snippet copyIcon()}<Icon icon={ClipboardDocumentIcon} size="sm" />{/snippet}
+{#snippet shareIcon()}<Icon icon={ShareIcon} size="sm" />{/snippet}
+{#snippet closeIcon()}<Icon icon={XMarkIcon} size="sm" />{/snippet}
 
 <!--
 	Header actions: version menu, copy, share. Pass `onClose` for the desktop
@@ -301,7 +310,7 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
 		style={artifactCard}
 	>
 		<HStack gap={3} vAlign="center" width="100%">
-			<Icon icon="menu" size="md" color="secondary" />
+			<Icon icon={DocumentTextIcon} size="md" color="secondary" />
 			<StackItem size="fill">
 				<VStack gap={0}>
 					<Text type="label" weight="semibold">
@@ -310,7 +319,7 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
 					<Text type="supporting" color="secondary">Document</Text>
 				</VStack>
 			</StackItem>
-			<Icon icon="chevronRight" size="sm" color="secondary" />
+			<Icon icon={ChevronRightIcon} size="sm" color="secondary" />
 		</HStack>
 	</ClickableCard>
 {/snippet}
@@ -318,8 +327,8 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
 <!-- Composer -->
 
 {#snippet composerInputSlot()}<ChatComposerInput />{/snippet}
-{#snippet mentionIcon()}<Icon icon="moreHorizontal" size="sm" />{/snippet}
-{#snippet attachIcon()}<Icon icon="arrowUp" size="sm" />{/snippet}
+{#snippet mentionIcon()}<Icon icon={AtSymbolIcon} size="sm" />{/snippet}
+{#snippet attachIcon()}<Icon icon={PaperClipIcon} size="sm" />{/snippet}
 
 {#snippet composerHeaderActions()}
 	<Button label="Mention" variant="ghost" size="sm" icon={mentionIcon} isIconOnly />
@@ -395,7 +404,7 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
 
 {#snippet toolbarStartContent()}
 	<HStack gap={3} vAlign="center">
-		<Icon icon="menu" size="sm" color="secondary" />
+		<Icon icon={DocumentTextIcon} size="sm" color="secondary" />
 		<VStack gap={0}>
 			<Text type="label" weight="semibold">
 				{ARTIFACT_TITLE}

--- a/packages/cli/assets/templates/pages/centered-hero/+page.svelte
+++ b/packages/cli/assets/templates/pages/centered-hero/+page.svelte
@@ -2,9 +2,13 @@
 	Ported from upstream's `assets/templates/pages/centered-hero/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons' `ArrowRightIcon`. The icon registry ships no
-	right-pointing arrow, so this is a registry substitution to `chevronRight` —
-	the same stand-in the docs examples make. Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's two `CSSProperties` objects become inline `style` strings; the
 	values are unchanged, and `maxWidth: 1200` picks up React's implicit `px`.
@@ -22,6 +26,7 @@
 		Text,
 		VStack
 	} from '@astryx-svelte/core';
+	import { ArrowRightIcon } from '@fvilers/heroicons-svelte/20/solid';
 
 	const IMAGE_URL = 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png';
 
@@ -29,7 +34,7 @@
 	const heroFrame = 'max-width: 1200px; margin-inline: auto; border-radius: var(--radius-page);';
 </script>
 
-{#snippet arrowRightIcon()}<Icon icon="chevronRight" size="sm" color="inherit" />{/snippet}
+{#snippet arrowRightIcon()}<Icon icon={ArrowRightIcon} size="sm" color="inherit" />{/snippet}
 
 {#snippet content()}
 	<LayoutContent padding={6}>

--- a/packages/cli/assets/templates/pages/contact-form/+page.svelte
+++ b/packages/cli/assets/templates/pages/contact-form/+page.svelte
@@ -2,12 +2,13 @@
 	Ported from upstream's `assets/templates/pages/contact-form/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVGs, so the three
-	"Why work with us" icons are registry substitutions: `RocketLaunchIcon` →
-	`arrowUp`, `AdjustmentsHorizontalIcon` → `wrench`, `HandRaisedIcon` →
-	`stop`. None is a true match — the registry ships 28 semantic names and no
-	rocket, sliders or raised hand — so all three are stand-ins, the same ones
-	the docs examples make. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Because of that, `WHY_US.icon` holds an `IconName` string here where
 	upstream holds a component reference; `<Icon icon={item.icon} …>` is

--- a/packages/cli/assets/templates/pages/dashboard-portfolio/+page.svelte
+++ b/packages/cli/assets/templates/pages/dashboard-portfolio/+page.svelte
@@ -5,9 +5,13 @@
 	Two upstream dependencies have no Svelte counterpart, and both are handled
 	the way this repo already handles them elsewhere.
 
-	1. Icons. Upstream imports Heroicons; the registry substitutions are
-	   `ArrowUpIcon` → `arrowUp` and `ArrowDownIcon` → `arrowDown`, which are
-	   both true matches rather than stand-ins. Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	2. Charts. Upstream draws with `recharts`, a React-only library — there is
 	   no Svelte build of it, and adding one is not something a scaffolded

--- a/packages/cli/assets/templates/pages/dashboard/+page.svelte
+++ b/packages/cli/assets/templates/pages/dashboard/+page.svelte
@@ -5,12 +5,13 @@
 	Two upstream dependencies have no Svelte counterpart, and both are handled
 	the way this repo already handles them elsewhere.
 
-	1. Icons. Upstream imports Heroicons. `ArrowUpIcon` → `arrowUp` and
-	   `ArrowDownIcon` → `arrowDown` are true matches; the solid `StopIcon` →
-	   `stop` is too (the registry's `stop` is a filled rounded square, the same
-	   glyph the legend swatches want). `ArrowPathIcon` → `arrowsUpDown` is a
-	   registry stand-in, the same one `ChatMessageMetadataFooter` makes.
-	   Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	2. Charts. Upstream draws with `recharts`, a React-only library — there is
 	   no Svelte build of it, and adding one is not something a scaffolded
@@ -69,6 +70,8 @@
 		proportional,
 		type TableColumn
 	} from '@astryx-svelte/core';
+	import { ArrowDownIcon, ArrowPathIcon, ArrowUpIcon } from '@fvilers/heroicons-svelte/24/outline';
+	import { StopIcon } from '@fvilers/heroicons-svelte/24/solid';
 
 	// ============= DATA =============
 
@@ -531,7 +534,7 @@
 
 {#snippet chartLegendItem(color: string, label: string)}
 	<HStack gap={2} vAlign="center">
-		<Icon icon="stop" size="xsm" style="color: {color};" />
+		<Icon icon={StopIcon} size="xsm" style="color: {color};" />
 		<Text type="supporting" color="secondary">{label}</Text>
 	</HStack>
 {/snippet}
@@ -542,7 +545,7 @@
 			<Text type="supporting" color="secondary">{point?.label ?? ''}</Text>
 			{#each activeSeries as entry (entry.name)}
 				<HStack gap={2} vAlign="center">
-					<Icon icon="stop" size="xsm" style="color: {entry.color};" />
+					<Icon icon={StopIcon} size="xsm" style="color: {entry.color};" />
 					<Text type="supporting">{entry.name}: {point[entry.dataKey]}</Text>
 				</HStack>
 			{/each}
@@ -651,9 +654,9 @@
 				<Heading level={2}>{metric.value}</Heading>
 				<HStack gap={1} vAlign="center">
 					{#if metric.positive}
-						<Icon icon="arrowUp" size="xsm" color="success" />
+						<Icon icon={ArrowUpIcon} size="xsm" color="success" />
 					{:else}
-						<Icon icon="arrowDown" size="xsm" color="error" />
+						<Icon icon={ArrowDownIcon} size="xsm" color="error" />
 					{/if}
 					<Text type="body" color="secondary">{metric.change}</Text>
 				</HStack>
@@ -685,7 +688,7 @@
 				{#each data as d (d.label)}
 					<VStack gap={0}>
 						<HStack gap={2} vAlign="center">
-							<Icon icon="stop" size="xsm" style="color: {d.color};" />
+							<Icon icon={StopIcon} size="xsm" style="color: {d.color};" />
 							<Text type="supporting">{d.label}</Text>
 						</HStack>
 						<Text type="supporting" color="secondary">
@@ -758,7 +761,7 @@
 <!-- ============= MAIN COMPONENT ============= -->
 
 {#snippet reloadIcon()}
-	<Icon icon="arrowsUpDown" size="sm" />
+	<Icon icon={ArrowPathIcon} size="sm" />
 {/snippet}
 
 {#snippet content()}

--- a/packages/cli/assets/templates/pages/detail-page/+page.svelte
+++ b/packages/cli/assets/templates/pages/detail-page/+page.svelte
@@ -2,15 +2,13 @@
 	Ported from upstream's `assets/templates/pages/detail-page/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`ArrowLeftIcon` → `chevronLeft`, `CalendarIcon` → `calendar`, `FunnelIcon` →
-	`funnel`, `ViewColumnsIcon` → `viewColumns`, `HandThumbUpIcon` → `success`,
-	`FlagIcon` → `warning`, `HeartIcon` → `info`, `PencilSquareIcon` → `copy`.
-	The first four are true matches (`chevronLeft` a near-direct swap); the last
-	four are stand-ins the 28-name registry cannot do better on — `info` is the
-	registry's general-purpose filler and `copy` repeats the substitution the
-	`messaging-shell` template makes for the same pencil glyph. Retires with the
-	icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `Bullet`, `PageHeader`, `ItemsCard`, `InvoiceCard`,
 	`TimelineSection`, `PanelContent` and `RightPanel` are components; a page
@@ -57,6 +55,16 @@
 		VStack,
 		useMediaQuery
 	} from '@astryx-svelte/core';
+	import {
+		ArrowLeftIcon,
+		CalendarIcon,
+		FlagIcon,
+		FunnelIcon,
+		HandThumbUpIcon,
+		HeartIcon,
+		PencilSquareIcon,
+		ViewColumnsIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	// ─── Styles ─────────────────────────────────────────────────────────────────
 
@@ -182,7 +190,7 @@
 {/snippet}
 
 <!-- ─── Page Header ───────────────────────────────────────────────────────── -->
-{#snippet viewColumnsIcon()}<Icon icon="viewColumns" size="sm" />{/snippet}
+{#snippet viewColumnsIcon()}<Icon icon={ViewColumnsIcon} size="sm" />{/snippet}
 
 {#snippet pageHeader()}
 	<LayoutHeader hasDivider padding={4}>
@@ -192,7 +200,7 @@
 					<VStack gap={0}>
 						<Link href="#" color="secondary">
 							<HStack gap={1} vAlign="center">
-								<Icon icon="chevronLeft" size="sm" color="inherit" />
+								<Icon icon={ArrowLeftIcon} size="sm" color="inherit" />
 								All orders
 							</HStack>
 						</Link>
@@ -213,12 +221,12 @@
 								</HStack>
 								<HStack gap={1} vAlign="center">
 									{@render bullet()}
-									<Icon icon="calendar" size="sm" color="secondary" />
+									<Icon icon={CalendarIcon} size="sm" color="secondary" />
 									<Text type="body" maxLines={1}>02/23/2026</Text>
 								</HStack>
 								<HStack gap={1} vAlign="center">
 									{@render bullet()}
-									<Icon icon="warning" size="sm" color="secondary" />
+									<Icon icon={FlagIcon} size="sm" color="secondary" />
 									<Text type="body" maxLines={1}>Needs attention</Text>
 								</HStack>
 								<HStack gap={1} vAlign="center">
@@ -410,7 +418,7 @@
 {/snippet}
 
 <!-- ─── Timeline ──────────────────────────────────────────────────────────── -->
-{#snippet funnelIcon()}<Icon icon="funnel" />{/snippet}
+{#snippet funnelIcon()}<Icon icon={FunnelIcon} />{/snippet}
 
 {#snippet timelineSection()}
 	<Section>
@@ -437,7 +445,7 @@
 												<VStack gap={1}>
 													{#each item.changes as change, j (j)}
 														<HStack gap={2} vAlign="center">
-															<Icon icon="copy" size="sm" color="secondary" />
+															<Icon icon={PencilSquareIcon} size="sm" color="secondary" />
 															<Text type="supporting" color="secondary">{change}</Text>
 														</HStack>
 													{/each}
@@ -447,8 +455,8 @@
 									</Card>
 									<HStack gap={3} vAlign="center">
 										<HStack gap={1} vAlign="center">
-											<Icon icon="success" size="xsm" color="secondary" />
-											<Icon icon="info" size="xsm" color="secondary" />
+											<Icon icon={HandThumbUpIcon} size="xsm" color="secondary" />
+											<Icon icon={HeartIcon} size="xsm" color="secondary" />
 											<Text type="supporting" color="secondary">{item.reactions}</Text>
 										</HStack>
 										<Text type="supporting" color="secondary">Like</Text>

--- a/packages/cli/assets/templates/pages/documentation-design/+page.svelte
+++ b/packages/cli/assets/templates/pages/documentation-design/+page.svelte
@@ -2,12 +2,13 @@
 	Ported from upstream's `assets/templates/pages/documentation-design/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`ArrowTopRightOnSquareIcon` → `externalLink` (a true match),
-	`ArrowsPointingOutIcon` → `arrowsUpDown`, `PlusIcon` → `check` (the registry
-	ships no plus — TODO.md records the gap, and the `Toolbar` example makes the
-	same swap). The last two are stand-ins. Retires with the icon registry
-	(TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `DialogPreview` is a component with one `useState`, and
 	`ComponentDetailView` is a second component the page renders with
@@ -62,6 +63,11 @@
 		useMediaQuery,
 		type OutlineItem
 	} from '@astryx-svelte/core';
+	import {
+		ArrowTopRightOnSquareIcon,
+		ArrowsPointingOutIcon,
+		PlusIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	const tabListFlush = 'margin-inline-start: -12px;';
 	const outlinePanel =
@@ -530,9 +536,9 @@
 	const docs = $derived(getComponentDocs(activeNav));
 </script>
 
-{#snippet plusIcon()}<Icon icon="check" />{/snippet}
-{#snippet arrowTopRightOnSquareIcon()}<Icon icon="externalLink" />{/snippet}
-{#snippet arrowsPointingOutIcon()}<Icon icon="arrowsUpDown" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} />{/snippet}
+{#snippet arrowTopRightOnSquareIcon()}<Icon icon={ArrowTopRightOnSquareIcon} />{/snippet}
+{#snippet arrowsPointingOutIcon()}<Icon icon={ArrowsPointingOutIcon} />{/snippet}
 {#snippet newBadge()}<Badge label="New" variant="info" />{/snippet}
 
 {#snippet dialogPreview()}

--- a/packages/cli/assets/templates/pages/documentation-technical/+page.svelte
+++ b/packages/cli/assets/templates/pages/documentation-technical/+page.svelte
@@ -2,11 +2,13 @@
 	Ported from upstream's `assets/templates/pages/documentation-technical/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`SparklesIcon` → `wrench`, `ClipboardDocumentIcon` → `copy` (an exact match),
-	`ChevronDownIcon` → `chevronDown` (a true match). Only `wrench` is a stand-in,
-	the same one the `ChatComposer` and `ChatSendButton` examples make. Retires
-	with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `outlinePanel` is a `CSSProperties` const applied through the
 	`style` prop; here it is a string of the same declarations, because Svelte's
@@ -37,6 +39,11 @@
 		useMediaQuery,
 		type OutlineItem
 	} from '@astryx-svelte/core';
+	import {
+		ChevronDownIcon,
+		ClipboardDocumentIcon,
+		SparklesIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	// ---------------------------------------------------------------------------
 	// Main component
@@ -70,8 +77,8 @@
 	}
 </script>
 
-{#snippet clipboardDocumentIcon()}<Icon icon="copy" />{/snippet}
-{#snippet chevronDownIcon()}<Icon icon="chevronDown" />{/snippet}
+{#snippet clipboardDocumentIcon()}<Icon icon={ClipboardDocumentIcon} />{/snippet}
+{#snippet chevronDownIcon()}<Icon icon={ChevronDownIcon} />{/snippet}
 
 {#snippet outlineEnd()}
 	<LayoutPanel isScrollable={false} label="On this page" role="complementary" style={outlinePanel}>
@@ -102,7 +109,7 @@
 					<HStack gap={2} vAlign="center">
 						<StackItem size="fill">
 							<HStack gap={2} vAlign="center">
-								<Icon icon="wrench" size="sm" color="secondary" />
+								<Icon icon={SparklesIcon} size="sm" color="secondary" />
 								<Text type="body" weight="semibold">AI Assistance</Text>
 							</HStack>
 						</StackItem>

--- a/packages/cli/assets/templates/pages/editor/+page.svelte
+++ b/packages/cli/assets/templates/pages/editor/+page.svelte
@@ -18,16 +18,13 @@
 	`ChatBubbleLeftIcon` → `moreHorizontal`, `PlayCircleIcon` → `chevronRight`,
 	`LockClosedIcon` → `warning`.
 
-	Twenty-four glyphs cannot stay distinct across a 28-name registry, so seven
-	names carry two or more: `viewColumns` covers Squares2X2 and ViewColumns;
-	`copy` covers DocumentText, DeviceTablet and Banknotes; `arrowUp` covers
-	CursorArrowRays and ChevronUp; `close` covers Trash and XMark; `wrench`
-	covers Sparkles and AdjustmentsHorizontal; `moreHorizontal` covers
-	ChatBubbleLeft and EllipsisHorizontal; `stop` covers ComputerDesktop and
-	ShoppingBag. The three
-	device glyphs of the viewport control get three *different* stand-ins on
-	purpose — the items are `isLabelHidden`, so identical icons would make them
-	untellable. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `IconComponent` alias goes with the Heroicons: an icon here is an
 	`IconName`, which is what `BLOCK_META.icon` and `CATEGORY_ICONS` now hold.
@@ -98,6 +95,21 @@
 		type IconName,
 		type TableColumn
 	} from '@astryx-svelte/core';
+	import {
+		AdjustmentsHorizontalIcon,
+		ChevronDownIcon,
+		ChevronUpIcon,
+		ComputerDesktopIcon,
+		DevicePhoneMobileIcon,
+		DeviceTabletIcon,
+		EllipsisHorizontalIcon,
+		EyeIcon,
+		LockClosedIcon,
+		PhotoIcon,
+		PlusCircleIcon,
+		TrashIcon,
+		XMarkIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	type BlockType = 'hero' | 'text' | 'image' | 'button' | 'cards' | 'features' | 'cta';
 
@@ -384,18 +396,18 @@
 	}
 </script>
 
-{#snippet ellipsisHorizontalIcon()}<Icon icon="moreHorizontal" size="sm" />{/snippet}
-{#snippet photoIcon()}<Icon icon="calendar" />{/snippet}
-{#snippet plusCircleIcon()}<Icon icon="check" />{/snippet}
-{#snippet chevronUpIcon()}<Icon icon="arrowUp" size="sm" />{/snippet}
-{#snippet chevronDownIcon()}<Icon icon="chevronDown" size="sm" />{/snippet}
-{#snippet trashIcon()}<Icon icon="close" size="sm" />{/snippet}
-{#snippet computerDesktopIcon()}<Icon icon="stop" size="sm" />{/snippet}
-{#snippet deviceTabletIcon()}<Icon icon="copy" size="sm" />{/snippet}
-{#snippet devicePhoneMobileIcon()}<Icon icon="menu" size="sm" />{/snippet}
-{#snippet eyeIcon()}<Icon icon="eyeSlash" size="sm" />{/snippet}
-{#snippet adjustmentsHorizontalIcon()}<Icon icon="wrench" size="sm" />{/snippet}
-{#snippet xMarkIcon()}<Icon icon="close" size="sm" />{/snippet}
+{#snippet ellipsisHorizontalIcon()}<Icon icon={EllipsisHorizontalIcon} size="sm" />{/snippet}
+{#snippet photoIcon()}<Icon icon={PhotoIcon} />{/snippet}
+{#snippet plusCircleIcon()}<Icon icon={PlusCircleIcon} />{/snippet}
+{#snippet chevronUpIcon()}<Icon icon={ChevronUpIcon} size="sm" />{/snippet}
+{#snippet chevronDownIcon()}<Icon icon={ChevronDownIcon} size="sm" />{/snippet}
+{#snippet trashIcon()}<Icon icon={TrashIcon} size="sm" />{/snippet}
+{#snippet computerDesktopIcon()}<Icon icon={ComputerDesktopIcon} size="sm" />{/snippet}
+{#snippet deviceTabletIcon()}<Icon icon={DeviceTabletIcon} size="sm" />{/snippet}
+{#snippet devicePhoneMobileIcon()}<Icon icon={DevicePhoneMobileIcon} size="sm" />{/snippet}
+{#snippet eyeIcon()}<Icon icon={EyeIcon} size="sm" />{/snippet}
+{#snippet adjustmentsHorizontalIcon()}<Icon icon={AdjustmentsHorizontalIcon} size="sm" />{/snippet}
+{#snippet xMarkIcon()}<Icon icon={XMarkIcon} size="sm" />{/snippet}
 {#snippet syncingSpinner()}<Spinner />{/snippet}
 
 <!-- Transaction table cells — `renderCell` is a `Snippet<[Transaction]>` here. -->
@@ -610,7 +622,7 @@
 		<Card padding={6} style={cardStyle} onclick={onSelect}>
 			<HStack gap={4} vAlign="start">
 				<Center width={40} height={40} style={iconCircle}>
-					<Icon icon="warning" color="secondary" />
+					<Icon icon={LockClosedIcon} color="secondary" />
 				</Center>
 				<VStack gap={1}>
 					<Text type="label" weight="semibold">{(props.heading as string) || 'Notice'}</Text>

--- a/packages/cli/assets/templates/pages/file-explorer/+page.svelte
+++ b/packages/cli/assets/templates/pages/file-explorer/+page.svelte
@@ -2,18 +2,13 @@
 	Ported from upstream's `assets/templates/pages/file-explorer/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`ChevronLeftIcon` → `chevronLeft`, `ChevronRightIcon` → `chevronRight`,
-	`MagnifyingGlassIcon` → `search`, `EllipsisHorizontalIcon` →
-	`moreHorizontal` and `ViewColumnsIcon` → `viewColumns` are true matches. The
-	rest are stand-ins: `ShareIcon` → `externalLink`, `TagIcon` → `funnel`,
-	`Squares2X2Icon` → `stop`, `Bars4Icon` → `menu`, `TableCellsIcon` →
-	`calendar`, `AdjustmentsHorizontalIcon` → `wrench`, `DocumentIcon` → `copy`,
-	and the solid `FolderIcon` → `menu` — the same folder/document pair
-	`shell-nav` takes, because the registry has neither glyph. `Bars4Icon` and
-	`FolderIcon` therefore collide on `menu`; they never appear side by side (one
-	is a view-mode toggle, the other a row icon). Retires with the icon registry
-	(TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's five `CSSProperties` objects become strings, because Svelte's
 	`style` prop is a string; the const names and declaration order are
@@ -45,6 +40,19 @@
 		Toolbar,
 		VStack
 	} from '@astryx-svelte/core';
+	import {
+		AdjustmentsHorizontalIcon,
+		Bars4Icon,
+		ChevronLeftIcon,
+		ChevronRightIcon,
+		EllipsisHorizontalIcon,
+		MagnifyingGlassIcon,
+		ShareIcon,
+		Squares2x2Icon,
+		TableCellsIcon,
+		TagIcon,
+		ViewColumnsIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	interface FileSystemItem {
 		id: string;
@@ -333,17 +341,17 @@
 	};
 </script>
 
-{#snippet chevronLeftIcon()}<Icon icon="chevronLeft" size="sm" />{/snippet}
-{#snippet chevronRightIcon()}<Icon icon="chevronRight" size="sm" />{/snippet}
-{#snippet squares2X2Icon()}<Icon icon="stop" size="sm" />{/snippet}
-{#snippet bars4Icon()}<Icon icon="menu" size="sm" />{/snippet}
-{#snippet viewColumnsIcon()}<Icon icon="viewColumns" size="sm" />{/snippet}
-{#snippet tableCellsIcon()}<Icon icon="calendar" size="sm" />{/snippet}
-{#snippet adjustmentsHorizontalIcon()}<Icon icon="wrench" size="sm" />{/snippet}
-{#snippet shareIcon()}<Icon icon="externalLink" size="sm" />{/snippet}
-{#snippet tagIcon()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet ellipsisHorizontalIcon()}<Icon icon="moreHorizontal" size="sm" />{/snippet}
-{#snippet magnifyingGlassIcon()}<Icon icon="search" size="sm" />{/snippet}
+{#snippet chevronLeftIcon()}<Icon icon={ChevronLeftIcon} size="sm" />{/snippet}
+{#snippet chevronRightIcon()}<Icon icon={ChevronRightIcon} size="sm" />{/snippet}
+{#snippet squares2X2Icon()}<Icon icon={Squares2x2Icon} size="sm" />{/snippet}
+{#snippet bars4Icon()}<Icon icon={Bars4Icon} size="sm" />{/snippet}
+{#snippet viewColumnsIcon()}<Icon icon={ViewColumnsIcon} size="sm" />{/snippet}
+{#snippet tableCellsIcon()}<Icon icon={TableCellsIcon} size="sm" />{/snippet}
+{#snippet adjustmentsHorizontalIcon()}<Icon icon={AdjustmentsHorizontalIcon} size="sm" />{/snippet}
+{#snippet shareIcon()}<Icon icon={ShareIcon} size="sm" />{/snippet}
+{#snippet tagIcon()}<Icon icon={TagIcon} size="sm" />{/snippet}
+{#snippet ellipsisHorizontalIcon()}<Icon icon={EllipsisHorizontalIcon} size="sm" />{/snippet}
+{#snippet magnifyingGlassIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" />{/snippet}
 {#snippet informationTitle()}Information{/snippet}
 
 {#snippet toolbarStart()}
@@ -416,7 +424,7 @@
 								/>
 							{/snippet}
 							{#snippet itemChevron()}
-								<Icon icon="chevronRight" size="xsm" color="secondary" />
+								<Icon icon={ChevronRightIcon} size="xsm" color="secondary" />
 							{/snippet}
 							<ListItem
 								label={item.name}

--- a/packages/cli/assets/templates/pages/gallery-hero/+page.svelte
+++ b/packages/cli/assets/templates/pages/gallery-hero/+page.svelte
@@ -2,9 +2,13 @@
 	Ported from upstream's `assets/templates/pages/gallery-hero/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons' `ArrowRightIcon`. The icon registry ships no
-	right-pointing arrow, so this is a registry substitution to `chevronRight` —
-	the same stand-in the docs examples make. Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `CSSProperties` objects become inline `style` strings; the values
 	are unchanged.
@@ -22,6 +26,7 @@
 		Text,
 		VStack
 	} from '@astryx-svelte/core';
+	import { ArrowRightIcon } from '@fvilers/heroicons-svelte/20/solid';
 
 	const IMAGES = [
 		{
@@ -48,7 +53,7 @@
 	const galleryImageClip = 'border-radius: var(--radius-container);';
 </script>
 
-{#snippet arrowRightIcon()}<Icon icon="chevronRight" size="sm" color="inherit" />{/snippet}
+{#snippet arrowRightIcon()}<Icon icon={ArrowRightIcon} size="sm" color="inherit" />{/snippet}
 
 {#snippet content()}
 	<LayoutContent padding={6}>

--- a/packages/cli/assets/templates/pages/ide/+page.svelte
+++ b/packages/cli/assets/templates/pages/ide/+page.svelte
@@ -2,11 +2,13 @@
 	Ported from upstream's `assets/templates/pages/ide/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so the icons are registry substitutions:
-	`FolderIcon` → `menu`, `DocumentTextIcon` → `copy`, `MagnifyingGlassIcon` →
-	`search`. Only `search` is a true match; the folder/document pair takes the
-	same two stand-ins `shell-nav` uses, because the registry has neither glyph.
-	Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`TreeListItemData.label` is `string | Snippet` here, and the `Snippet` arm
 	takes no arguments — so upstream's `label={<Text maxLines={1}>{id}</Text>}`
@@ -60,6 +62,11 @@
 		useResizable,
 		type TreeListItemData
 	} from '@astryx-svelte/core';
+	import {
+		DocumentTextIcon,
+		FolderIcon,
+		MagnifyingGlassIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	const styles: Record<string, string> = {
 		contentFill: 'height: 100%;',
@@ -224,9 +231,9 @@ $ `;
 	const isMobile = useMediaQuery(() => '(max-width: 768px)');
 </script>
 
-{#snippet folderIcon()}<Icon icon="menu" size="xsm" />{/snippet}
-{#snippet documentTextIcon()}<Icon icon="copy" size="xsm" />{/snippet}
-{#snippet magnifyingGlassIcon()}<Icon icon="search" size="sm" />{/snippet}
+{#snippet folderIcon()}<Icon icon={FolderIcon} size="xsm" />{/snippet}
+{#snippet documentTextIcon()}<Icon icon={DocumentTextIcon} size="xsm" />{/snippet}
+{#snippet magnifyingGlassIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" />{/snippet}
 
 {#snippet start()}
 	{#if !startPanel.isCollapsed}

--- a/packages/cli/assets/templates/pages/incident-console/+page.svelte
+++ b/packages/cli/assets/templates/pages/incident-console/+page.svelte
@@ -2,10 +2,13 @@
 	Ported from upstream's `assets/templates/pages/incident-console/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports two Heroicons, so both are registry substitutions:
-	`BellAlertIcon` → `warning` and `PlusIcon` → `check` (the registry ships no
-	plus — the same stand-in `shell-side-nav` takes, and TODO.md records the
-	gap). Neither is a true match. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`useResizable`, `useMediaQuery` and `usePowerSearchConfig` all take their
 	config as a **getter** here, against upstream's plain value, and all three
@@ -72,6 +75,7 @@
 		useResizable,
 		type PowerSearchFilter
 	} from '@astryx-svelte/core';
+	import { BellAlertIcon, PlusIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	const styles: Record<string, string> = {
 		contentFill: 'height: 100%; min-height: 0;',
@@ -346,8 +350,8 @@
 	const openCount = INCIDENTS.filter((incident) => incident.status === 'investigating').length;
 </script>
 
-{#snippet bellAlertIcon()}<Icon icon="warning" size="lg" />{/snippet}
-{#snippet plusIcon()}<Icon icon="check" size="sm" />{/snippet}
+{#snippet bellAlertIcon()}<Icon icon={BellAlertIcon} size="lg" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} size="sm" />{/snippet}
 
 {#snippet incidentRows(
 	incidents: Incident[],

--- a/packages/cli/assets/templates/pages/kanban-board/+page.svelte
+++ b/packages/cli/assets/templates/pages/kanban-board/+page.svelte
@@ -2,15 +2,13 @@
 	Ported from upstream's `assets/templates/pages/kanban-board/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`ArrowsUpDownIcon` → `arrowsUpDown`, `FunnelIcon` → `funnel`,
-	`MagnifyingGlassIcon` → `search`, `InformationCircleIcon` → `info` and
-	`CheckCircleIcon` → `success` are true matches. The rest are stand-ins:
-	`PlusIcon` → `check` (the registry ships no plus — the same call
-	`shell-side-nav` makes, and TODO.md records the gap), `ArrowPathIcon` →
-	`clock`, `InboxIcon` → `arrowDown` (as `messaging-shell` takes it), and
-	`ClipboardDocumentCheckIcon` → `checkDouble`. No two collide here. Retires
-	with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream authors its styles in `stylex.create`. StyleX may not be imported
 	from a `.svelte` file, so the static ones become `style` strings and the two
@@ -64,6 +62,13 @@
 		VStack,
 		type IconName
 	} from '@astryx-svelte/core';
+	import {
+		ArrowsUpDownIcon,
+		FunnelIcon,
+		InformationCircleIcon,
+		MagnifyingGlassIcon,
+		PlusIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 	import type { Snippet } from 'svelte';
 	import type { Attachment } from 'svelte/attachments';
 
@@ -476,10 +481,10 @@
 	};
 </script>
 
-{#snippet arrowsUpDownIcon()}<Icon icon="arrowsUpDown" size="sm" />{/snippet}
-{#snippet funnelIcon()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet magnifyingGlassIcon()}<Icon icon="search" size="sm" />{/snippet}
-{#snippet plusIcon()}<Icon icon="check" size="sm" />{/snippet}
+{#snippet arrowsUpDownIcon()}<Icon icon={ArrowsUpDownIcon} size="sm" />{/snippet}
+{#snippet funnelIcon()}<Icon icon={FunnelIcon} size="sm" />{/snippet}
+{#snippet magnifyingGlassIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} size="sm" />{/snippet}
 
 <!-- ============= CARD BODY ============= -->
 
@@ -545,7 +550,7 @@
 					<StatusDot variant={meta.variant} label={`${meta.title} status`} />
 					<Heading level={4}>{meta.title}</Heading>
 					<Tooltip content={meta.tooltip}>
-						<Icon icon="info" size="sm" color="secondary" />
+						<Icon icon={InformationCircleIcon} size="sm" color="secondary" />
 					</Tooltip>
 				</HStack>
 				<Text type="supporting" color="secondary" hasTabularNumbers>{count}</Text>

--- a/packages/cli/assets/templates/pages/library/+page.svelte
+++ b/packages/cli/assets/templates/pages/library/+page.svelte
@@ -2,11 +2,13 @@
 	Ported from upstream's `assets/templates/pages/library/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports one Heroicon here, and it is a registry substitution:
-	`MagnifyingGlassIcon` → `search` — a true match, the only kind the 28-name
-	registry manages often. `TextInput.startIcon` is a `Snippet` rather than
-	upstream's `ReactNode | IconType`, so the caller sets the `size="sm"
-	color="secondary"` upstream applies for you.
+	The one Heroicon here is upstream's own, from `@fvilers/heroicons-svelte` —
+	the Heroicons set built for Svelte 5, keeping upstream's component names and
+	entry points.
+
+	`TextInput.startIcon` is a `Snippet` rather than upstream's
+	`ReactNode | IconType`, so the caller sets the `size="sm" color="secondary"`
+	upstream applies for you.
 
 	`OverflowList` is compositional upstream — `children` is arbitrary elements,
 	sliced through `Children.toArray`. A Svelte snippet is one opaque unit that
@@ -45,6 +47,7 @@
 		VStack,
 		type OverflowItem
 	} from '@astryx-svelte/core';
+	import { MagnifyingGlassIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	interface LibraryItem {
 		id: string;
@@ -411,7 +414,7 @@
 	</VStack>
 {/snippet}
 
-{#snippet searchIcon()}<Icon icon="search" size="sm" color="secondary" />{/snippet}
+{#snippet searchIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" color="secondary" />{/snippet}
 
 {#snippet categoryToggle(cat: string)}
 	<ToggleButton label={cat} value={cat} size="lg" />

--- a/packages/cli/assets/templates/pages/login-card/+page.svelte
+++ b/packages/cli/assets/templates/pages/login-card/+page.svelte
@@ -2,13 +2,13 @@
 	Ported from upstream's `assets/templates/pages/login-card/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream splits two ways on icons here. The logo *imports* Heroicons, so it is
-	a registry substitution: `CubeIcon` → `stop`. A stand-in rather than a true
-	match — the registry has no cube glyph and `stop` is its square — and the same
-	one the demo routes make. Retires with the icon registry (TODO.md). The two
-	brand marks are *inlined* SVG paths upstream, so they transcribe as-is; they
-	are local components there and snippets here, since `Button.icon` is a
-	`Snippet`.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 -->
 <script lang="ts">
 	import {
@@ -23,6 +23,7 @@
 		TextInput,
 		VStack
 	} from '@astryx-svelte/core';
+	import { CubeIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	// Standalone auth page paints its own body background (no host shell).
 	const pageStyle =
@@ -84,7 +85,7 @@
 	<VStack gap={4} hAlign="center" style={contentStyle}>
 		<!-- Logo -->
 		<VStack gap={2} hAlign="center">
-			<Icon icon="stop" size="lg" />
+			<Icon icon={CubeIcon} size="lg" />
 			<Text type="body" weight="bold" size="lg">Product Inc.</Text>
 		</VStack>
 

--- a/packages/cli/assets/templates/pages/login-split/+page.svelte
+++ b/packages/cli/assets/templates/pages/login-split/+page.svelte
@@ -2,12 +2,13 @@
 	Ported from upstream's `assets/templates/pages/login-split/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVGs, so the icons
-	are registry substitutions: `SquaresPlusIcon` → `stop`, `CheckCircleIcon` →
-	`success`. Only `success` is a true match; the registry has no squares/plus
-	glyph, so the logo reuses the `stop` square the repo already stands in for
-	`CubeIcon` in the sibling Login templates. Retires with the icon registry
-	(TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 -->
 <script lang="ts">
 	import {
@@ -26,6 +27,7 @@
 		TextInput,
 		VStack
 	} from '@astryx-svelte/core';
+	import { CheckCircleIcon, SquaresPlusIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	const COVER_IMAGE_URL =
 		'https://lookaside.facebook.com/assets/astryx/light-working-vertical-1.png';
@@ -68,7 +70,7 @@
 </script>
 
 {#snippet successIcon()}
-	<Icon icon="success" size="lg" />
+	<Icon icon={CheckCircleIcon} size="lg" />
 {/snippet}
 
 {#snippet appleLogo()}
@@ -93,7 +95,7 @@
 					<Section variant="transparent" padding={0} height="100%">
 						<VStack gap={4} height="100%">
 							<HStack gap={2} vAlign="center">
-								<Icon icon="stop" />
+								<Icon icon={SquaresPlusIcon} />
 								<Text type="body" weight="bold">Product Inc.</Text>
 							</HStack>
 

--- a/packages/cli/assets/templates/pages/login-sso/+page.svelte
+++ b/packages/cli/assets/templates/pages/login-sso/+page.svelte
@@ -2,11 +2,13 @@
 	Ported from upstream's `assets/templates/pages/login-sso/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVG, so the trust
-	mark is a registry substitution: `ShieldCheckIcon` → `check`. A stand-in
-	rather than a true match — the registry has no shield glyph, and only the
-	"verified" half of the meaning survives — and the same one the nav demo routes
-	make. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 -->
 <script lang="ts">
 	import {
@@ -23,6 +25,7 @@
 		TextInput,
 		VStack
 	} from '@astryx-svelte/core';
+	import { ShieldCheckIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	// -------------------------------------------------------------------------
 	// Styles
@@ -181,7 +184,7 @@
 				<Card padding={0}>
 					<Section variant="muted" padding={4}>
 						<HStack gap={2} vAlign="center">
-							<Icon icon="check" color="secondary" />
+							<Icon icon={ShieldCheckIcon} color="secondary" />
 							<VStack gap={0}>
 								<Text type="label">{provider.name}</Text>
 								<Text type="supporting" color="secondary">{email}</Text>

--- a/packages/cli/assets/templates/pages/login/+page.svelte
+++ b/packages/cli/assets/templates/pages/login/+page.svelte
@@ -2,10 +2,13 @@
 	Ported from upstream's `assets/templates/pages/login/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVG, so the logo is a
-	registry substitution: `CubeIcon` → `stop`. A stand-in rather than a true
-	match — the registry has no cube glyph and `stop` is its square — and the same
-	one the demo routes make. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 -->
 <script lang="ts">
 	import {
@@ -19,6 +22,7 @@
 		TextInput,
 		VStack
 	} from '@astryx-svelte/core';
+	import { CubeIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	// Standalone auth page paints its own body background (no host shell).
 	const pageStyle =
@@ -47,7 +51,7 @@
 	<VStack gap={4} hAlign="center" style={contentStyle}>
 		<!-- Logo -->
 		<VStack gap={2} hAlign="center">
-			<Icon icon="stop" size="lg" />
+			<Icon icon={CubeIcon} size="lg" />
 			<Text type="body" weight="bold" size="lg">Product Inc.</Text>
 		</VStack>
 

--- a/packages/cli/assets/templates/pages/messaging-shell/+page.svelte
+++ b/packages/cli/assets/templates/pages/messaging-shell/+page.svelte
@@ -2,13 +2,13 @@
 	Ported from upstream's `assets/templates/pages/messaging-shell/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`HomeIcon` → `viewColumns`, `ChatBubbleLeftRightIcon` → `moreHorizontal`,
-	`BellIcon` → `warning`, `BookmarkIcon` → `stop`, `Cog6ToothIcon` → `wrench`,
-	`PencilSquareIcon` → `copy`, `HashtagIcon` → `menu`, `UserGroupIcon` →
-	`info`, `InboxIcon` → `arrowDown`. `MagnifyingGlassIcon` → `search` and
-	`XMarkIcon` → `close` are true matches; the rest are stand-ins. Retires with
-	the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `styles` is a `Record<string, CSSProperties>` applied through the
 	`style` prop; here it is a `Record<string, string>` of the same declarations,
@@ -73,6 +73,15 @@
 		useMediaQuery,
 		type IconName
 	} from '@astryx-svelte/core';
+	import {
+		Cog6ToothIcon,
+		HashtagIcon,
+		InboxIcon,
+		MagnifyingGlassIcon,
+		PencilSquareIcon,
+		UserGroupIcon,
+		XMarkIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	// ---------------------------------------------------------------------------
 	// Styles — plain CSS properties with semantic tokens only.
@@ -336,7 +345,7 @@
 {/snippet}
 
 {#snippet youStatus()}<AvatarStatusDot variant="success" label="Online" />{/snippet}
-{#snippet settingsIcon()}<Icon icon="wrench" size="sm" color="inherit" />{/snippet}
+{#snippet settingsIcon()}<Icon icon={Cog6ToothIcon} size="sm" color="inherit" />{/snippet}
 
 {#snippet workspaceRail()}
 	<VStack gap={2} style={styles.rail}>
@@ -363,8 +372,8 @@
 	</VStack>
 {/snippet}
 
-{#snippet newMessageIcon()}<Icon icon="copy" size="sm" color="inherit" />{/snippet}
-{#snippet jumpToIcon()}<Icon icon="search" size="sm" />{/snippet}
+{#snippet newMessageIcon()}<Icon icon={PencilSquareIcon} size="sm" color="inherit" />{/snippet}
+{#snippet jumpToIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" />{/snippet}
 {#snippet channelsHeader()}
 	<Text type="label" size="sm" color="secondary">Channels</Text>
 {/snippet}
@@ -401,7 +410,7 @@
 		<StackItem size="fill" style={styles.sidebarScroll}>
 			<List density="compact" hasDividers={false} header={channelsHeader}>
 				{#each visibleChannels as channel (channel.id)}
-					{#snippet hashtagIcon()}<Icon icon="menu" size="sm" color="secondary" />{/snippet}
+					{#snippet hashtagIcon()}<Icon icon={HashtagIcon} size="sm" color="secondary" />{/snippet}
 					{#snippet unreadBadge()}<Badge label={String(channel.unread)} variant="neutral" />{/snippet}
 					<ListItem
 						label={channel.name}
@@ -442,8 +451,8 @@
 	</Stack>
 {/snippet}
 
-{#snippet membersIcon()}<Icon icon="info" size="sm" color="inherit" />{/snippet}
-{#snippet inboxIcon()}<Icon icon="arrowDown" size="lg" />{/snippet}
+{#snippet membersIcon()}<Icon icon={UserGroupIcon} size="sm" color="inherit" />{/snippet}
+{#snippet inboxIcon()}<Icon icon={InboxIcon} size="lg" />{/snippet}
 
 {#snippet streamComposer()}
 	<ChatComposer placeholder={`Message #${selectedChannel.name}`} onSubmit={() => {}} />
@@ -460,7 +469,7 @@
 {#snippet messageStream()}
 	<Stack direction="vertical" style={styles.streamColumn}>
 		<HStack gap={3} style={styles.streamHeader}>
-			<Icon icon="menu" size="sm" color="secondary" />
+			<Icon icon={HashtagIcon} size="sm" color="secondary" />
 			<Heading level={5}>{selectedChannel.name}</Heading>
 			<StackItem size="fill" style={styles.streamTopic}>
 				<Text type="supporting" color="secondary" maxLines={1}>
@@ -496,7 +505,7 @@
 	</Stack>
 {/snippet}
 
-{#snippet closeThreadIcon()}<Icon icon="close" size="sm" color="inherit" />{/snippet}
+{#snippet closeThreadIcon()}<Icon icon={XMarkIcon} size="sm" color="inherit" />{/snippet}
 {#snippet threadRootAvatar()}<Avatar name={USERS[THREAD_ROOT.userId].name} size="md" />{/snippet}
 {#snippet threadRootTimestamp()}<Timestamp value={THREAD_ROOT.time} format="time" />{/snippet}
 {#snippet threadRootMetadata()}<ChatMessageMetadata timestamp={threadRootTimestamp} />{/snippet}

--- a/packages/cli/assets/templates/pages/payment-form/+page.svelte
+++ b/packages/cli/assets/templates/pages/payment-form/+page.svelte
@@ -2,15 +2,13 @@
 	Ported from upstream's `assets/templates/pages/payment-form/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVGs, so the four
-	glyphs are registry substitutions: `CheckCircleIcon` → `success` (a true
-	match — the registry's `success` is a checkmark in a circle),
-	`ShieldCheckIcon` → `check`, `LockClosedIcon` → `eyeSlash`, `TruckIcon` →
-	`arrowDown`. The last three are stand-ins: the registry ships 28 semantic
-	names and no shield, padlock or truck, so the shield keeps its checkmark and
-	loses the shield, the padlock borrows the concealment glyph, and the
-	delivery truck borrows the incoming-arrow. Retires with the icon registry
-	(TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Other translations:
 	  - `Layout content={<…>}` → a `content` snippet passed as that prop.
@@ -56,6 +54,12 @@
 		VStack,
 		useMediaQuery
 	} from '@astryx-svelte/core';
+	import {
+		CheckCircleIcon,
+		LockClosedIcon,
+		ShieldCheckIcon,
+		TruckIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	// ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -258,7 +262,7 @@
 {/snippet}
 
 {#snippet freeShippingIcon()}
-	<Icon icon="arrowDown" size="sm" />
+	<Icon icon={TruckIcon} size="sm" />
 {/snippet}
 
 {#snippet content()}
@@ -668,15 +672,15 @@
 								<VStack gap={4}>
 									<HStack gap={5} hAlign="center" wrap="wrap">
 										<HStack gap={1} vAlign="center">
-											<Icon icon="check" size="sm" color="secondary" />
+											<Icon icon={ShieldCheckIcon} size="sm" color="secondary" />
 											<Text type="supporting" color="secondary">Secure Payment</Text>
 										</HStack>
 										<HStack gap={1} vAlign="center">
-											<Icon icon="eyeSlash" size="sm" color="secondary" />
+											<Icon icon={LockClosedIcon} size="sm" color="secondary" />
 											<Text type="supporting" color="secondary">SSL Encrypted</Text>
 										</HStack>
 										<HStack gap={1} vAlign="center">
-											<Icon icon="success" size="sm" color="secondary" />
+											<Icon icon={CheckCircleIcon} size="sm" color="secondary" />
 											<Text type="supporting" color="secondary">Free Returns</Text>
 										</HStack>
 									</HStack>

--- a/packages/cli/assets/templates/pages/product-detail/+page.svelte
+++ b/packages/cli/assets/templates/pages/product-detail/+page.svelte
@@ -2,13 +2,13 @@
 	Ported from upstream's `assets/templates/pages/product-detail/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`MinusIcon` → `close`, `PlusIcon` → `check` (the registry ships no plus —
-	TODO.md records the gap), outline `StarIcon` → `check`, solid `StarIcon` →
-	`success`. None is a true match, and the 28-name registry cannot keep four
-	glyphs distinct — `check` stands in twice over, so the increment button and
-	an unfilled rating star draw the same glyph. Retires with the icon registry
-	(TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `StarRating`, `ImageGallery` and `ProductInfo` are components; a
 	page template is a single `+page.svelte` (the CLI copies `PAGE_SOURCE_FILE`
@@ -26,7 +26,6 @@
 		AspectRatio,
 		Badge,
 		Button,
-		Card,
 		Center,
 		Collapsible,
 		CollapsibleGroup,
@@ -44,6 +43,8 @@
 		Text,
 		VStack
 	} from '@astryx-svelte/core';
+	import { MinusIcon, PlusIcon, StarIcon } from '@fvilers/heroicons-svelte/24/outline';
+	import { StarIcon as StarIconSolid } from '@fvilers/heroicons-svelte/24/solid';
 
 	// Custom CSS here is limited to what Astryx components can't express today:
 	// - image fill + corner radius (no Image primitive — #2582)
@@ -118,10 +119,10 @@
 	{@const empty = 5 - filled}
 	<HStack gap={1} vAlign="center">
 		{#each Array.from({ length: filled }) as _, i (`full-${i}`)}
-			<Icon icon="success" size="sm" />
+			<Icon icon={StarIconSolid} size="sm" />
 		{/each}
 		{#each Array.from({ length: empty }) as _, i (`empty-${i}`)}
-			<Icon icon="check" size="sm" />
+			<Icon icon={StarIcon} size="sm" />
 		{/each}
 		<Text type="body" color="secondary">{rating} ({count})</Text>
 	</HStack>
@@ -156,8 +157,8 @@
 {/snippet}
 
 <!-- ─── Product Info ──────────────────────────────────────────────────────── -->
-{#snippet minusIcon()}<Icon icon="close" size="sm" />{/snippet}
-{#snippet plusIcon()}<Icon icon="check" size="sm" />{/snippet}
+{#snippet minusIcon()}<Icon icon={MinusIcon} size="sm" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} size="sm" />{/snippet}
 {#snippet compositionTrigger()}<Heading level={3}>Composition</Heading>{/snippet}
 {#snippet deliveryTrigger()}<Heading level={3}>Delivery &amp; Returns</Heading>{/snippet}
 {#snippet dimensionsTrigger()}<Heading level={3}>Dimensions</Heading>{/snippet}

--- a/packages/cli/assets/templates/pages/product-gallery/+page.svelte
+++ b/packages/cli/assets/templates/pages/product-gallery/+page.svelte
@@ -2,9 +2,13 @@
 	Ported from upstream's `assets/templates/pages/product-gallery/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons' `ArrowRightIcon`. The icon registry ships no
-	right-pointing arrow, so this is a registry substitution to `chevronRight` —
-	the same stand-in the docs examples make. Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`ProductCard` is a local sub-component upstream; here it is a snippet.
 -->
@@ -21,6 +25,7 @@
 		Text,
 		VStack
 	} from '@astryx-svelte/core';
+	import { ArrowRightIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	// ─── Styles ─────────────────────────────────────────────────────────────────
 	// The only custom CSS is the image fill — there is no Image primitive to
@@ -92,7 +97,7 @@
 	const fmt = (n: number) => `$${n.toFixed(2)}`;
 </script>
 
-{#snippet arrowRightIcon()}<Icon icon="chevronRight" color="inherit" />{/snippet}
+{#snippet arrowRightIcon()}<Icon icon={ArrowRightIcon} color="inherit" />{/snippet}
 
 <!-- ─── Product Card ─────────────────────────────────────────────────────────── -->
 

--- a/packages/cli/assets/templates/pages/settings-dialog/+page.svelte
+++ b/packages/cli/assets/templates/pages/settings-dialog/+page.svelte
@@ -2,18 +2,13 @@
 	Ported from upstream's `assets/templates/pages/settings-dialog/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVGs, so every icon
-	is a registry substitution: `UserIcon` → `info`, `LockClosedIcon` → `stop`,
-	`ShieldCheckIcon` → `success`, `BellIcon` → `warning`, `DocumentTextIcon` →
-	`copy`, `CreditCardIcon` → `viewColumns`, `GlobeAltIcon` → `clock`,
-	`BriefcaseIcon` → `calendar`, `WrenchScrewdriverIcon` → `wrench`,
-	`ComputerDesktopIcon` → `stop`, `PencilSquareIcon` → `copy`, `ShareIcon` →
-	`externalLink`. Twelve glyphs will not fit a 28-name *semantic* registry
-	without collisions: `stop` stands in for both the padlock and the desktop,
-	and `copy` for both the document and the pencil. The sidebar's eight stay
-	distinct from one another, which is where a collision would actually read as
-	a mistake. Only `wrench` is close to a true match. Retires with the icon
-	registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `iconBox`/`headerSticky`/`contentMaxWidth`/`sideNavHeading`/
 	`dialogHeight` are `CSSProperties` objects handed to `style`; Svelte's `style`
@@ -55,6 +50,14 @@
 		VStack,
 		type IconName
 	} from '@astryx-svelte/core';
+	import {
+		ComputerDesktopIcon,
+		LockClosedIcon,
+		PencilSquareIcon,
+		ShareIcon,
+		ShieldCheckIcon,
+		WrenchScrewdriverIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	const iconBox =
 		'border-radius: var(--radius-container); ' +
@@ -210,7 +213,7 @@
 	<Divider />
 {/snippet}
 
-{#snippet hostingToolsIcon()}<Icon icon="wrench" />{/snippet}
+{#snippet hostingToolsIcon()}<Icon icon={WrenchScrewdriverIcon} />{/snippet}
 
 {#snippet legalNameInput()}
 	<TextInput
@@ -430,7 +433,7 @@
 							<VStack gap={4}>
 								<HStack gap={3} vAlign="start">
 									<Center width={48} height={48} style={iconBox}>
-										<Icon icon="stop" />
+										<Icon icon={LockClosedIcon} />
 									</Center>
 									<VStack gap={0}>
 										<Text type="body" weight="semibold" display="block">
@@ -444,7 +447,7 @@
 								<Divider />
 								<HStack gap={3} vAlign="start">
 									<Center width={48} height={48} style={iconBox}>
-										<Icon icon="copy" />
+										<Icon icon={PencilSquareIcon} />
 									</Center>
 									<VStack gap={0}>
 										<Text type="body" weight="semibold" display="block">
@@ -460,7 +463,7 @@
 								<Divider />
 								<HStack gap={3} vAlign="start">
 									<Center width={48} height={48} style={iconBox}>
-										<Icon icon="externalLink" />
+										<Icon icon={ShareIcon} />
 									</Center>
 									<VStack gap={0}>
 										<Text type="body" weight="semibold" display="block">
@@ -506,7 +509,7 @@
 									<Divider />
 									{#each DEVICE_ROWS as device, i (i)}
 										<HStack gap={3} vAlign="start">
-											<Icon icon="stop" />
+											<Icon icon={ComputerDesktopIcon} />
 											<StackItem size="fill">
 												<VStack gap={0}>
 													<HStack gap={2} vAlign="center">
@@ -562,7 +565,7 @@
 								<Card variant="muted">
 									<HStack gap={4} vAlign="start">
 										<Center width={48} height={48} style={iconBox}>
-											<Icon icon="stop" />
+											<Icon icon={LockClosedIcon} />
 										</Center>
 										<VStack gap={1}>
 											<Text type="body" weight="bold">
@@ -715,7 +718,7 @@
 								<Card variant="muted">
 									<HStack gap={4} vAlign="start">
 										<Center width={48} height={48} style={iconBox}>
-											<Icon icon="success" />
+											<Icon icon={ShieldCheckIcon} />
 										</Center>
 										<VStack gap={1}>
 											<Text type="body" weight="bold">Committed to privacy</Text>

--- a/packages/cli/assets/templates/pages/settings-sidebar/+page.svelte
+++ b/packages/cli/assets/templates/pages/settings-sidebar/+page.svelte
@@ -2,19 +2,13 @@
 	Ported from upstream's `assets/templates/pages/settings-sidebar/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here rather than inlining the SVGs, so every icon
-	is a registry substitution: `UserIcon` → `info`, `LockClosedIcon` → `stop`,
-	`ShieldCheckIcon` → `success`, `BellIcon` → `warning`, `DocumentTextIcon` →
-	`copy`, `CreditCardIcon` → `viewColumns`, `GlobeAltIcon` → `clock`,
-	`BriefcaseIcon` → `calendar`, `WrenchScrewdriverIcon` → `wrench`,
-	`ComputerDesktopIcon` → `stop`, `PencilSquareIcon` → `copy`, `ShareIcon` →
-	`externalLink`, `ArrowLeftIcon` → `chevronLeft`, `ChevronRightIcon` →
-	`chevronRight`. Fourteen glyphs will not fit a 28-name *semantic* registry
-	without collisions: `stop` stands in for both the padlock and the desktop,
-	and `copy` for both the document and the pencil. The sidebar's eight stay
-	distinct from one another, which is where a collision would actually read as
-	a mistake. `chevronRight` is a true match and `wrench`/`chevronLeft` are
-	close; the rest are stand-ins. Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `fillViewport`/`iconBox`/`rowPadding`/`sideNavPadding`/
 	`sideNavHeading` are `CSSProperties` objects handed to `style`; Svelte's
@@ -57,6 +51,16 @@
 		useMediaQuery,
 		type IconName
 	} from '@astryx-svelte/core';
+	import {
+		ArrowLeftIcon,
+		ChevronRightIcon,
+		ComputerDesktopIcon,
+		LockClosedIcon,
+		PencilSquareIcon,
+		ShareIcon,
+		ShieldCheckIcon,
+		WrenchScrewdriverIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	// Anchor the page to the viewport height so the sidebar + content fill the
 	// screen. Layout height="fill" is min-height:100% which collapses when the
@@ -229,9 +233,9 @@
 	<Divider />
 {/snippet}
 
-{#snippet chevronIcon()}<Icon icon="chevronRight" size="sm" color="secondary" />{/snippet}
-{#snippet hostingToolsIcon()}<Icon icon="wrench" />{/snippet}
-{#snippet backIcon()}<Icon icon="chevronLeft" size="sm" />{/snippet}
+{#snippet chevronIcon()}<Icon icon={ChevronRightIcon} size="sm" color="secondary" />{/snippet}
+{#snippet hostingToolsIcon()}<Icon icon={WrenchScrewdriverIcon} />{/snippet}
+{#snippet backIcon()}<Icon icon={ArrowLeftIcon} size="sm" />{/snippet}
 
 {#snippet navList()}
 	<VStack gap={4} style={sideNavPadding}>
@@ -423,7 +427,7 @@
 								<Divider />
 								{#each DEVICE_ROWS as device, i (i)}
 									<HStack gap={3} vAlign="start" style={rowPadding}>
-										<Icon icon="stop" />
+										<Icon icon={ComputerDesktopIcon} />
 										<StackItem size="fill">
 											<VStack gap={0}>
 												<HStack gap={2} vAlign="center">
@@ -479,7 +483,7 @@
 							<Card variant="muted">
 								<HStack gap={4} vAlign="start">
 									<Center width={48} height={48} style={iconBox}>
-										<Icon icon="stop" />
+										<Icon icon={LockClosedIcon} />
 									</Center>
 									<VStack gap={1}>
 										<Text type="body" weight="bold">
@@ -611,7 +615,7 @@
 						<VStack gap={4}>
 							<HStack gap={3} vAlign="start">
 								<Center width={48} height={48} style={iconBox}>
-									<Icon icon="stop" />
+									<Icon icon={LockClosedIcon} />
 								</Center>
 								<VStack gap={0}>
 									<Text type="body" weight="semibold" display="block">
@@ -625,7 +629,7 @@
 							<Divider />
 							<HStack gap={3} vAlign="start">
 								<Center width={48} height={48} style={iconBox}>
-									<Icon icon="copy" />
+									<Icon icon={PencilSquareIcon} />
 								</Center>
 								<VStack gap={0}>
 									<Text type="body" weight="semibold" display="block">
@@ -641,7 +645,7 @@
 							<Divider />
 							<HStack gap={3} vAlign="start">
 								<Center width={48} height={48} style={iconBox}>
-									<Icon icon="externalLink" />
+									<Icon icon={ShareIcon} />
 								</Center>
 								<VStack gap={0}>
 									<Text type="body" weight="semibold" display="block">
@@ -765,7 +769,7 @@
 							<Card variant="muted">
 								<HStack gap={4} vAlign="start">
 									<Center width={48} height={48} style={iconBox}>
-										<Icon icon="success" />
+										<Icon icon={ShieldCheckIcon} />
 									</Center>
 									<VStack gap={1}>
 										<Text type="body" weight="bold">Committed to privacy</Text>

--- a/packages/cli/assets/templates/pages/settings/+page.svelte
+++ b/packages/cli/assets/templates/pages/settings/+page.svelte
@@ -2,12 +2,15 @@
 	Ported from upstream's `assets/templates/pages/settings/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports one Heroicon here rather than inlining the SVG, so it is a
-	registry substitution: `MagnifyingGlassIcon` → `search`. That one is a true
-	match rather than a stand-in, so nothing retires with the icon registry
-	(TODO.md). Upstream hands `Typeahead.startIcon` the component; the prop takes
-	`IconName | Snippet` here, and a registry name is the closer of the two —
-	`Typeahead` then applies the `size="sm" color="secondary"` upstream applies.
+	The one Heroicon here is upstream's own, from `@fvilers/heroicons-svelte` —
+	the Heroicons set built for Svelte 5, keeping upstream's component names and
+	entry points.
+
+	`Typeahead.startIcon` is `IconName | Snippet` here where upstream's is
+	`ReactNode | IconType`, so the component goes through the `Snippet` arm
+	rather than being passed directly. That arm renders raw, so the snippet
+	supplies the `size="sm" color="secondary"` that `Typeahead` applies for the
+	`IconName` arm — the same values, and the same rendering as upstream.
 -->
 <script lang="ts">
 	import {
@@ -17,6 +20,7 @@
 		Grid,
 		HStack,
 		Heading,
+		Icon,
 		Layout,
 		LayoutContent,
 		LayoutHeader,
@@ -34,6 +38,7 @@
 		type SearchSource,
 		type SearchableItem
 	} from '@astryx-svelte/core';
+	import { MagnifyingGlassIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	const NAV_ITEMS = ['Profile', 'Account', 'Members', 'Billing', 'Invoices', 'API'];
 
@@ -69,6 +74,8 @@
 	let searchValue = $state<SearchableItem | null>(null);
 </script>
 
+{#snippet searchIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" color="secondary" />{/snippet}
+
 {#snippet header()}
 	<LayoutHeader hasDivider>
 		<HStack vAlign="center">
@@ -83,7 +90,7 @@
 				value={searchValue}
 				onChange={(item) => (searchValue = item)}
 				hasEntriesOnFocus
-				startIcon="search"
+				startIcon={searchIcon}
 			/>
 		</HStack>
 	</LayoutHeader>

--- a/packages/cli/assets/templates/pages/shell-nav/+page.svelte
+++ b/packages/cli/assets/templates/pages/shell-nav/+page.svelte
@@ -2,12 +2,13 @@
 	Ported from upstream's `assets/templates/pages/shell-nav/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so the icons are registry substitutions:
-	`PlayIcon` → `arrowUp`, `MagnifyingGlassIcon` → `search`, `FolderIcon` →
-	`menu`, `DocumentTextIcon` → `copy`. Only `search` is a true match; the file
-	tree's folder/document pair takes the same two stand-ins
-	`TreeListFileTreeWithIcons` uses, because the registry has neither glyph.
-	Retires with the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`TreeListItemData.label` is `string | Snippet` here, and the `Snippet` arm
 	takes no arguments — so upstream's `label={<Text maxLines={1}>{id}</Text>}`
@@ -40,6 +41,12 @@
 		createStaticSource,
 		type TreeListItemData
 	} from '@astryx-svelte/core';
+	import {
+		DocumentTextIcon,
+		FolderIcon,
+		MagnifyingGlassIcon,
+		PlayIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	const noop = () => {};
 
@@ -206,8 +213,8 @@
 	});
 </script>
 
-{#snippet folderIcon()}<Icon icon="menu" size="xsm" />{/snippet}
-{#snippet documentIcon()}<Icon icon="copy" size="xsm" />{/snippet}
+{#snippet folderIcon()}<Icon icon={FolderIcon} size="xsm" />{/snippet}
+{#snippet documentIcon()}<Icon icon={DocumentTextIcon} size="xsm" />{/snippet}
 
 {#snippet startContent()}
 	{#each MENUS as menu (menu.label)}
@@ -231,9 +238,9 @@
 	{/each}
 {/snippet}
 
-{#snippet playIcon()}<Icon icon="arrowUp" size="sm" />{/snippet}
+{#snippet playIcon()}<Icon icon={PlayIcon} size="sm" />{/snippet}
 <!-- `TextInput.startIcon` is a `Snippet` here where upstream's is an `IconType`. -->
-{#snippet magnifyingGlassIcon()}<Icon icon="search" size="sm" />{/snippet}
+{#snippet magnifyingGlassIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" />{/snippet}
 
 {#snippet endContent()}
 	<Stack onclick={() => (isPaletteOpen = true)}>

--- a/packages/cli/assets/templates/pages/shell-side-nav/+page.svelte
+++ b/packages/cli/assets/templates/pages/shell-side-nav/+page.svelte
@@ -2,14 +2,13 @@
 	Ported from upstream's `assets/templates/pages/shell-side-nav/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`SparklesIcon` → `wrench`, `PlusIcon` → `check` (the registry ships no plus —
-	TODO.md records the gap), `MagnifyingGlassIcon` → `search`, `BookOpenIcon` →
-	`copy`, `Cog6ToothIcon` → `wrench`, `UserCircleIcon` → `info`, `UserIcon` →
-	`info`, `BuildingOffice2Icon` → `stop`, `CodeBracketIcon` → `wrench`. Only
-	`search` is a true match, and the 28-name registry cannot keep nine glyphs
-	distinct — `wrench` and `info` each stand in twice over. Retires with the
-	icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's `ConversationItem` is a component with two `useState`s; a page
 	template is a single `+page.svelte` (the CLI copies `PAGE_SOURCE_FILE` and
@@ -40,6 +39,7 @@
 		type IconName,
 		type StatusDotVariant
 	} from '@astryx-svelte/core';
+	import { SparklesIcon } from '@fvilers/heroicons-svelte/24/outline';
 
 	type Conversation = {
 		label: string;
@@ -127,7 +127,7 @@
 	</Stack>
 {/snippet}
 
-{#snippet sparklesIcon()}<Icon icon="wrench" size="sm" />{/snippet}
+{#snippet sparklesIcon()}<Icon icon={SparklesIcon} size="sm" />{/snippet}
 {#snippet headingIcon()}<NavIcon icon={sparklesIcon} />{/snippet}
 
 {#snippet header()}

--- a/packages/cli/assets/templates/pages/shell-top-nav/+page.svelte
+++ b/packages/cli/assets/templates/pages/shell-top-nav/+page.svelte
@@ -2,17 +2,13 @@
 	Ported from upstream's `assets/templates/pages/shell-top-nav/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons here, so every icon is a registry substitution:
-	`ShoppingBagIcon` → `stop`, `ShoppingCartIcon` → `checkDouble`,
-	`MagnifyingGlassIcon` → `search`, `SparklesIcon` → `wrench`, `SwatchIcon` →
-	`viewColumns`, `TagIcon` → `funnel`, `HomeModernIcon` → `menu`,
-	`FaceSmileIcon` → `info`, `ReceiptPercentIcon` → `copy`, `GiftIcon` →
-	`calendar`, `CloudIcon` → `arrowsUpDown`, `BoltIcon` → `arrowUp`, `SunIcon` →
-	`success`, `StarIcon` → `check`, `FireIcon` → `error`, `GlobeAltIcon` →
-	`externalLink`, `MoonIcon` → `clock`. Only `search` is a true match; the rest
-	are stand-ins, the same ones the example blocks make, and `MegaItem.icon` is
-	an `IconName` rather than upstream's `IconType` because of it. Retires with
-	the icon registry (TODO.md).
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Upstream's three `stylex.create` styles become `style` strings. StyleX may
 	not be imported from a `.svelte` file, and a scoped `<style>` class never
@@ -40,6 +36,11 @@
 		VStack,
 		type IconName
 	} from '@astryx-svelte/core';
+	import {
+		MagnifyingGlassIcon,
+		ShoppingBagIcon,
+		ShoppingCartIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 
 	const styles = {
 		// Cap + center the page body so wide screens show whitespace gutters.
@@ -158,7 +159,7 @@
 	})}
 {/snippet}
 
-{#snippet shoppingBagIcon()}<Icon icon="stop" size="sm" />{/snippet}
+{#snippet shoppingBagIcon()}<Icon icon={ShoppingBagIcon} size="sm" />{/snippet}
 {#snippet logo()}<NavIcon icon={shoppingBagIcon} />{/snippet}
 
 {#snippet heading()}
@@ -172,8 +173,8 @@
 	<TopNavItem label="Service" href="#" />
 {/snippet}
 
-{#snippet magnifyingGlassIcon()}<Icon icon="search" size="sm" />{/snippet}
-{#snippet shoppingCartIcon()}<Icon icon="checkDouble" size="sm" />{/snippet}
+{#snippet magnifyingGlassIcon()}<Icon icon={MagnifyingGlassIcon} size="sm" />{/snippet}
+{#snippet shoppingCartIcon()}<Icon icon={ShoppingCartIcon} size="sm" />{/snippet}
 <!-- `Badge.label` is `string | Snippet` here; upstream's `label={3}` is `ReactNode`. -->
 {#snippet cartCount()}<Badge label="3" />{/snippet}
 

--- a/packages/cli/assets/templates/pages/table-grouped/+page.svelte
+++ b/packages/cli/assets/templates/pages/table-grouped/+page.svelte
@@ -2,16 +2,13 @@
 	Ported from upstream's `assets/templates/pages/table-grouped/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons, which have no Svelte build, so each is a stand-in
-	from core's 28-name `Icon` registry. Only the two chevrons are true matches:
-	`ChevronDownIcon` → `chevronDown`, `ChevronRightIcon` → `chevronRight`,
-	`XMarkIcon` → `close`, `EllipsisHorizontalIcon` → `moreHorizontal`,
-	`ChartBarIcon` → `viewColumns`, `PencilIcon` → `wrench`, `UserIcon` → `info`,
-	`TagIcon` → `stop`, `DocumentDuplicateIcon` → `copy`, `ArrowRightIcon` →
-	`chevronRight` (**a collision** — the same glyph the collapsed group header
-	uses), `TrashIcon` → `error` (the registry ships no trash; `error` is the
-	nearest destructive-action glyph and avoids a second `close`). Retires with
-	the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	Three structural translations:
 
@@ -77,6 +74,8 @@
 		resolveColumnWidths,
 		useResizable
 	} from '@astryx-svelte/core';
+	import { ChartBarIcon } from '@fvilers/heroicons-svelte/24/solid';
+	import { EllipsisHorizontalIcon, XMarkIcon } from '@fvilers/heroicons-svelte/24/outline';
 	import type {
 		PowerSearchConfig,
 		PowerSearchFilter,
@@ -811,8 +810,8 @@
 	}
 </script>
 
-{#snippet closeIcon()}<Icon icon="close" size="sm" />{/snippet}
-{#snippet ellipsisIcon()}<Icon icon="moreHorizontal" size="sm" />{/snippet}
+{#snippet closeIcon()}<Icon icon={XMarkIcon} size="sm" />{/snippet}
+{#snippet ellipsisIcon()}<Icon icon={EllipsisHorizontalIcon} size="sm" />{/snippet}
 
 {#snippet taskDetailPanel(
 	task: TaskRow | null,
@@ -860,7 +859,7 @@
 					</MetadataListItem>
 					<MetadataListItem label="Priority">
 						<HStack gap={2} vAlign="center">
-							<Icon icon="viewColumns" size="sm" color={PRIORITY_COLOR[task.priority]} />
+							<Icon icon={ChartBarIcon} size="sm" color={PRIORITY_COLOR[task.priority]} />
 							<Text type="body">{PRIORITY_LABEL[task.priority]}</Text>
 						</HStack>
 					</MetadataListItem>
@@ -989,7 +988,7 @@
 								</TableCell>
 								<TableCell>
 									<HStack gap={3} vAlign="center">
-										<Icon icon="viewColumns" size="sm" color={PRIORITY_COLOR[task.priority]} />
+										<Icon icon={ChartBarIcon} size="sm" color={PRIORITY_COLOR[task.priority]} />
 										<Text type="supporting" color="secondary">{task.taskId}</Text>
 										<Text type="body" maxLines={1}>{task.title}</Text>
 										{#if task.subtitle}

--- a/packages/cli/assets/templates/pages/table-page-chart/+page.svelte
+++ b/packages/cli/assets/templates/pages/table-page-chart/+page.svelte
@@ -11,12 +11,13 @@
 	must build. `revenueData` is transcribed live and is currently read only by
 	that block. Uncomment when `charts` lands.
 
-	Upstream imports Heroicons, which have no Svelte build, so each is a stand-in
-	from core's 28-name `Icon` registry: `FunnelIcon` → `funnel` (the one true
-	match), `ArrowDownTrayIcon` → `arrowDown` (the registry ships no download
-	glyph), `PlusIcon` → `check` (it ships no plus either — the same substitution
-	`TabList`'s _New item_ block and the `shell-side-nav` template already make).
-	Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`TableColumn.renderCell` is a `Snippet<[T]>` here where upstream's is
 	`(item: T) => ReactNode`; a template snippet does not exist yet while
@@ -46,6 +47,7 @@
 		pixel,
 		proportional
 	} from '@astryx-svelte/core';
+	import { ArrowDownTrayIcon, FunnelIcon, PlusIcon } from '@fvilers/heroicons-svelte/24/outline';
 	import type { TableColumn } from '@astryx-svelte/core';
 
 	// ============= DATA =============
@@ -551,9 +553,9 @@
 	<Text type="body">{item.date}</Text>
 {/snippet}
 
-{#snippet funnelIcon()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet exportIcon()}<Icon icon="arrowDown" size="sm" />{/snippet}
-{#snippet plusIcon()}<Icon icon="check" size="sm" />{/snippet}
+{#snippet funnelIcon()}<Icon icon={FunnelIcon} size="sm" />{/snippet}
+{#snippet exportIcon()}<Icon icon={ArrowDownTrayIcon} size="sm" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} size="sm" />{/snippet}
 
 {#snippet header()}
 	<LayoutHeader hasDivider>

--- a/packages/cli/assets/templates/pages/table-page-heatmap-status/+page.svelte
+++ b/packages/cli/assets/templates/pages/table-page-heatmap-status/+page.svelte
@@ -12,12 +12,13 @@
 	(`DAYS`, `HOURS`, `buildHeatmapData`) is transcribed live and is currently
 	read only by that block. Uncomment when `lab` lands.
 
-	Upstream imports Heroicons, which have no Svelte build, so each is a stand-in
-	from core's 28-name `Icon` registry: `FunnelIcon` → `funnel` (the one true
-	match), `ArrowDownTrayIcon` → `arrowDown` (the registry ships no download
-	glyph), `ArrowPathIcon` → `arrowsUpDown` (it ships no refresh glyph; the
-	stand-in reads as "sort" elsewhere in the registry, which is the collision).
-	Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`TableColumn.renderCell` is a `Snippet<[T]>` here where upstream's is
 	`(item: T) => ReactNode`; a template snippet does not exist yet while
@@ -43,6 +44,11 @@
 		pixel,
 		proportional
 	} from '@astryx-svelte/core';
+	import {
+		ArrowDownTrayIcon,
+		ArrowPathIcon,
+		FunnelIcon
+	} from '@fvilers/heroicons-svelte/24/outline';
 	import type { TableColumn } from '@astryx-svelte/core';
 
 	// ============= DATA =============
@@ -408,9 +414,9 @@
 	<Text type="body">{item.date}</Text>
 {/snippet}
 
-{#snippet funnelIcon()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet exportIcon()}<Icon icon="arrowDown" size="sm" />{/snippet}
-{#snippet refreshIcon()}<Icon icon="arrowsUpDown" size="sm" />{/snippet}
+{#snippet funnelIcon()}<Icon icon={FunnelIcon} size="sm" />{/snippet}
+{#snippet exportIcon()}<Icon icon={ArrowDownTrayIcon} size="sm" />{/snippet}
+{#snippet refreshIcon()}<Icon icon={ArrowPathIcon} size="sm" />{/snippet}
 
 {#snippet header()}
 	<LayoutHeader hasDivider>

--- a/packages/cli/assets/templates/pages/table-page-shoe-store-heatmap/+page.svelte
+++ b/packages/cli/assets/templates/pages/table-page-shoe-store-heatmap/+page.svelte
@@ -15,13 +15,13 @@
 	must build. `revenueData` is transcribed live and is currently read only by
 	that block. Uncomment when `charts` lands.
 
-	Upstream imports Heroicons, which have no Svelte build, so each is a stand-in
-	from core's 28-name `Icon` registry: `FunnelIcon` → `funnel` (the one true
-	match), `ArrowDownTrayIcon` → `arrowDown` (the registry ships no download
-	glyph), `PlusIcon` → `check` (it ships no plus either — the same substitution
-	`TabList`'s _New item_ block and the `shell-side-nav` template already make).
-	Retires with the icon registry. `shoeSvg`'s inlined path data is upstream's
-	own and transcribes untouched.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`TableColumn.renderCell` is a `Snippet<[T]>` here where upstream's is
 	`(item: T) => ReactNode`; a template snippet does not exist yet while
@@ -51,6 +51,7 @@
 		pixel,
 		proportional
 	} from '@astryx-svelte/core';
+	import { ArrowDownTrayIcon, FunnelIcon, PlusIcon } from '@fvilers/heroicons-svelte/24/outline';
 	import type { TableColumn } from '@astryx-svelte/core';
 
 	// ============= DATA =============
@@ -909,9 +910,9 @@
 	<Text type="body">{item.date}</Text>
 {/snippet}
 
-{#snippet funnelIcon()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet exportIcon()}<Icon icon="arrowDown" size="sm" />{/snippet}
-{#snippet plusIcon()}<Icon icon="check" size="sm" />{/snippet}
+{#snippet funnelIcon()}<Icon icon={FunnelIcon} size="sm" />{/snippet}
+{#snippet exportIcon()}<Icon icon={ArrowDownTrayIcon} size="sm" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} size="sm" />{/snippet}
 
 {#snippet header()}
 	<LayoutHeader hasDivider>

--- a/packages/cli/assets/templates/pages/table-page/+page.svelte
+++ b/packages/cli/assets/templates/pages/table-page/+page.svelte
@@ -2,12 +2,13 @@
 	Ported from upstream's `assets/templates/pages/table-page/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Upstream imports Heroicons, which have no Svelte build, so each is a stand-in
-	from core's 28-name `Icon` registry: `FunnelIcon` → `funnel` (the one true
-	match), `ArrowDownTrayIcon` → `arrowDown` (the registry ships no download
-	glyph), `PlusIcon` → `check` (it ships no plus either — the same substitution
-	`TabList`'s _New item_ block and the `shell-side-nav` template already make).
-	Retires with the icon registry.
+	Icons are Heroicons, upstream's own set: `@fvilers/heroicons-svelte` is that
+	set built for Svelte 5, and it keeps upstream's component names and its
+	`24/outline` / `20/solid` / `24/solid` entry points. The imports below are
+	upstream's with the package name changed, so each glyph is the one upstream
+	draws rather than a stand-in from core's 28-name `Icon` registry — that
+	registry names theme-swappable UI affordances and was never meant to carry
+	arbitrary artwork.
 
 	`TableColumn.renderCell` is a `Snippet<[T]>` here where upstream's is
 	`(item: T) => ReactNode`; a template snippet does not exist yet while
@@ -40,6 +41,7 @@
 		pixel,
 		proportional
 	} from '@astryx-svelte/core';
+	import { ArrowDownTrayIcon, FunnelIcon, PlusIcon } from '@fvilers/heroicons-svelte/24/outline';
 	import type { PowerSearchFilter, TableColumn } from '@astryx-svelte/core';
 
 	interface DogRow extends Record<string, unknown> {
@@ -409,9 +411,9 @@
 	<Text type="body">{item.age}</Text>
 {/snippet}
 
-{#snippet funnelIcon()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet downloadIcon()}<Icon icon="arrowDown" size="sm" />{/snippet}
-{#snippet plusIcon()}<Icon icon="check" size="sm" />{/snippet}
+{#snippet funnelIcon()}<Icon icon={FunnelIcon} size="sm" />{/snippet}
+{#snippet downloadIcon()}<Icon icon={ArrowDownTrayIcon} size="sm" />{/snippet}
+{#snippet plusIcon()}<Icon icon={PlusIcon} size="sm" />{/snippet}
 
 {#snippet header()}
 	<LayoutHeader hasDivider>

--- a/packages/cli/assets/templates/pages/theme-showcase/+page.svelte
+++ b/packages/cli/assets/templates/pages/theme-showcase/+page.svelte
@@ -2,22 +2,20 @@
 	Ported from upstream's `assets/templates/pages/theme-showcase/page.tsx`.
 	Transcribed, not re-authored: the parity rule covers template content too.
 
-	Icons. Upstream imports `lucide-react`, which has no Svelte build and is not
-	a dependency a scaffolded template may assume, so every glyph is a name from
-	core's `Icon` registry — the same substitution the `docs/` examples make for
-	Heroicons. True matches: `Search` → `search`, `Mic` → `microphone`,
-	`X` → `close`. Established stand-ins: `Folder` → `calendar`,
-	`User` → `info`, `Lock` → `stop`. The rest are stand-ins picked here, with
-	their collisions named: `Plus` → `check`; `Tag` → `funnel`;
-	`MapPin` → `info` (collides with `User`); `List` → `menu`;
-	`LayoutGrid` → `viewColumns`; `ShoppingBag` and `CreditCard` → `copy`;
-	`Banknote` and `Wallet` → `wrench`; `Smartphone` → `stop` (collides with
-	`Lock`); `Download` → `arrowDown`. Sizes map onto the `Icon` scale:
-	`size={16}` → `size="sm"` (16px) and `size={20}` → `size="md"` (20px);
-	`size={18}` has no step, so the two view-toggle buttons round to `md`. The
-	three filter `Selector`s pass the registry *name* rather than a snippet —
-	`Selector.startIcon` accepts `IconName` and renders it at `size="sm"`, which
-	is upstream's 16 exactly. Retires with the icon registry.
+	Icons. This page is the one that draws with Lucide rather than Heroicons, as
+	upstream's does: `@lucide/svelte` is `lucide-react`'s Svelte build and the
+	names match, so the import below is upstream's with the package name
+	changed. It is already this repo's own dependency — the shipped themes build
+	their icon registries from it.
+
+	Sizes map onto the `Icon` scale: `size={16}` → `size="sm"` (16px) and
+	`size={20}` → `size="md"` (20px); `size={18}` has no step, so the two
+	view-toggle buttons round to `md`.
+
+	`Selector.startIcon` is `IconName | Snippet` here where upstream's takes the
+	element, so the three inventory filters go through the `Snippet` arm. A
+	snippet does not exist while `<script>` runs, so `INVENTORY_FILTERS` is
+	`$derived.by` — the same move the column arrays in this file make.
 
 	Four shape changes the Svelte port forces.
 
@@ -134,9 +132,27 @@
 		pixel,
 		proportional,
 		useAppShellMobile,
-		type IconName,
 		type TableColumn
 	} from '@astryx-svelte/core';
+	import {
+		Banknote,
+		CreditCard,
+		Download,
+		Folder,
+		LayoutGrid,
+		List,
+		Lock,
+		MapPin,
+		Mic,
+		Plus,
+		Search,
+		ShoppingBag,
+		Smartphone,
+		Tag,
+		User,
+		Wallet,
+		X
+	} from '@lucide/svelte';
 
 	// Styles passed to Astryx components via their `style` prop. Astryx components
 	// forward the DOM `style` prop, so these work with no CSS compiler — in
@@ -505,30 +521,30 @@
 	interface FilterSpec {
 		label: string;
 		placeholder: string;
-		startIcon: IconName;
+		startIcon: Snippet;
 		options: string[];
 	}
 
-	const INVENTORY_FILTERS: FilterSpec[] = [
+	const INVENTORY_FILTERS = $derived.by<FilterSpec[]>(() => [
 		{
 			label: 'Categories',
 			placeholder: 'Categories',
-			startIcon: 'calendar',
+			startIcon: folderIcon16,
 			options: ['Wearables', 'Audio', 'Bags', 'Drinkware', 'Home']
 		},
 		{
 			label: 'Locations',
 			placeholder: 'Locations',
-			startIcon: 'info',
+			startIcon: mapPinIcon16,
 			options: ['Aisle 1', 'Aisle 2', 'Aisle 3', 'Aisle 4', 'Aisle 5', 'Aisle 6']
 		},
 		{
 			label: 'Tags',
 			placeholder: 'Tags',
-			startIcon: 'funnel',
+			startIcon: tagIcon16,
 			options: ['New', 'Popular', 'Limited', 'Leather', 'Drinkware', 'Home']
 		}
-	];
+	]);
 
 	const inventoryColumns = $derived.by<TableColumn<InventoryRow>[]>(() => [
 		{
@@ -584,24 +600,26 @@
 <!-- ─── Icons ─────────────────────────────────────────────────────────────────
      One snippet per upstream glyph + size. See the header comment for the map. -->
 
-{#snippet searchIcon20()}<Icon icon="search" size="md" />{/snippet}
-{#snippet userIcon20()}<Icon icon="info" size="md" />{/snippet}
-{#snippet shoppingBagIcon20()}<Icon icon="copy" size="md" />{/snippet}
-{#snippet creditCardIcon20()}<Icon icon="copy" size="md" />{/snippet}
-{#snippet smartphoneIcon20()}<Icon icon="stop" size="md" />{/snippet}
-{#snippet walletIcon20()}<Icon icon="wrench" size="md" />{/snippet}
-{#snippet listIcon18()}<Icon icon="menu" size="md" />{/snippet}
-{#snippet layoutGridIcon18()}<Icon icon="viewColumns" size="md" />{/snippet}
-{#snippet plusIcon16()}<Icon icon="check" size="sm" />{/snippet}
-{#snippet searchIcon16()}<Icon icon="search" size="sm" />{/snippet}
-{#snippet tagIcon16()}<Icon icon="funnel" size="sm" />{/snippet}
-{#snippet creditCardIcon16()}<Icon icon="copy" size="sm" />{/snippet}
-{#snippet lockIcon16()}<Icon icon="stop" size="sm" />{/snippet}
-{#snippet downloadIcon16()}<Icon icon="arrowDown" size="sm" />{/snippet}
-{#snippet closeIcon16()}<Icon icon="close" size="sm" />{/snippet}
-{#snippet micIcon16()}<Icon icon="microphone" size="sm" />{/snippet}
-{#snippet shoppingBagIcon16()}<Icon icon="copy" size="sm" />{/snippet}
-{#snippet banknoteIcon16()}<Icon icon="wrench" size="sm" />{/snippet}
+{#snippet searchIcon20()}<Icon icon={Search} size="md" />{/snippet}
+{#snippet userIcon20()}<Icon icon={User} size="md" />{/snippet}
+{#snippet shoppingBagIcon20()}<Icon icon={ShoppingBag} size="md" />{/snippet}
+{#snippet creditCardIcon20()}<Icon icon={CreditCard} size="md" />{/snippet}
+{#snippet smartphoneIcon20()}<Icon icon={Smartphone} size="md" />{/snippet}
+{#snippet walletIcon20()}<Icon icon={Wallet} size="md" />{/snippet}
+{#snippet listIcon18()}<Icon icon={List} size="md" />{/snippet}
+{#snippet layoutGridIcon18()}<Icon icon={LayoutGrid} size="md" />{/snippet}
+{#snippet plusIcon16()}<Icon icon={Plus} size="sm" />{/snippet}
+{#snippet searchIcon16()}<Icon icon={Search} size="sm" />{/snippet}
+{#snippet tagIcon16()}<Icon icon={Tag} size="sm" />{/snippet}
+{#snippet folderIcon16()}<Icon icon={Folder} size="sm" />{/snippet}
+{#snippet mapPinIcon16()}<Icon icon={MapPin} size="sm" />{/snippet}
+{#snippet creditCardIcon16()}<Icon icon={CreditCard} size="sm" />{/snippet}
+{#snippet lockIcon16()}<Icon icon={Lock} size="sm" />{/snippet}
+{#snippet downloadIcon16()}<Icon icon={Download} size="sm" />{/snippet}
+{#snippet closeIcon16()}<Icon icon={X} size="sm" />{/snippet}
+{#snippet micIcon16()}<Icon icon={Mic} size="sm" />{/snippet}
+{#snippet shoppingBagIcon16()}<Icon icon={ShoppingBag} size="sm" />{/snippet}
+{#snippet banknoteIcon16()}<Icon icon={Banknote} size="sm" />{/snippet}
 
 <!-- ─── Store preview ─────────────────────────────────────────────────────── -->
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -105,6 +105,8 @@
 		"@astryx-svelte/core": "workspace:*",
 		"@astryx-svelte/theme-neutral": "workspace:*",
 		"@eslint/js": "^10.0.1",
+		"@fvilers/heroicons-svelte": "2.1.5-fix.3",
+		"@lucide/svelte": "^1.25.0",
 		"@types/node": "^22",
 		"eslint": "^10.4.1",
 		"eslint-config-prettier": "^10.1.8",

--- a/packages/core/src/lib/components/icon/icon-registry.ts
+++ b/packages/core/src/lib/components/icon/icon-registry.ts
@@ -1,5 +1,4 @@
 import type { Component, Snippet } from 'svelte';
-import type { SVGAttributes } from 'svelte/elements';
 import type { DefinedTheme } from '../../theme/define-theme.js';
 import { getRegisteredTheme } from '../../theme/theme-registry.js';
 import { warnOnce } from '../../utils/dev-warning.js';
@@ -91,8 +90,35 @@ export type IconRegistrySource = DefinedTheme | string | null | undefined;
  * the same type instead of restating it. Note this is deliberately *not*
  * `IconRegistry`'s value type — the prop takes a component, the registry holds a
  * rendered snippet, which is upstream's split too.
+ *
+ * ## Why this is a bare `Component`
+ *
+ * Upstream is `ComponentType<SVGProps<SVGSVGElement>>`, and the literal
+ * translation — `Component<SVGAttributes<SVGSVGElement>>` — typechecks against
+ * nothing a consumer can actually pass. Component props are contravariant, and
+ * the element parameter reaches the event handlers in `DOMAttributes<T>`, so a
+ * package declaring `SVGAttributes<SVGElement>` and one declaring
+ * `SVGAttributes<SVGSVGElement>` are mutually unassignable. Every real Svelte
+ * icon package was measured against the strict form and every one failed:
+ * `@fvilers/heroicons-svelte` on the element parameter, `@lucide/svelte`
+ * (already this repo's own theme dependency) on a narrowed `name`,
+ * `svelte-heros-v2` on a narrowed `focusable`, and `heroicons-svelte` on being
+ * Svelte 4 classes rather than Svelte 5 components.
+ *
+ * The strictness is an artefact of the translation, not of upstream's intent.
+ * `@heroicons/react` accepts the *full* `SVGProps<SVGSVGElement>` and only adds
+ * optional extras, so upstream's type admits its own icon set; no Svelte icon
+ * package is written that way. Keeping the literal form would mean core's
+ * published `Icon` accepts no icon library at all — which is what pushed the
+ * page templates onto the 28-name semantic registry and the wrong glyphs that
+ * implies.
+ *
+ * A bare `Component` is the same call shadcn-svelte makes for the same reason.
+ * `Icon` passes only SVG attributes to whatever it renders, so the shape this
+ * name documents is unchanged; what is dropped is the element parameter that
+ * no package can satisfy.
  */
-export type IconType = Component<SVGAttributes<SVGSVGElement>>;
+export type IconType = Component;
 
 // Keyed by plain `string`, not `IconName`: since 0.3.0 a library may register
 // its own extension keys alongside the built-ins.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,12 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0(jiti@2.7.0))
+      '@fvilers/heroicons-svelte':
+        specifier: 2.1.5-fix.3
+        version: 2.1.5-fix.3(svelte@5.56.7(@typescript-eslint/types@8.65.0))
+      '@lucide/svelte':
+        specifier: ^1.25.0
+        version: 1.30.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))
       '@types/node':
         specifier: ^22
         version: 22.20.1
@@ -913,6 +919,11 @@ packages:
 
   '@formatjs/icu-skeleton-parser@2.1.11':
     resolution: {integrity: sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==}
+
+  '@fvilers/heroicons-svelte@2.1.5-fix.3':
+    resolution: {integrity: sha512-YULvWz+ik0ZHTUlLp4Psh1lI2B2X2ndXnK36rmVSHMe5bz8tTWSU5ODcDTcN1Ddx7f9KOQ9zVOBrx1vJvidpxQ==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2856,6 +2867,10 @@ snapshots:
       '@formatjs/icu-skeleton-parser': 2.1.11
 
   '@formatjs/icu-skeleton-parser@2.1.11': {}
+
+  '@fvilers/heroicons-svelte@2.1.5-fix.3(svelte@5.56.7(@typescript-eslint/types@8.65.0))':
+    dependencies:
+      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
 
   '@humanfs/core@0.19.2':
     dependencies:


### PR DESCRIPTION
The 43 page templates drew the **wrong pictures**. 69 documented substitutions across **37 of 43** files mapped upstream's ~85 distinct Heroicons onto core's 28-name *semantic* registry:

| Upstream | Rendered as | Count |
| --- | --- | --- |
| `PlusIcon` | `check` — "Add" buttons drew a checkmark | ×8 |
| `PencilSquareIcon` | `copy` | ×5 |
| `SparklesIcon` | `wrench` | ×4 |
| `UserIcon` | `info` | ×3 |
| `StarIcon` | `check` — rating stars drew checkmarks | ×2 |
| `FolderIcon` | `menu` | ×2 |

The same upstream icon was also mapped inconsistently across files — `LockClosedIcon` reached `stop`, `eyeSlash` *and* `warning`.

**Styles were never involved.** The class oracle reads 0 mismatches before and after.

## The header comments blamed the wrong thing

They asserted Heroicons "has no Svelte build". The real blocker was one line of core:

```ts
IconType = Component<SVGAttributes<SVGSVGElement>>   // literal port of upstream's React type
```

Component props are contravariant and the element parameter reaches `DOMAttributes<T>`'s handlers, so **every** real Svelte icon package failed it. Measured, not assumed:

| Package | Result | Blocking property |
| --- | --- | --- |
| `@fvilers/heroicons-svelte` | fails | declares `SVGAttributes<SVGElement>` |
| `@lucide/svelte` | fails | narrows `name` to `string \| undefined` |
| `svelte-heros-v2` | fails | narrows `focusable` to `'true' \| 'false' \| 'auto'` |
| `heroicons-svelte` | fails | Svelte 4 class components |

`@heroicons/react` accepts the *full* `SVGProps` and only **adds** optional extras, which is why upstream's type admits its own icon set and ours admitted nothing. `IconType` is now a bare `Component` — the call shadcn-svelte makes for the same reason. `Icon` passes only SVG attributes to whatever it renders, so the shape is unchanged in practice.

## What landed

All 149 icon sites draw upstream's glyph. `@fvilers/heroicons-svelte` mirrors `@heroicons/react`'s `24/outline` / `20/solid` / `24/solid` entry points **and** its `XxxIcon` export names, so the imports are upstream's with the package name changed. `theme-showcase` is the one page upstream draws with Lucide, and uses `@lucide/svelte` for the same reason.

Both are `packages/cli` devDependencies rather than `docs`': the templates are CLI assets, so resolution has to work from that path — the docs build fails otherwise. Upstream's arrangement is the same, its sandbox declaring `@heroicons/react` while its CLI declares nothing.

- One export name differs: heroicons-react's `Squares2X2Icon` is `Squares2x2Icon`
- Three `Selector.startIcon`s in `theme-showcase` go through the `Snippet` arm, so `INVENTORY_FILTERS` became `$derived.by` — a snippet does not exist while `<script>` runs
- 37 header comments rewritten; they documented substitutions that are now gone
- `product-detail` imported `Card` and never used it

## Verified

- `pnpm -r lint` clean, `pnpm -r check` 0 errors
- docs build compiles all 43 templates
- class oracle: 1,528 style keys, 615 inline call sites, **0 mismatches**
- 0 string-icon usages left
- the real Heroicons plus path `M12 4.5v15m7.5-7.5h-15` is in the built output where a checkmark used to be

**Test-suite worker flakiness is pre-existing, not a regression** — a clean tree gives 162/196 files with a crashed worker, this branch 149–163, and the crashing file differs every run. 0 test failures in every run.

## Reviewer note

`IconType` is a **published** core type. The change is strictly more permissive, so no consumer breaks — but it deviates from upstream's type *literally*, which the parity rule normally forbids. The argument is in the JSDoc and `TODO.md`: upstream's type is satisfiable in React only because `@heroicons/react` never narrows an SVG attribute, and no Svelte icon package is written that way, so the literal translation defeats the intent it was translating. Happy to split it into its own commit if you'd rather land the two independently.

`TODO.md` also records the open item this exposed: **templates are not typechecked at all** (mutation-checked — a deliberate type error in one produces 0 `svelte-check` errors, because `assets/` is outside every tsconfig include). That is how the substitutions survived, and it matters more now that a scaffolded app typechecks what it received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
