### PR TITLE
Stop the Svelte-version guard counting optional peers as frameworks

### DIFF
--- a/packages/cli/api/docs/svelte-version-sync.test.mjs
+++ b/packages/cli/api/docs/svelte-version-sync.test.mjs
@@ -72,9 +72,19 @@ describe('documented Svelte version matches the core peer dependency', () => {
 		// `react-dom`). It is a peer rather than a dependency on purpose — the
 		// consumer's own bundler runs the StyleX compiler over core, so a second
 		// copy resolving at a different version renders unstyled with no error.
+		//
+		// Optional peers are excluded on the same reasoning, mechanically rather
+		// than by name. A framework peer cannot be optional — the framework is
+		// what the package is written against, and a consumer without it has
+		// nothing to run. So `peerDependenciesMeta[name].optional` is a reliable
+		// signal that a peer is tooling, and it keeps this guard from firing every
+		// time core declares another one. `vite` and `@stylexjs/unplugin` arrived
+		// that way with the Vite preset: needed to *compile* core from source,
+		// irrelevant to anyone importing the pre-built stylesheet.
 		const BUILD_TOOL_PEERS = new Set(['@stylexjs/stylex']);
+		const optional = pkg.peerDependenciesMeta ?? {};
 		const frameworkPeers = Object.keys(pkg.peerDependencies).filter(
-			(name) => !BUILD_TOOL_PEERS.has(name)
+			(name) => !BUILD_TOOL_PEERS.has(name) && optional[name]?.optional !== true
 		);
 		expect(
 			frameworkPeers,


### PR DESCRIPTION
Unblocks the 0.3.1 release. CI on #3 failed one test out of 1,971 and the release workflow stopped before publishing — **nothing reached npm**, so the version number is unburned.

## The failure

```
core acquired a second framework peer dependency; if that is intentional,
update every surface that names the supported Svelte version…
  expected [ 'svelte', '@stylexjs/unplugin', 'vite' ] to deeply equal [ 'svelte' ]
```

`svelte-version-sync.test.mjs` keeps the documented Svelte version in sync with core's peer dependency, and asserts core has exactly **one** framework peer so there is only one version for the two READMEs and the getting-started guide to name.

The Vite preset added `vite` and `@stylexjs/unplugin` as **optional** peers. The guard could not tell tooling from framework, so it failed the release.

Note this arrived with the preset commit and had simply never run in CI — it is not a regression from the 0.3.1 work.

## The fix

```js
const optional = pkg.peerDependenciesMeta ?? {};
const frameworkPeers = Object.keys(pkg.peerDependencies).filter(
	(name) => !BUILD_TOOL_PEERS.has(name) && optional[name]?.optional !== true
);
```

Excluded mechanically rather than by name. A framework peer **cannot** be optional — the framework is what the package is written against, so a consumer without it has nothing to run. That makes `optional` a reliable tooling signal, and one that keeps working when core declares the next tooling peer instead of needing another name added to a list.

This is the same blind spot already fixed in `doctor`'s `checkPeerDeps` earlier in the 0.3.1 work, in a second place nobody looked.

## Verification

**Mutation-checked**, because loosening a guard is exactly where one gets defanged by accident — adding a required `solid-js` peer still fails it:

```
expected [ 'solid-js', 'svelte' ] to deeply equal [ 'svelte' ]
```

Full CLI suite: **103 files, 1,946 passing, 25 todo, 1 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)