### PR TITLE
Track upstream 0.4.2, and fix what the closing audits found

### DIFF
--- a/.claude/agents/astryx-idiom.md
+++ b/.claude/agents/astryx-idiom.md
@@ -8,7 +8,7 @@ You review the **translation**, not the API surface. `astryx-parity` compares pr
 styles, elements and exports, and it is explicitly instructed that the idiom
 translations (`useState` → `$state`, `ReactNode` → `Snippet`, and the rest) are settled
 and not findings. That leaves a gap, and it is where this port's real bugs have lived:
-the right idiom applied *wrongly*. A context that stores a value instead of a getter is
+the right idiom applied _wrongly_. A context that stores a value instead of a getter is
 a correct-looking translation that freezes every descendant at mount, and no props diff
 will ever see it.
 
@@ -22,14 +22,14 @@ component uses before judging it.
 
 ## Where things live
 
-| What | Path |
-|---|---|
+| What              | Path                                                  |
+| ----------------- | ----------------------------------------------------- |
 | Upstream original | `reference/astryx-upstream/packages/core/src/<Name>/` |
-| Upstream hooks | `reference/astryx-upstream/packages/core/src/hooks/` |
-| Our port | `packages/core/src/lib/components/<kebab-name>/` |
-| Our hooks | `packages/core/src/lib/hooks/` |
-| Pattern canon | `port/research/06-react-to-svelte-patterns.md` |
-| Typecheck | `pnpm -F @astryx-svelte/core check` |
+| Upstream hooks    | `reference/astryx-upstream/packages/core/src/hooks/`  |
+| Our port          | `packages/core/src/lib/components/<kebab-name>/`      |
+| Our hooks         | `packages/core/src/lib/hooks/`                        |
+| Pattern canon     | `port/research/06-react-to-svelte-patterns.md`        |
+| Typecheck         | `pnpm -F @astryx-svelte/core check`                   |
 
 ## Method
 
@@ -40,7 +40,7 @@ things it is — a DOM handle or a mutable box), `useCallback`, `useId`,
 callback, every place a hook returns JSX.
 
 **2. Find each device's counterpart in our port** and judge it against the table below.
-A device with *no* counterpart is a finding unless it is on the obviated list.
+A device with _no_ counterpart is a finding unless it is on the obviated list.
 
 **3. State the symptom.** An idiom bug is invisible in a static read, so every finding
 must name what actually breaks and when — "descendants keep the mount-time size after
@@ -53,36 +53,75 @@ the symptom, you have not verified the finding; say so instead of reporting it.
 precisely because a plain value freezes descendants at mount. Any
 `setXContext({ size })` is a finding; it must be `setXContext({ get size() { … } })`.
 
-**`$derived` used where the value must be re-read *during* one server render.** A
+**`$derived` used where the value must be re-read _during_ one server render.** A
 derived is computed once per server render and cached. `MetadataList`'s registration
 count read through a `$derived` meant every item after the first saw a stale count, the
 SSR HTML carried all six items and no toggle, and only hydration corrected it. Rule: if
-a value changes as a single render *proceeds*, it must be a plain function call.
+a value changes as a single render _proceeds_, it must be a plain function call.
 Template expressions still track `$state`, so reactivity is not lost.
 
 **A dependency array flattened into an over-tracking effect.** Reading `options()`
 inside an `$effect` tracks every source the getter touches, where upstream keyed the
 effect on two of them. Route those through `$derived` first — a derived notifies only
-when its *value* changes, which is what a dependency array means (`useFocusTrap`).
+when its _value_ changes, which is what a dependency array means (`useFocusTrap`).
 
 **A ref callback translated to anything but an attachment.** Same attach/replace/detach
 lifecycle: the callback body becomes the attachment, its teardown becomes the return.
 An upstream unmount-only `useEffect` that exists solely because ref callbacks have no
-cleanup phase is *absorbed*, not ported alongside (`useScrollOverflow`). And an
+cleanup phase is _absorbed_, not ported alongside (`useScrollOverflow`). And an
 attachment that calls a function reading reactive sources must run it `untrack`ed, or it
 re-subscribes on every change — which is the `$effect`'s job, not the attachment's
 (`useOverflow`, `useListFocus`).
 
+**A moved node whose block teardown can no longer find it.** Svelte has no `createPortal`,
+so a React portal becomes an attachment that `appendChild`s the node into its target. That
+is fine for a node Svelte removes _by reference_, and wrong for one inside an `{#if}`:
+block teardown clears the range between the block's anchors **in the block's original
+parent**, so a node moved out of that range survives its own unmount. The attachment must
+therefore return `() => node.remove()` — idempotent, since a node Svelte did remove is
+simply not in a tree. `<Layer>`'s corrective portal is the precedent, and the symptom was a
+hidden `lazyMount` HoverCard staying in the DOM forever. `ChatComposerInput`'s token
+portals need no cleanup only because they sit in an `{#each}` of components, whose teardown
+does go through the moved node.
+
+**…and the same attachment must handle the move back.** A portal target that can become
+`null` (the resolve lands somewhere safe) is a _move_, not a no-op: returning early leaves
+the previous cleanup's `node.remove()` as the last word, and Svelte will not re-insert a
+node it considers already rendered. Capture where the node was rendered on first attach and
+put it back. `<Layer>`'s `portalHome` is the precedent; the symptom was a container that
+vanished when its render call moved from a `<p>` into a `<section>`, and it went unseen
+because upstream's `re-resolves the host when a persistent render call moves` had never been
+ported.
+
+**An attachment keyed on an object that is rebuilt per resolve.** `{@attach f(value)}`
+compares the returned function by identity, so a `value` reallocated with identical contents
+tears the attachment down and re-runs it. In React the same "re-set an equal object" is free
+— it re-renders into the same `createPortal` container and moves no DOM. Here the identity
+change _is_ a physical move, and moving a showing popover evicts it from the top layer
+without firing `toggle`. Give the producer an equality bail-out, **and** check the inverse:
+an attachment that must re-run when a value changes (`<Layer>`'s `attachPopover`, whose
+re-show branch repairs exactly that eviction) gets nothing if its expression is a stable
+function reference. Both directions cost a release blocker.
+
+**A React `ref` read is a non-tracking read; a `$state` read is not.** `isOpenRef.current`
+inside a callback cannot subscribe to anything, which is why upstream's dependency arrays are
+short. Transcribing it as a bare `$state` read inside an attachment or `$derived` silently
+adds a dependency the original never had, and the effect then re-runs on a value it was only
+ever meant to _sample_. `useLayer`'s `attachSentinel` read `isOpen` this way and closed every
+corrected-out `HoverCard` the instant it opened. Wrap sampled reads in `untrack`, and treat a
+docstring claiming "X is the only tracked read here" as a claim to verify rather than accept —
+short-circuit operators mean the reads _after_ the first are still reached.
+
 **A stale-closure ref transcribed instead of deleted.** `onLongPressRef`, `isOpenRef`,
 `listenedElRef`/`listenedHandlerRef` and friends exist only because React closures go
-stale. Options arriving as a getter read at *event* time make them dead weight. A ref
+stale. Options arriving as a getter read at _event_ time make them dead weight. A ref
 that survived the port is a finding even though it works.
 
 **Effect ordering assumed rather than checked.** A hook's `$effect` is created before
-the template's; a child component's attachment flushes *before* the parent's `$effect`;
+the template's; a child component's attachment flushes _before_ the parent's `$effect`;
 `$effect.pre` runs before both. Any `$effect` that touches a DOM node, calls
 `layer.show()`, or reads something an attachment sets must be checked against that order
-— `useListFocus` had to move its sync *into* the attachment for exactly this reason.
+— `useListFocus` had to move its sync _into_ the attachment for exactly this reason.
 
 **`useId` faked.** `$props.id()` is the only correct counterpart, and the compiler
 permits it only at the top level of a component. A `.svelte.ts` must therefore take `id`
@@ -90,7 +129,7 @@ as a required option (`useLayer`). A module-level counter keeps the signature an
 diverges between server and client, which is the failure `useId` exists to prevent.
 
 **`useSyncExternalStore` collapsed into `$derived`.** The three-argument form renders a
-*server snapshot* and re-renders live; the counterpart is `$state` + `$effect` (or
+_server snapshot_ and re-renders live; the counterpart is `$state` + `$effect` (or
 `$effect.pre` when there must be no flash — `useMediaQuery`). `Kbd`'s platform
 detection is the shape: deferred past hydration, never derived.
 
@@ -106,8 +145,8 @@ handler must be `onfocusin` — `onfocus` fires only for the container itself.
 
 **A hook that returns JSX kept as a function.** It splits: the rendering half becomes a
 component, and the hook hands back what the closure captured (`layer.render` → `<Layer>`,
-`renderTooltip` → `<TooltipLayer>`). Check the seam both ways — props upstream *accepts
-and then overwrites* must not be re-advertised on the new component, and overloads
+`renderTooltip` → `<TooltipLayer>`). Check the seam both ways — props upstream _accepts
+and then overwrites_ must not be re-advertised on the new component, and overloads
 should become a discriminated union rather than optional-everything.
 
 **A finished class string where a `stylex.props` merge was needed.** Helpers that
@@ -133,14 +172,14 @@ one line of checking rather than a finding.
 
 Lead with **SOUND** or **N findings**.
 
-| # | Device | Upstream (`file:line`) | Our counterpart (`file:line`) | Verdict | Symptom |
-|---|--------|------------------------|-------------------------------|---------|---------|
+| #   | Device | Upstream (`file:line`) | Our counterpart (`file:line`) | Verdict | Symptom |
+| --- | ------ | ---------------------- | ----------------------------- | ------- | ------- |
 
 Then a paragraph per finding: what React did, what ours does, the sequence that makes
 them diverge, and the smallest fix. Rank by whether the divergence is observable at all
 — a reactivity break that only shows after a prop change outranks a redundant ref that
 merely reads as untranslated.
 
-Where a translation is *interesting and right*, say so in one line rather than in
+Where a translation is _interesting and right_, say so in one line rather than in
 silence: this port's design notes are written from these reviews, and a confirmed hard
 case is worth as much as a finding.

--- a/.claude/agents/astryx-oracle.md
+++ b/.claude/agents/astryx-oracle.md
@@ -46,6 +46,17 @@ the keys used alongside a dynamic style while resolving the others inline (`Avat
 A case declared in object mode that compares _nothing_ is caught by the empty-case guard —
 that means inline mode, not "no styles".
 
+**A call site that starts going through a runtime helper flips inline → object.** StyleX
+folds a call site it can read statically; it cannot fold one whose styles are arguments to
+a function, so the keys stay objects in `dist/` and the call site emits no class string at
+all. `xstyle` crossing a component boundary is the familiar case; `focusOutlineProps.
+focusVisible(a, b)` is the same mechanism, and upstream 0.4.2's focus-ring adoption flipped
+five `side-nav-*` pairs at once. The tell is **"upstream has no matching call site"** with
+a short, unrelated list of what its inline sites actually are — delete the inline claim
+rather than trying to repair it, and let the object diff cover the keys. The reverse also
+happens: a style that stops taking a dynamic argument starts folding, and needs an inline
+entry it never had (`Avatar`'s `content`, when 0.4.2 moved the size onto the wrapper).
+
 **Finding the upstream file** takes a look, not a guess. It is sometimes
 `<Name>/<name>.stylex.js` and sometimes `<Name>/<Name>.js` with the `stylex.create` inline;
 one of our modules can even map to two upstream files, and two of our modules can map to

--- a/.claude/skills/track-upstream/SKILL.md
+++ b/.claude/skills/track-upstream/SKILL.md
@@ -6,8 +6,8 @@ description: Track a new upstream Astryx version — diff the tags, re-pin the e
 Track upstream `$ARGUMENTS` (a version, e.g. `0.4.2`).
 
 This sequence has been improvised three times (0.2.0, 0.3.0, 0.4.1). Batch 18 records what that
-costs: it *"began as 'track 0.3.0' and grew, because four closing audits and a release-readiness
-sweep kept finding things older than 0.3.0."* Follow the order.
+costs: it _"began as 'track 0.3.0' and grew, because four closing audits and a release-readiness
+sweep kept finding things older than 0.3.0."_ Follow the order.
 
 ## 1. Diff the tags
 
@@ -49,7 +49,7 @@ Mismatches here are expected — they are the diff. Work them with the `astryx-o
 
 Every `skip` entry (and `inlineSkip`, and the whole-module `ABSENT_UPSTREAM` list) in
 `packages/core/scripts/compare-upstream-classes.mjs` is a deferral with a reason, and the list
-cannot rot: a skip that stops matching fails the run, and so does one that *starts* matching. On a
+cannot rot: a skip that stops matching fails the run, and so does one that _starts_ matching. On a
 version bump, entries that read "published dist lags source" often retire themselves. Delete every
 entry the new tarball has caught up with rather than carrying it forward.
 
@@ -58,6 +58,27 @@ entry the new tarball has caught up with rather than carrying it forward.
 Do not carry the previous count forward. 0.3.0 removed the `--transition-fast` / `--transition-normal`
 pair and the count moved 186 -> 184; the figure "100 / 100 components" survived three batches after
 upstream moved to 101.
+
+## 5b. Diff the **test** delta, and treat it as scope
+
+```sh
+git diff --stat v<old>..v<new> -- 'packages/core/src/**/*.test.tsx' 'packages/core/src/**/*.test.ts'
+git diff --name-status v<old>..v<new> -- packages/core/src | grep -E '^A.*test'
+```
+
+A release's new cases are part of what it ships, not a follow-up. 0.4.2 added ~90 across the
+changed suites and the batch ported 21; the closing audits then found the two Layer defects that
+upstream's own unported `describe('context hosting')` block was written to catch, and the batch's
+headline change (`THUMB_INSET`) had shipped with no coverage at all while the ledger described it
+as transcribed and routed. **An added test _file_ is the loudest signal** — `useMenuHover.test.tsx`
+arrived new with 21 cases for a hook this port rewrote from scratch in the same batch, and nothing
+flagged that no suite existed on this side.
+
+Then **re-derive every suite header's count against the new tag**. A header saying "all N cases,
+nothing dropped" is a contract against upstream's file _at the current pin_, so a version bump
+invalidates it even when nothing local changed. Four headers were false at 0.4.2 — `side-nav`
+("all 99 … at v0.3.0"), `layer` ("all twenty-nine"), `slider` ("32 … nothing dropped", never true
+of any tag) and `hover-card` — and each one made a real gap look accounted for.
 
 ## 6. Check whether the tarball lags the source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,111 @@ release the port makes on its own has no number of its own to take. 0.3.1 is the
 ports Astryx 0.3.0, exactly as 0.3.0 did, and changes only things upstream has no counterpart for.
 Each entry states its parity target for that reason.
 
+## 0.4.2
+
+Ports Astryx `0.4.2`.
+
+No component was added, deleted or renamed upstream, so this is drift inside directories the port
+already shipped: 28 `packages/core/src` component directories, three hooks, the theme internals, the
+`en` locale catalog, and one new CLI command.
+
+### Layers now correct themselves out of hosts that cannot legally contain them
+
+A context layer renders an inert `<template>` marker at its position and mounts the real container
+where the marker's parent allows it — inline when that parent is safe, portaled to the nearest legal
+ancestor when it is not. A `HoverCard` written inside a `<p>`, a link, a `<td>` or an `<li>` no
+longer depends on the HTML parser to reparent it.
+
+`HoverCard` also defers mounting until it opens, so rich content never enters an invalid paragraph
+even briefly, and every layer declares its own `font-size`/`line-height` rather than inheriting the
+trigger's — the same `Tooltip` no longer renders at 13px from a caption and 20px from a lede.
+
+### One hover-menu machine, five adopters
+
+The hover→click guard, time-bounded reopen suppression, synchronous focus and focus restoration all
+moved into the shared `useMenuHover`. `TopNavMegaMenu` lost its private copy and `SideNavItem` its
+hand-rolled timers; `TopNavMenu`, `TopNavHeading`, `SideNavHeading` and `DropdownMenuSubMenu` gained
+a guard they never had. Hovering a menu open and clicking it no longer dismisses it, and a menu
+dismissed under a stationary pointer no longer springs back open.
+
+### Touch targets, forced colors, and the SideNav hardening pass
+
+`Switch`, `CheckboxInput` and `RadioListItem` floor their tappable area to 24x24 on a coarse pointer
+(WCAG 2.5.8 AA), `Thumbnail` grows a hit inset, and `Slider`'s track floors to 24px. The selected
+SideNav row survives Windows High Contrast — a 6% background tint flattens away entirely under
+forced colors, leaving the current page unmarked — and every focusable row now draws the _shared_
+focus ring, so a theme that restyles focus restyles all of them together.
+
+### New
+
+- **`astryx-svelte theme template`** writes an annotated reference of the whole `defineTheme`
+  surface into your project. It is machine-checked against this port's own types, so it cannot drift
+  into documenting a field that does not exist.
+- **`theme build` warns about fonts you named but never loaded.**
+- **`typography.body/heading/code` take a role-level `weight`**, filling every heading level
+  `weights` does not name. Named weights become token references so retuning `--font-weight-*` moves
+  them too; a raw CSS value passes through.
+- **`ChatMessageBubble.width`**, so ghost-bubble custom content can span the full message column
+  instead of the `max(80%, 280px)` cap.
+- **`useContainerReveal`** gained a hover-intent dwell (`hoverDelay`) and forced states.
+- **`Slider`'s thumb is inset by half its width at each end**, which is the geometry a native
+  `input[type=range]` uses: at min/max it no longer overhangs the component box by 10px.
+- **21 new locale keys.** `CommandPaletteFooter`'s keyboard hints and `DateTimeInput`'s time
+  placeholders stopped being hardcoded English.
+
+### Fixed
+
+Live in shipped behaviour, not style drift:
+
+- **Every `HoverCard` inside a `<p>`, `<a>`, `<td>` or `<li>` mounted hidden and never appeared.**
+  Three faults compounded: the marker's attachment subscribed to the open state, the resolved mount
+  was reallocated on every resolve, and the portal treated "no target" as nothing to do. Any one of
+  them evicted a showing popover from the top layer with nothing left to re-show it.
+- **A layer whose render call moved between two positions vanished**, because the portal removed it
+  and never put it back; if it was open, it did not reopen.
+- **`TopNavMegaMenuItem`'s drawer row drew no focus ring at all** — keyboard users had no visible
+  focus anywhere in the mobile drawer.
+- **`SideNavHeading`'s collapsed flyout could not be dismissed from the keyboard.** Its heading
+  button was still wired to the trigger's click handler, so Enter and Space only re-focused the
+  first item; Escape restored focus to nothing, because the collapsed trigger never registered.
+- **`Switch` and `AvatarGroupOverflow` documented a `size` theming axis they did not emit.** A theme
+  rule written against `[data-size]` silently matched nothing.
+- **A `TreeList` with no expandable items indented every row** by a chevron column none of them had.
+- **`Text` discarded a consumer's `title`** on every untruncated instance: the component wrote
+  `title={undefined}` after the rest spread, and a later `undefined` removes an attribute. The same
+  ordering hid a caller's `aria-label`/`role` on `Breadcrumbs`, `Heading`, `SideNav` and `TopNav`,
+  and let a caller's `oncancel` replace `Lightbox`'s Escape handler.
+- **`--radius-none` was `0.125rem` in four themes.** It is fixed by contract, like `--radius-full`,
+  and must never be scaled.
+- **A whitespace-only `Avatar` name rendered an empty plate** behind a blank accessible name.
+
+### API
+
+- `useTruncation`, `SizeProvider` and `FormLayoutContext` are published, closing the last of the
+  missing exports upstream ships.
+- `themeProps`, `parseStyleKey`, `observeResize` and seven siblings are reachable from
+  `@astryx-svelte/core/utils`, the subpath upstream puts them on. Their existing root exports stay.
+- `BreadcrumbMenuDividerProps` and `ContextMenuDividerProps` complete those two alias families.
+- Three CLI internals (`buildHelp`, `buildKit`, `importSpecifier`) left the `api` barrel, where
+  upstream keeps them module-private.
+
+### Verified
+
+Both fidelity oracles reach zero: 1,621 style keys and 515 inline call sites with **no skips**, and
+`astryx.css` matching upstream across 1,504 shared classes. All seven theme oracles are clean, and
+the token map now matches upstream family for family — same names, same counts, nothing extra on
+either side — for the first time.
+
+**The closing audits found a release blocker in this release's own headline feature**, and the
+corrective-portal defects above are what they turned up. The cause was uncovered code: upstream
+added roughly 90 test cases at this tag and the first pass ported 21, including none of the nine
+that exercise exactly the layer paths that broke. Around 105 cases have since landed across
+thirteen suites — among them the whole 21-case `useMenuHover` suite, which this port had never had
+for a hook it rewrote from scratch. 165 client files, 4,621 cases, plus 854 server cases.
+
+Two suites remain short of upstream and are named in `port/debts.md` rather than left implied:
+`SideNav` (26 cases) and `Slider` (12, predating this release).
+
 ## 0.4.1
 
 Ports Astryx `0.4.1`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,11 @@ wrong:
   version `packages/core` targets. Prose is reused verbatim; prop _types_ are read from
   `packages/core/dist/**/*.d.ts`, because upstream's are React types and mapping them guesses wrong
   (`Button.icon` is `ReactNode` upstream and `Snippet` here, with no string branch).
+- **`packages/core/src/lib/**/*.doc.mjs` are generated, and hand-editing them is a mistake** — each
+  says so at the top. `docs/scripts/emit-core-docs.mjs` writes them from the pinned upstream
+  `.doc.mjs` plus core's built `dist/**/*.d.ts`, so after a version bump the whole prose delta lands
+  with `pnpm -r build && pnpm -F docs emit-core-docs` (17 files at 0.4.2), and `--check` fails on
+  drift. They are the CLI's discovery corpus, not just the docs site's.
 
 ## The fidelity oracles
 
@@ -155,6 +160,13 @@ a `$state` write flushes on its own and `expect.element` retries.
 
 Upstream suites are ported **case for case**; the count is the contract. Any dropped case is named in
 the file with its reason.
+
+**The count is a contract against upstream's file at the _current pin_, so a version bump
+invalidates every header that states one** — re-derive them in the same batch, and diff the test
+delta as scope rather than as follow-up (`track-upstream` step 5b). Four headers were false at
+0.4.2, each making a real gap look accounted for, and the two Layer defects that shipped were
+exactly what the unported cases existed to catch. A dropped case's stated reason expires too:
+`button-group` carried "`DropdownMenu` is not ported" for three batches after it was.
 
 Coverage _beyond_ upstream needs a high bar: a hazard with **no upstream analogue**, which the ported
 suites structurally cannot catch — a Svelte-specific DOM or reactivity failure React cannot

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,8 +29,8 @@
 		"@stylexjs/stylex": "^0.19.0"
 	},
 	"devDependencies": {
-		"@astryxdesign/cli": "0.4.1",
-		"@astryxdesign/core": "0.4.1",
+		"@astryxdesign/cli": "0.4.2",
+		"@astryxdesign/core": "0.4.2",
 		"@eslint/js": "^10.0.1",
 		"@qwik.dev/partytown": "^0.14.0",
 		"@stylexjs/unplugin": "^0.19.0",

--- a/packages/cli/api/index.mjs
+++ b/packages/cli/api/index.mjs
@@ -52,8 +52,11 @@ export { template } from './template/template.mjs';
 export { swizzle } from './swizzle/swizzle.mjs';
 export { init } from './init/init.mjs';
 export { doctor } from './doctor/doctor.mjs';
-export { build, buildHelp, buildKit } from './build/build.mjs';
-export { themeBuild, themeAdd, themeList, listThemes, importSpecifier } from './theme/theme.mjs';
+// `buildHelp`/`buildKit`/`importSpecifier` are module-public and barrel-absent
+// upstream (`api/index.mjs:28,31`), so they stay internals here too — a name on
+// this barrel is a compatibility promise.
+export { build } from './build/build.mjs';
+export { themeBuild, themeAdd, themeList, listThemes } from './theme/theme.mjs';
 export { layoutExpand, layoutCheck, layoutGrammar } from './layout/layout.mjs';
 export { upgrade } from './upgrade/upgrade.mjs';
 // Landed with `validate-integration` but missing from this barrel until slice 5

--- a/packages/cli/api/init/init.test.mjs
+++ b/packages/cli/api/init/init.test.mjs
@@ -66,13 +66,30 @@ describe('init() — receipts + side effects', () => {
 		expect(res.type === 'init.run' && res.data.docsWritten).toContain('AGENTS.md');
 	});
 
-	it('--features theme emits guidance, writes no files, and flags theme', async () => {
+	it('--features theme writes the annotated template and reports it on the receipt', async () => {
 		const res = await init({ features: 'theme' }, { cwd: tmpDir });
 		expect(res.type).toBe('init.run');
 		if (res.type !== 'init.run') return;
 		expect(res.data.theme).toBe(true);
+		expect(res.data.themeTemplate).toBe('created');
+		expect(res.data.themeTemplatePath).toBe('theme.template.ts');
 		expect(res.data.docsWritten).toEqual([]);
-		expect(fs.readdirSync(tmpDir)).toEqual([]);
+		expect(fs.readdirSync(tmpDir)).toEqual(['theme.template.ts']);
+		// The consumer's copy is their file: it must not carry the upstream repo
+		// header, which their own lint would flag.
+		const written = fs.readFileSync(path.join(tmpDir, 'theme.template.ts'), 'utf-8');
+		expect(written).not.toMatch(/Copyright \(c\) Meta Platforms/);
+		expect(written.startsWith('/**')).toBe(true);
+	});
+
+	it('--features theme reports `skipped` rather than overwriting an existing template', async () => {
+		fs.writeFileSync(path.join(tmpDir, 'theme.template.ts'), '// mine\n');
+		const res = await init({ features: 'theme' }, { cwd: tmpDir });
+		expect(res.type).toBe('init.run');
+		if (res.type !== 'init.run') return;
+		expect(res.data.themeTemplate).toBe('skipped');
+		expect(res.data.themeTemplatePath).toBe(null);
+		expect(fs.readFileSync(path.join(tmpDir, 'theme.template.ts'), 'utf-8')).toBe('// mine\n');
 	});
 
 	it('--features template returns the workflow (or skipped) outcome, no crash', async () => {

--- a/packages/cli/api/init/init.type.mjs
+++ b/packages/cli/api/init/init.type.mjs
@@ -9,7 +9,9 @@
  * @property {string[]} features Features that were run, in order.
  * @property {string[]} docsWritten Agent-doc files written (empty if agents weren't run or install failed).
  * @property {{kind: 'path-safety' | 'install-failed', message?: string} | null} docsError Soft agent-docs failure, if any. `path-safety` also implies a non-zero exit.
- * @property {boolean} theme Whether theme guidance was emitted.
+ * @property {boolean} theme Whether the theme feature ran.
+ * @property {'created' | 'skipped' | 'failed' | null} themeTemplate Outcome of writing the annotated theme template (`skipped` = a file was already there).
+ * @property {string | null} themeTemplatePath Relative output path when `themeTemplate === 'created'`.
  * @property {'workflow' | 'created' | 'skipped' | null} template Template outcome (`workflow` is the CLI default; `created`/`skipped` are programmatic).
  * @property {string | null} templatePath Relative output path when `template === 'created'`.
  * @property {boolean} nextSteps Whether the getting-started "Next steps" were emitted (default mode).
@@ -30,7 +32,7 @@
 /**
  * Options for `init()`.
  * @typedef {object} InitOptions
- * @property {string} [features] Comma-separated features to install (agents, theme, template).
+ * @property {string} [features] Comma-separated features to install: agents (agent docs), theme (writes the annotated theme.template.ts), template (page-template guidance).
  * @property {boolean} [all] Install all features.
  * @property {boolean} [removeAgents] Remove the managed agent-docs block instead of installing.
  * @property {string} [agent] Agent preset: claude, cursor, codex, hermes, all.

--- a/packages/cli/api/init/run/run.mjs
+++ b/packages/cli/api/init/run/run.mjs
@@ -21,6 +21,7 @@ import { installAgentDocs } from '../../../foundation/agent-docs/agent-docs.mjs'
 import { AstryxError } from '../../error.mjs';
 import { ERROR_CODES } from '../../../foundation/response/error-codes.mjs';
 import { logger } from '../../logger.mjs';
+import { themeTemplate } from '../../theme/template/template.mjs';
 
 const VALID_FEATURES = ['agents', 'theme', 'template'];
 const VALID_AGENTS = ['claude', 'cursor', 'codex', 'hermes', 'all'];
@@ -216,6 +217,41 @@ async function applyTemplate(cwd, { templateName }, invocation, data) {
 }
 
 /**
+ * Write the annotated theme template, via the same leaf `astryx-svelte theme
+ * template` uses — init is a convenience wrapper over the theme command, not a
+ * second implementation of it.
+ *
+ * It replaced a one-line hint at upstream 0.4.2 (#5048): pointing at a command
+ * is the weakest form of the help a theme author needs, because the first
+ * problem is not knowing the command but not knowing what the theme surface
+ * contains.
+ *
+ * @param {string} cwd
+ * @param {string} invocation
+ * @param {import('../init.type.mjs').InitRunData} data
+ */
+function applyTheme(cwd, invocation, data) {
+	data.theme = true;
+	try {
+		const { path: written, written: didWrite } = themeTemplate({ cwd }).data;
+		data.themeTemplate = didWrite ? 'created' : 'skipped';
+		data.themeTemplatePath = didWrite ? written : null;
+		logger.log(
+			didWrite
+				? `[ok] Theme template written -> ${written}`
+				: `- ${written} already exists — left as is.`
+		);
+	} catch {
+		// Soft failure, like agent docs: the guidance below is still useful.
+		data.themeTemplate = 'failed';
+		logger.error('Could not write the theme template.');
+	}
+	logger.log(
+		`  Copy it to your theme file and edit, or run \`${invocation} theme add <slug>\` to start from a shipped theme (\`${invocation} theme list\` to browse).`
+	);
+}
+
+/**
  * Run the install path of the non-interactive init flow (the default no-flags
  * install plus `--features` / `--all`). Performs the side effects (agent-docs
  * install, template scaffold) and returns an `init.run` receipt. Progress is
@@ -253,18 +289,15 @@ export async function run(options = {}, { cwd = process.cwd() } = {}) {
 			docsWritten: [],
 			docsError: null,
 			theme: false,
+			themeTemplate: null,
+			themeTemplatePath: null,
 			template: null,
 			templatePath: null,
 			nextSteps: false
 		};
 		for (const feature of features) {
 			if (feature === 'agents') applyAgents(cwd, options, invocation, data);
-			if (feature === 'theme') {
-				logger.log(
-					`[ok] For a custom theme, run \`${invocation} theme\` (browse) or \`${invocation} theme add <slug>\` (scaffold).`
-				);
-				data.theme = true;
-			}
+			if (feature === 'theme') applyTheme(cwd, invocation, data);
 			if (feature === 'template') {
 				await applyTemplate(cwd, { templateName: options.templateName }, invocation, data);
 			}
@@ -281,6 +314,8 @@ export async function run(options = {}, { cwd = process.cwd() } = {}) {
 		docsWritten: [],
 		docsError: null,
 		theme: false,
+		themeTemplate: null,
+		themeTemplatePath: null,
 		template: null,
 		templatePath: null,
 		nextSteps: true

--- a/packages/cli/api/theme/add/add.mjs
+++ b/packages/cli/api/theme/add/add.mjs
@@ -11,24 +11,7 @@ import { assertWithin, PathSafetyError } from '../../../foundation/fs/path-safet
 import { AstryxError } from '../../error.mjs';
 import { ERROR_CODES } from '../../../foundation/response/error-codes.mjs';
 import { THEMES_DIR, listThemes, findTheme } from '../_adapter.mjs';
-
-// Stripped from scaffolded files so the consumer's copy doesn't carry our
-// repo boilerplate (mirrors the docsite). Preserves a leading BOM/shebang.
-//
-// Ported unchanged, and it is a guard rather than a transform here: this port's
-// own theme sources carry no Meta copyright line, so it matches nothing today.
-// It is kept because the bundle is a copy of `packages/themes/*/src`, and a
-// theme source adapted from upstream would arrive with the header attached.
-const META_COPYRIGHT_HEADER_RE =
-	/^(\uFEFF?(?:#![^\r\n]*(?:\r?\n))?)\/\/ Copyright \(c\) Meta Platforms, Inc\. and affiliates\.\r?\n(?:\r?\n)*/;
-
-/**
- * @param {string} source
- * @returns {string}
- */
-function stripCopyrightHeader(source) {
-	return source.replace(META_COPYRIGHT_HEADER_RE, '$1');
-}
+import { stripCopyrightHeader } from '../../../foundation/text/copyright-header.mjs';
 
 /**
  * @param {string} slug

--- a/packages/cli/api/theme/build/build.font-warning.test.mjs
+++ b/packages/cli/api/theme/build/build.font-warning.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * API-contract tests for the font-loading warning in `themeBuild()` (#5015):
+ * a theme that names font families it does not load gets one entry per family
+ * in the `theme.build` receipt's `warnings` array, on BOTH load paths — a raw
+ * typography config (resolved through core's defineTheme) and an
+ * already-resolved theme that sets `--font-family-*` tokens directly. Themes
+ * that only name generics or known system families warn about nothing, and
+ * the warning never breaks the API's silence contract (default noopLogger).
+ *
+ * Needs a built core — the same precondition every other `themeBuild()` suite
+ * in this package has.
+ *
+ * Ported case-for-case from Astryx's
+ * `api/theme/build/build.font-warning.test.mjs`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { themeBuild } from './build.mjs';
+
+vi.setConfig({ testTimeout: 30000 });
+
+let tmpDir;
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-theme-fonts-api-'));
+});
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('themeBuild() — font-loading warnings in the receipt', () => {
+	it('warns once per unloaded family for a typography config (heading inherits body without duplicating)', async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, 'fonty.mjs'),
+			`export default {
+  name: 'fonty',
+  typography: {
+    body: {family: 'Space Grotesk', fallbacks: 'Arial, sans-serif'},
+    code: {family: 'JetBrains Mono'},
+  },
+};\n`
+		);
+
+		const result = await themeBuild('fonty.mjs', {}, { cwd: tmpDir });
+
+		expect(result?.type).toBe('theme.build');
+		const warnings = result?.data.warnings ?? [];
+		expect(warnings).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('Font "Space Grotesk"'),
+				expect.stringContaining('Font "JetBrains Mono"')
+			])
+		);
+		// Heading inherits body's family; the shared family warns exactly once.
+		expect(warnings.filter((w) => w.includes('Space Grotesk'))).toHaveLength(1);
+	});
+
+	it('warns for an already-resolved theme: font-family tokens and component overrides, nothing else', async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, 'raw.mjs'),
+			`export default {
+  name: 'raw',
+  tokens: {
+    '--font-family-body': '"Bungee", cursive',
+    '--font-size-base': '1rem',
+  },
+  components: {button: {base: {fontFamily: 'Orbitron'}}},
+};\n`
+		);
+
+		const result = await themeBuild('raw.mjs', {}, { cwd: tmpDir });
+
+		// Exactly the two named families — a non-family --font-* token must not
+		// produce a bogus "Font \\"1rem\\"" entry, and the components half of the
+		// feature must survive the real themeBuild path, not just the unit helper.
+		const fontWarnings = (result?.data.warnings ?? []).filter((w) => w.startsWith('Font "'));
+		expect(fontWarnings).toEqual([
+			expect.stringContaining('Font "Bungee"'),
+			expect.stringContaining('Font "Orbitron"')
+		]);
+	});
+
+	it('warns for a family named only inside a pseudo-class component override (defineTheme path)', async () => {
+		// ':hover' blocks are legal override values (generateThemeRules), and the
+		// typography path deep-merges author components with generated ones — a
+		// webfont hiding at that depth must survive the merge and still warn.
+		fs.writeFileSync(
+			path.join(tmpDir, 'pseudo.mjs'),
+			`export default {
+  name: 'pseudo',
+  typography: {
+    body: {family: 'Helvetica', fallbacks: 'Arial, sans-serif'},
+  },
+  components: {
+    button: {base: {':hover': {fontFamily: '"Rubik Doodle", cursive'}}},
+  },
+};\n`
+		);
+
+		const result = await themeBuild('pseudo.mjs', {}, { cwd: tmpDir });
+
+		const fontWarnings = (result?.data.warnings ?? []).filter((w) => w.startsWith('Font "'));
+		// Exactly the hidden family — Helvetica/Arial are system fonts.
+		expect(fontWarnings).toEqual([expect.stringContaining('Font "Rubik Doodle"')]);
+	});
+
+	it('warns about nothing when every named family is a generic or known system font', async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, 'sys.mjs'),
+			`export default {
+  name: 'sys',
+  tokens: {
+    '--color-bg': '#fff',
+    '--font-family-body': 'Helvetica, Arial, sans-serif',
+  },
+};\n`
+		);
+
+		const result = await themeBuild('sys.mjs', {}, { cwd: tmpDir });
+
+		expect(result?.type).toBe('theme.build');
+		expect(result?.data.warnings).toEqual([]);
+	});
+
+	it('stays silent under the default noopLogger even when font warnings fire', async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, 'loud.mjs'),
+			`export default { name: 'loud', tokens: { '--font-family-body': '"Orbitron", sans-serif' } };\n`
+		);
+
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+		try {
+			const result = await themeBuild('loud.mjs', {}, { cwd: tmpDir });
+			expect(result?.data.warnings).toEqual(
+				expect.arrayContaining([expect.stringContaining('Font "Orbitron"')])
+			);
+			expect(logSpy).not.toHaveBeenCalled();
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(errSpy).not.toHaveBeenCalled();
+			expect(outSpy).not.toHaveBeenCalled();
+		} finally {
+			logSpy.mockRestore();
+			warnSpy.mockRestore();
+			errSpy.mockRestore();
+			outSpy.mockRestore();
+		}
+	});
+});

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -76,6 +76,7 @@ import {
 import { ERROR_CODES } from '../../../foundation/response/error-codes.mjs';
 import { AstryxError } from '../../error.mjs';
 import { logger } from '../../logger.mjs';
+import { collectUnloadedFonts, formatFontLoadingHelp } from './font-warning.mjs';
 import { CORE_PACKAGE } from '../../../foundation/discovery/component-discovery.mjs';
 import { loadComponentDoc } from '../../../foundation/discovery/component-loader.mjs';
 
@@ -1340,17 +1341,21 @@ Or with a <link> tag:
   </Theme>
 `);
 
-	// Print font declaration warnings (derived from typography roles). Inert in
-	// both codebases today: neither `defineTheme` puts a `fonts` array on the
-	// theme it returns. Kept verbatim rather than pruned — it is upstream's
-	// output for a theme that carries one, and dropping it would be silent drift.
-	if (resolvedTheme && resolvedTheme.fonts && resolvedTheme.fonts.length > 0) {
-		logger.log(`\n⚠ Theme "${themeDef.name}" requires fonts not included in the build:`);
-		for (const font of resolvedTheme.fonts) {
-			logger.log(`  ${font.family} — add to your document <head>:`);
-			logger.log(`  <link rel="stylesheet" href="${font.url}" />`);
-		}
-		logger.log('');
+	// Fonts the theme names but nothing loads (#5015). Resolved tokens and
+	// component overrides carry the final font-family values on both load
+	// paths, so this sees jiti-resolved and legacy themes alike.
+	//
+	// It replaced a `resolvedTheme.fonts` loop at upstream 0.4.2. That loop was
+	// inert in both codebases — no `defineTheme` ever put a `fonts` array on the
+	// theme it returns — so the warning it was meant to give never fired.
+	const unloadedFonts = collectUnloadedFonts(resolvedTheme);
+	for (const family of unloadedFonts) {
+		const msg = `Font "${family}" is named by this theme but not loaded — add a <link> or @font-face in your app (recipe: astryx-svelte docs typography)`;
+		warningMessages.push(msg);
+		logger.warn(`  [warn] ${msg}`);
+	}
+	if (unloadedFonts.length > 0) {
+		logger.log(formatFontLoadingHelp(themeDef.name, unloadedFonts));
 	}
 
 	return {

--- a/packages/cli/api/theme/build/font-warning.mjs
+++ b/packages/cli/api/theme/build/font-warning.mjs
@@ -1,0 +1,219 @@
+/**
+ * @file Font-loading warning helpers for `astryx-svelte theme build` (#5015).
+ *
+ * Nothing in the pipeline loads font files — `defineTheme` and the built CSS
+ * only set `font-family` — so a theme that names a webfont renders in the
+ * fallback typeface on every machine whose app never loads it, and no step
+ * says so. These helpers close that gap at build time.
+ *
+ * `collectUnloadedFonts` inspects a RESOLVED theme (raw typography configs
+ * are already collapsed into `--font-family-*` tokens by the time the build
+ * sees the theme, so tokens + component-override `fontFamily` values are the
+ * complete font surface on both load paths) and returns the families that
+ * are neither CSS generics nor known preinstalled system fonts. Unrecognized
+ * names are assumed to be webfonts on purpose: a missed warning hides the
+ * bug, a spurious one costs a glance.
+ *
+ * @input A resolved theme object ({tokens, components}) from build.mjs.
+ * @output Ordered, case-insensitively deduped family names, and the human
+ *   help snippet (<link> pair + @font-face) printed after the install
+ *   instructions.
+ * @position Sits beside build.mjs (api/theme/build/). Pure functions, no IO,
+ *   so the `--json` receipt and the human output share one source of truth.
+ */
+
+// font-family values that never need loading: CSS generic families, the ui-*
+// system keywords, and CSS-wide keywords that can appear in a token value.
+const GENERIC_KEYWORDS = new Set([
+	'serif',
+	'sans-serif',
+	'monospace',
+	'cursive',
+	'fantasy',
+	'system-ui',
+	'math',
+	'emoji',
+	'fangsong',
+	'ui-serif',
+	'ui-sans-serif',
+	'ui-monospace',
+	'ui-rounded',
+	'inherit',
+	'initial',
+	'unset',
+	'revert',
+	'revert-layer'
+]);
+
+// Families a clean machine already has: the members of core's own default
+// stacks (tokens.stylex.ts typographyDefaults) plus the classic web-safe
+// macOS/Windows set. Deliberately short — an unknown family warns, and for a
+// preinstalled rarity that is a one-line false alarm, not a broken theme.
+const SYSTEM_FAMILIES = new Set([
+	'-apple-system',
+	'blinkmacsystemfont',
+	'segoe ui',
+	'segoe ui emoji',
+	'segoe ui symbol',
+	'roboto',
+	'helvetica',
+	'helvetica neue',
+	'arial',
+	'arial black',
+	'sf mono',
+	'sf pro',
+	'sf pro text',
+	'sf pro display',
+	'monaco',
+	'consolas',
+	'menlo',
+	'courier',
+	'courier new',
+	'georgia',
+	'times',
+	'times new roman',
+	'verdana',
+	'tahoma',
+	'trebuchet ms',
+	'impact',
+	'palatino',
+	'cambria',
+	'calibri',
+	'lucida grande',
+	'lucida console',
+	'gill sans',
+	'brush script mt',
+	'snell roundhand',
+	'old english text mt',
+	// Linux staples — the shipped themes' fallback stacks name these on
+	// purpose (e.g. neutral's code stack ends in Liberation Mono).
+	'liberation mono',
+	'liberation sans',
+	'liberation serif',
+	'dejavu sans',
+	'dejavu sans mono'
+]);
+
+/**
+ * Split a CSS font-family value into clean family names. Complete `var()`
+ * calls are stripped first — neither the reference nor its fallback
+ * arguments are this theme's own family declarations (the referenced token
+ * is checked in its own right) — then names are unquoted and
+ * whitespace-collapsed, and any remaining function-shaped fragment is
+ * dropped. The unquoted branch of the tokenizer cannot start at whitespace
+ * or a quote, so a quoted name is always taken whole even mid-list (commas
+ * inside quotes stay inside the name).
+ *
+ * @param {string} value
+ * @returns {string[]}
+ */
+function splitFamilies(value) {
+	const families = [];
+	const withoutVars = value.replace(/var\([^()]*(?:\([^()]*\)[^()]*)*\)/g, '');
+	for (const segment of withoutVars.match(/"[^"]*"|'[^']*'|[^,"'\s][^,]*/g) ?? []) {
+		let name = segment.trim();
+		if (!name) continue;
+		// /s: a quoted name may span lines (template-literal theme sources).
+		const quoted = /^(["']).*\1$/s.test(name);
+		if (quoted) name = name.slice(1, -1);
+		name = name.trim().replace(/\s+/g, ' ');
+		if (!name || (!quoted && /[()]/.test(name))) continue;
+		families.push(name);
+	}
+	return families;
+}
+
+/**
+ * Collect the font families a resolved theme names but does not load —
+ * every `--font-family-*` token plus every component-override `fontFamily`,
+ * minus generics, CSS-wide keywords, `var()` references, and known system
+ * families. Source order, first-seen casing, deduped case-insensitively.
+ *
+ * **Both token fields are read, which upstream does not have to do.** This
+ * port's `DefinedTheme` splits them differently: upstream's `theme.tokens`
+ * (already resolved to strings) is this port's `theme.resolvedTokens`, and
+ * `theme.tokens` here is the raw input map. A theme that reaches the build as a
+ * plain object carries `tokens`; one resolved through `defineTheme` — which is
+ * how a `typography` config becomes `--font-family-*` — carries
+ * `resolvedTokens`. Reading only one silently misses a whole load path.
+ *
+ * @param {{tokens?: Record<string, string>, resolvedTokens?: Record<string, string>, components?: object}} resolvedTheme
+ * @returns {string[]}
+ */
+export function collectUnloadedFonts(resolvedTheme) {
+	const seen = new Set();
+	/** @type {string[]} */
+	const unloaded = [];
+
+	/** @param {unknown} value */
+	const consider = (value) => {
+		if (typeof value !== 'string') return;
+		for (const family of splitFamilies(value)) {
+			const key = family.toLowerCase();
+			if (GENERIC_KEYWORDS.has(key) || SYSTEM_FAMILIES.has(key)) continue;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			unloaded.push(family);
+		}
+	};
+
+	for (const source of [resolvedTheme?.resolvedTokens, resolvedTheme?.tokens]) {
+		for (const [token, value] of Object.entries(source ?? {})) {
+			if (token.startsWith('--font-family-')) consider(value);
+		}
+	}
+
+	// Component overrides are plain CSS maps of unknown depth (style keys,
+	// nested at-rule blocks) — walk them and pick up every fontFamily.
+	/** @param {unknown} node */
+	const walk = (node) => {
+		if (!node || typeof node !== 'object') return;
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'fontFamily') consider(value);
+			else walk(value);
+		}
+	};
+	walk(resolvedTheme?.components);
+
+	return unloaded;
+}
+
+/**
+ * Render the human fix printed after the install instructions: which fonts
+ * the theme names but does not load, the Google Fonts `<link>` recipe, and
+ * the self-hosted `@font-face` alternative.
+ *
+ * @param {string} themeName
+ * @param {string[]} families
+ * @returns {string}
+ */
+export function formatFontLoadingHelp(themeName, families) {
+	const named = families.map((f) => `"${f}"`).join(', ');
+	const cssHref =
+		'https://fonts.googleapis.com/css2?' +
+		families.map((f) => `family=${encodeURIComponent(f).replace(/%20/g, '+')}`).join('&') +
+		'&display=swap';
+	const first = families[0];
+	const slug = first.toLowerCase().replace(/ /g, '-');
+	return `
+[warn] Theme "${themeName}" names fonts it does not load: ${named}
+  The built CSS only sets font-family — load these in your app, or every
+  browser quietly falls back.
+
+  Google Fonts (add :wght@… axes as your theme's weights require):
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="${cssHref}" />
+
+  Self-hosted (repeat per family and weight):
+
+    @font-face {
+      font-family: ${JSON.stringify(first)};
+      src: url('/fonts/${slug}.woff2') format('woff2');
+      font-display: swap;
+    }
+
+  Recipe and fallback-stack guidance: astryx-svelte docs typography
+`;
+}

--- a/packages/cli/api/theme/build/font-warning.test.mjs
+++ b/packages/cli/api/theme/build/font-warning.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the font-loading warning helpers behind `astryx-svelte theme build`
+ * (#5015). `collectUnloadedFonts()` reads a RESOLVED theme — `--font-family-*`
+ * tokens plus component-override `fontFamily` values (typography configs are
+ * already collapsed into tokens by the time the build sees the theme) — and
+ * returns the families the theme names but nothing loads. CSS generics,
+ * CSS-wide keywords, `var()` references, and known preinstalled system
+ * families are treated as loaded; anything unrecognized is assumed to be a
+ * webfont, because a missed warning is worse than a spurious one.
+ * `formatFontLoadingHelp()` renders the human snippet (<link> pair +
+ * @font-face) printed after the install instructions.
+ *
+ * Ported case-for-case from Astryx's `api/theme/build/font-warning.test.mjs`.
+ * The one restatement is the warning marker: this port prints `[warn]` where
+ * upstream prints `⚠`, matching the ASCII markers the rest of its CLI output
+ * uses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { collectUnloadedFonts, formatFontLoadingHelp } from './font-warning.mjs';
+
+describe('collectUnloadedFonts', () => {
+	it('returns webfont families from font-family tokens, skipping known fallbacks', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-body': '"Fraunces", Georgia, serif' }
+			})
+		).toEqual(['Fraunces']);
+	});
+
+	it('returns nothing for the default system stacks', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-body':
+						'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+					'--font-family-code': '"SF Mono", Monaco, Consolas, monospace'
+				}
+			})
+		).toEqual([]);
+	});
+
+	it('treats bare system keywords like ui-monospace as loaded', () => {
+		expect(collectUnloadedFonts({ tokens: { '--font-family-code': 'ui-monospace' } })).toEqual([]);
+	});
+
+	it('handles single-quoted and unquoted multi-word family names', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-body': "'JetBrains Mono', monospace",
+					'--font-family-heading': 'Space Grotesk, sans-serif'
+				}
+			})
+		).toEqual(['JetBrains Mono', 'Space Grotesk']);
+	});
+
+	it('dedupes case-insensitively across roles, keeping the first casing', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-body': '"Space Grotesk", sans-serif',
+					'--font-family-heading': '"space grotesk", serif'
+				}
+			})
+		).toEqual(['Space Grotesk']);
+	});
+
+	it('skips var() references and CSS-wide keywords', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-heading': 'var(--font-family-body)',
+					'--font-family-code': 'inherit'
+				}
+			})
+		).toEqual([]);
+	});
+
+	it("strips whole var() calls — fallback arguments are not this theme's declarations", () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-body': 'var(--x, "Web Font")',
+					'--font-family-heading': 'var(--x, "Web Font", serif)'
+				}
+			})
+		).toEqual([]);
+		// Families outside the var() call still count.
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-code': 'var(--x), Bungee' }
+			})
+		).toEqual(['Bungee']);
+	});
+
+	it('keeps a comma inside a quoted name whole, even mid-list', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-body': 'Georgia, "Foo, Bar", serif' }
+			})
+		).toEqual(['Foo, Bar']);
+	});
+
+	it('ignores an empty font-family token', () => {
+		expect(collectUnloadedFonts({ tokens: { '--font-family-body': '' } })).toEqual([]);
+	});
+
+	it('collects component-override fontFamily values, any style key', () => {
+		expect(
+			collectUnloadedFonts({
+				components: {
+					Button: { base: { fontFamily: '"Orbitron", sans-serif' } },
+					Card: { 'variant:hero': { fontFamily: 'Bungee' } }
+				}
+			})
+		).toEqual(['Orbitron', 'Bungee']);
+	});
+
+	it('matches known system families case-insensitively', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-body': 'arial, sans-serif' }
+			})
+		).toEqual([]);
+	});
+
+	it('returns nothing for a theme with no tokens or components', () => {
+		expect(collectUnloadedFonts({})).toEqual([]);
+	});
+
+	it('returns nothing for a null or undefined resolved theme', () => {
+		// Older build.mjs consumers guard with `resolvedTheme || themeDef` — if
+		// a path ever hands the collector nothing, it must shrug, not throw.
+		expect(collectUnloadedFonts(null)).toEqual([]);
+		expect(collectUnloadedFonts(undefined)).toEqual([]);
+	});
+
+	it('ignores non-string values without throwing: numeric or object-valued', () => {
+		// The generator only allows object values under ':pseudo' keys, so an
+		// object-valued fontFamily is not a family declaration — skip, not crash.
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-body': 42 },
+				components: {
+					button: { base: { fontFamily: 700 } },
+					card: { base: { fontFamily: { default: '"Sneaky"' } } }
+				}
+			})
+		).toEqual([]);
+	});
+
+	it('collects fontFamily nested under a pseudo-class block', () => {
+		// generateThemeRules accepts {':hover': {fontFamily}} inside a style
+		// key — a family named only there must still warn.
+		expect(
+			collectUnloadedFonts({
+				components: {
+					button: { base: { ':hover': { fontFamily: '"Rubik Doodle", cursive' } } }
+				}
+			})
+		).toEqual(['Rubik Doodle']);
+	});
+
+	it('strips a var() whose fallback list contains another var()', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-body': 'var(--brand, var(--fallback), "Web Font")'
+				}
+			})
+		).toEqual([]);
+		// …and still keeps a family declared outside the nested call.
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-code': 'var(--a, var(--b, serif)), Bungee' }
+			})
+		).toEqual(['Bungee']);
+	});
+
+	it('matches generic keywords case-insensitively', () => {
+		expect(
+			collectUnloadedFonts({
+				tokens: {
+					'--font-family-body': 'Sans-Serif',
+					'--font-family-heading': 'SERIF',
+					'--font-family-code': 'Ui-Monospace'
+				}
+			})
+		).toEqual([]);
+	});
+
+	it('collapses newlines and whitespace runs inside a family name', () => {
+		// Template-literal theme sources wrap long stacks across lines.
+		expect(
+			collectUnloadedFonts({
+				tokens: { '--font-family-body': '"Space\n      Grotesk",\n  serif' }
+			})
+		).toEqual(['Space Grotesk']);
+	});
+});
+
+describe('formatFontLoadingHelp', () => {
+	const help = formatFontLoadingHelp('ocean', ['Fraunces', 'JetBrains Mono']);
+
+	it('names the theme and every family in the headline', () => {
+		expect(help).toContain('[warn]');
+		expect(help).toContain('ocean');
+		expect(help).toContain('"Fraunces"');
+		expect(help).toContain('"JetBrains Mono"');
+	});
+
+	it('includes the Google Fonts recipe: preconnect pair + the exact css2 URL', () => {
+		expect(help).toContain('<link rel="preconnect" href="https://fonts.googleapis.com"');
+		expect(help).toContain('https://fonts.gstatic.com');
+		// The whole href, so a malformed URL cannot hide behind fragment checks.
+		expect(help).toContain(
+			'href="https://fonts.googleapis.com/css2?family=Fraunces&family=JetBrains+Mono&display=swap"'
+		);
+	});
+
+	it('includes a self-hosted @font-face alternative with font-display: swap', () => {
+		expect(help).toContain('@font-face');
+		expect(help).toContain('font-family: "Fraunces"');
+		expect(help).toContain('woff2');
+		expect(help).toContain('font-display: swap');
+	});
+
+	it('points at the docs recipe', () => {
+		expect(help).toContain('astryx-svelte docs typography');
+	});
+
+	it('percent-encodes family names in the css2 URL', () => {
+		const spiced = formatFontLoadingHelp('spice', ['P&Co Sans', 'Sömething']);
+		expect(spiced).toContain(
+			'href="https://fonts.googleapis.com/css2?family=P%26Co+Sans&family=S%C3%B6mething&display=swap"'
+		);
+	});
+});

--- a/packages/cli/api/theme/template/template.mjs
+++ b/packages/cli/api/theme/template/template.mjs
@@ -1,0 +1,67 @@
+/**
+ * @file `astryx-svelte theme template` leaf — writes the annotated theme
+ * template into the consumer's project.
+ *
+ * Sibling of `theme add`: both answer "put a theme starting point in my
+ * project", and they split on where you start. `add` copies a theme we ship
+ * (you like stone, you want to own it); `template` writes the blank annotated
+ * reference (you want your own, and need to know what the surface contains).
+ *
+ * The template is a doc that happens to compile, so it is one file at the
+ * project root by default rather than a package under src/themes/ — you read
+ * it, copy what you need into your own theme file, and delete it.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { CLI_ROOT } from '../../../foundation/fs/paths.mjs';
+import { assertWithin, PathSafetyError } from '../../../foundation/fs/path-safety.mjs';
+import { stripCopyrightHeader } from '../../../foundation/text/copyright-header.mjs';
+import { AstryxError } from '../../error.mjs';
+import { ERROR_CODES } from '../../../foundation/response/error-codes.mjs';
+
+/** The annotated `defineTheme` reference that ships with the CLI. */
+export const THEME_TEMPLATE_SRC = path.join(CLI_ROOT, 'assets', 'theme.template.ts');
+
+/** Where it lands when the caller does not say. */
+export const THEME_TEMPLATE_DEFAULT_PATH = 'theme.template.ts';
+
+/**
+ * Write the annotated theme template into a project.
+ *
+ * Refuses to overwrite without `overwrite`: an edited copy is the consumer's
+ * work, and this command is safe to re-run (init calls it on every setup).
+ *
+ * @param {{targetPath?: string, overwrite?: boolean, cwd?: string}} [options]
+ * @returns {import('../theme.type.mjs').ThemeTemplateResponse}
+ */
+export function themeTemplate(options = {}) {
+	const {
+		targetPath = THEME_TEMPLATE_DEFAULT_PATH,
+		overwrite = false,
+		cwd = process.cwd()
+	} = options;
+
+	let resolved;
+	try {
+		resolved = assertWithin(targetPath, cwd, { label: 'theme template path' });
+	} catch (err) {
+		if (err instanceof PathSafetyError) {
+			throw new AstryxError(err.message, undefined, ERROR_CODES.ERR_PATH_TRAVERSAL);
+		}
+		throw err;
+	}
+
+	const relative = path.relative(cwd, resolved) || targetPath;
+
+	if (fs.existsSync(resolved) && !overwrite) {
+		return { type: 'theme.template', data: { path: relative, written: false, reason: 'exists' } };
+	}
+
+	// The upstream repo header has no business in someone else's source tree.
+	const contents = stripCopyrightHeader(fs.readFileSync(THEME_TEMPLATE_SRC, 'utf-8'));
+	fs.mkdirSync(path.dirname(resolved), { recursive: true });
+	fs.writeFileSync(resolved, contents);
+
+	return { type: 'theme.template', data: { path: relative, written: true, reason: null } };
+}

--- a/packages/cli/api/theme/template/template.test.mjs
+++ b/packages/cli/api/theme/template/template.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * @file Direct API tests for `themeTemplate()` — the function behind
+ * `astryx-svelte theme template` and `astryx-svelte init --features theme`.
+ *
+ * What matters here is that it never destroys work: the template lands once,
+ * a second run leaves an edited copy alone, and a path that escapes the
+ * project is refused.
+ *
+ * Ported case-for-case from Astryx's `api/theme/template/template.test.mjs`
+ * (6 cases).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { themeTemplate, THEME_TEMPLATE_DEFAULT_PATH } from './template.mjs';
+
+let tmpDir;
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-theme-template-'));
+});
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('themeTemplate()', () => {
+	it('writes the template and returns a theme.template receipt', () => {
+		const res = themeTemplate({ cwd: tmpDir });
+
+		expect(res).toEqual({
+			type: 'theme.template',
+			data: { path: THEME_TEMPLATE_DEFAULT_PATH, written: true, reason: null }
+		});
+		const written = fs.readFileSync(path.join(tmpDir, THEME_TEMPLATE_DEFAULT_PATH), 'utf-8');
+		expect(written).toMatch(/defineTheme/);
+	});
+
+	it('does not carry the upstream copyright header into the consumer tree', () => {
+		themeTemplate({ cwd: tmpDir });
+		const written = fs.readFileSync(path.join(tmpDir, THEME_TEMPLATE_DEFAULT_PATH), 'utf-8');
+		expect(written).not.toMatch(/Copyright \(c\) Meta Platforms/);
+		expect(written.startsWith('/**')).toBe(true);
+	});
+
+	it('leaves an existing file alone and says so', () => {
+		const dest = path.join(tmpDir, THEME_TEMPLATE_DEFAULT_PATH);
+		fs.writeFileSync(dest, '// mine\n');
+
+		const res = themeTemplate({ cwd: tmpDir });
+
+		expect(res.data).toEqual({
+			path: THEME_TEMPLATE_DEFAULT_PATH,
+			written: false,
+			reason: 'exists'
+		});
+		expect(fs.readFileSync(dest, 'utf-8')).toBe('// mine\n');
+	});
+
+	it('overwrites when asked', () => {
+		const dest = path.join(tmpDir, THEME_TEMPLATE_DEFAULT_PATH);
+		fs.writeFileSync(dest, '// mine\n');
+
+		const res = themeTemplate({ cwd: tmpDir, overwrite: true });
+
+		expect(res.data.written).toBe(true);
+		expect(fs.readFileSync(dest, 'utf-8')).toMatch(/defineTheme/);
+	});
+
+	it('honors a custom path and creates its directory', () => {
+		const res = themeTemplate({ cwd: tmpDir, targetPath: 'src/themes/starter.ts' });
+
+		expect(res.data.path).toBe(path.join('src', 'themes', 'starter.ts'));
+		expect(fs.existsSync(path.join(tmpDir, 'src/themes/starter.ts'))).toBe(true);
+	});
+
+	it('refuses a path that escapes the project', () => {
+		expect(() => themeTemplate({ cwd: tmpDir, targetPath: '../escaped.ts' })).toThrow(
+			/theme template path/
+		);
+		expect(fs.existsSync(path.join(path.dirname(tmpDir), 'escaped.ts'))).toBe(false);
+	});
+});

--- a/packages/cli/api/theme/theme.mjs
+++ b/packages/cli/api/theme/theme.mjs
@@ -8,5 +8,6 @@
 
 export { themeBuild, importSpecifier } from './build/build.mjs';
 export { themeAdd } from './add/add.mjs';
+export { themeTemplate } from './template/template.mjs';
 export { themeList } from './list/list.mjs';
 export { listThemes } from './_adapter.mjs';

--- a/packages/cli/api/theme/theme.type.mjs
+++ b/packages/cli/api/theme/theme.type.mjs
@@ -10,9 +10,10 @@
  * astryx-svelte --json theme build <file> --check   -> theme.build.check
  * astryx-svelte --json theme list                   -> theme.list
  * astryx-svelte --json theme add <slug>             -> theme.add
+ * astryx-svelte --json theme template               -> theme.template
  * (file not found / parse error)                    -> CLIError
  *
- * @position api — colocated typedefs for api/theme/{theme,build,add,list,_adapter}
+ * @position api — colocated typedefs for api/theme/{theme,build,add,list,template,_adapter}
  */
 
 /**
@@ -50,6 +51,15 @@
  * @typedef {object} ThemeAddResponse
  * @property {'theme.add'} type
  * @property {{slug: string, displayName: string, maintained: boolean, outputDir: string, entry: string, exportName: string, files: string[]}} data
+ */
+
+/**
+ * astryx-svelte --json theme template
+ * `written: false` with `reason: 'exists'` is a success: the command is safe to
+ * re-run, and an edited template is the consumer's file to keep.
+ * @typedef {object} ThemeTemplateResponse
+ * @property {'theme.template'} type
+ * @property {{path: string, written: boolean, reason: 'exists' | null}} data
  */
 
 // Make this a module so the @typedefs above are importable as types via

--- a/packages/cli/assets/docs/getting-started.doc.mjs
+++ b/packages/cli/assets/docs/getting-started.doc.mjs
@@ -38,8 +38,18 @@ export const docs = {
 				{
 					type: 'code',
 					lang: 'text',
-					label: 'Paste this into your AI',
+					label: 'Set up the design system',
 					code: 'Install @astryx-svelte/core, @astryx-svelte/theme-neutral, and @astryx-svelte/cli in this project, then run `npx @astryx-svelte/cli init` to set up agent docs. Read the generated files to learn the conventions.'
+				},
+				{
+					type: 'prose',
+					text: 'Then give it a look. Every app gets a theme whether or not anyone picks one, so it is worth one question at setup rather than revisiting screens later that were built around the wrong look:'
+				},
+				{
+					type: 'code',
+					lang: 'text',
+					label: 'Give it a look',
+					code: 'Ask me what look and feel this app should have. Run `npx @astryx-svelte/cli theme list` and start from the closest shipped theme with `theme add <slug>`, which copies it in as editable source; if none of them fit, run `npx @astryx-svelte/cli theme template` and fill in the annotated template it writes. Default to neutral if I have no preference, and show me the result before moving on.'
 				}
 			]
 		},

--- a/packages/cli/assets/docs/theme.doc.mjs
+++ b/packages/cli/assets/docs/theme.doc.mjs
@@ -168,13 +168,17 @@ export const docs = {
 			content: [
 				{
 					type: 'prose',
-					text: 'Scaffold one with the CLI (recommended) or create it manually with defineTheme. Only override tokens that differ from defaults; omitted tokens use the design system defaults.'
+					text: 'Start from a theme we ship, or write one from scratch with defineTheme. Only override tokens that differ from defaults; omitted tokens use the design system defaults.'
 				},
 				{
 					type: 'code',
 					lang: 'bash',
-					label: 'Scaffold from a published theme',
-					code: 'astryx-svelte theme add neutral'
+					label: 'Browse, then copy a theme in as editable source',
+					code: 'astryx-svelte theme list\nastryx-svelte theme add stone'
+				},
+				{
+					type: 'prose',
+					text: 'For an annotated map of the whole surface — every defineTheme field, the token families, and the component override syntax, each with the CLI command that prints its reference — run `astryx-svelte theme template`. It writes `theme.template.ts` into your project to read and copy from (`astryx-svelte init --features theme` writes it as part of project setup).'
 				}
 			]
 		},
@@ -307,11 +311,16 @@ export const brandTheme = defineTheme({
 		base: { borderRadius: '20px', padding: '24px' }
 	},
 	button: {
-		base: { borderRadius: '9999px', textTransform: 'uppercase' },
-		'variant:ghost': { borderWidth: '2px', borderStyle: 'solid' },
-		// Some components have public CSS vars for properties that don't map
-		// to standard CSS. Set these directly.
-		'--button-press-scale': 'scale(0.95)'
+		base: {
+			borderRadius: '9999px',
+			textTransform: 'uppercase',
+			// Some components have public CSS vars for properties that don't map
+			// to standard CSS. Set these directly. Take the name from
+			// \`astryx-svelte component <Name>\` — a var the component does not
+			// define compiles to CSS that never applies.
+			'--button-focus-offset': '3px'
+		},
+		'variant:ghost': { borderWidth: '2px', borderStyle: 'solid' }
 	}
 }`
 				},

--- a/packages/cli/assets/docs/typography.doc.mjs
+++ b/packages/cli/assets/docs/typography.doc.mjs
@@ -182,6 +182,43 @@ const denseTheme = defineTheme({
 				}
 			]
 		},
+		// -- Loading Custom Fonts -------------------------------------------------
+		{
+			title: 'Loading Custom Fonts',
+			category: 'foundations',
+			content: [
+				{
+					type: 'prose',
+					text: "Astryx never loads font files. defineTheme and the built CSS only set font-family — naming a webfont (Fraunces, JetBrains Mono, ...) makes every browser look for it, and quietly fall back when the app has not loaded it. `astryx-svelte theme build` warns when a theme names families that are neither CSS generics nor common system fonts and prints the snippet to add; loading the font is always the app's job."
+				},
+				{
+					type: 'code',
+					lang: 'html',
+					label: 'Google Fonts - add to your src/app.html <head>',
+					code: `<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Fraunces:wght@400;600;700&family=JetBrains+Mono&display=swap"
+/>`
+				},
+				{
+					type: 'code',
+					lang: 'css',
+					label: 'Self-hosted - one @font-face per family and weight',
+					code: `@font-face {
+  font-family: 'Fraunces';
+  src: url('/fonts/fraunces.woff2') format('woff2');
+  font-weight: 400 700; /* variable-font range, or one weight per file */
+  font-display: swap; /* fallback text stays visible while the font loads */
+}`
+				},
+				{
+					type: 'prose',
+					text: "Always pair a webfont with a real fallback stack - metric-similar system fonts plus a generic - so text stays readable before the font loads and wherever it never does: defineTheme({typography: {heading: {family: 'Fraunces', fallbacks: 'Georgia, serif'}}})."
+				}
+			]
+		},
 		{
 			title: 'Best Practices',
 			category: 'foundations',

--- a/packages/cli/assets/templates/themes/butter/butter-theme.ts
+++ b/packages/cli/assets/templates/themes/butter/butter-theme.ts
@@ -205,8 +205,11 @@ export const butterTheme = defineTheme({
 		// Radius
 		//   --radius-element drives buttons, badges, inputs — 8px per design
 		//   --radius-container drives cards, banners, popovers — 12px per design
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.375rem',
 		'--radius-element': '0.5rem', // 8px
 		'--radius-container': '0.75rem', // 12px

--- a/packages/cli/assets/templates/themes/chocolate/chocolate-theme.ts
+++ b/packages/cli/assets/templates/themes/chocolate/chocolate-theme.ts
@@ -184,8 +184,11 @@ export const chocolateTheme = defineTheme({
 
 		// =========================================================================
 		// Radius — soft and rounded
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.375rem',
 		'--radius-element': '0.625rem',
 		'--radius-container': '0.75rem',

--- a/packages/cli/assets/templates/themes/gothic/gothic-theme.ts
+++ b/packages/cli/assets/templates/themes/gothic/gothic-theme.ts
@@ -205,8 +205,11 @@ export const gothicTheme = defineTheme({
 
 		// =========================================================================
 		// Radius — subtle rounding (original gothic)
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.25rem',
 		'--radius-element': '0.5rem',
 		'--radius-container': '0.75rem',

--- a/packages/cli/assets/templates/themes/stone/stone-theme.ts
+++ b/packages/cli/assets/templates/themes/stone/stone-theme.ts
@@ -222,8 +222,11 @@ export const stoneTheme = defineTheme({
 
 		// =========================================================================
 		// Radius — clean and subtle
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.25rem',
 		'--radius-element': '0.5rem',
 		'--radius-container': '0.75rem',

--- a/packages/cli/assets/theme.template.ts
+++ b/packages/cli/assets/theme.template.ts
@@ -1,0 +1,327 @@
+/**
+ * astryx-svelte theme template — every `defineTheme` field, with a note on what
+ * it does and when to reach for it.
+ *
+ * Only `name` is required. Delete what you do not need: the values here are
+ * placeholders that reproduce the built-in defaults, so a field you leave
+ * untouched changes nothing.
+ *
+ * Each section names the CLI command that prints the authoritative reference
+ * for it. These comments are a map; the CLI is the territory — it reads the
+ * same source the components do. `astryx-svelte docs` lists every topic.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * HOW A THEME IS CONSUMED
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * 1. WRAP THE APP. A theme does nothing until it is provided.
+ *
+ *      <script lang="ts">
+ *        import { Theme } from '@astryx-svelte/core';
+ *        import { myTheme } from './theme';
+ *      <\/script>
+ *
+ *      <Theme theme={myTheme} mode="system">   <!-- 'system' | 'light' | 'dark' -->
+ *        <App />
+ *      </Theme>
+ *
+ *    `system` follows the OS. Nest a second `<Theme>` to give one region its
+ *    own theme or mode — a dark sidebar inside a light page.
+ *
+ * 2. SHIP THE FONTS YOU NAME. Astryx sets the `--font-family-*` tokens; it
+ *    never loads a font file, so use whatever typeface the design needs and
+ *    load it yourself. Either add it to `src/app.html`:
+ *
+ *      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+ *      <link rel="stylesheet"
+ *            href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" />
+ *
+ *    or self-host it in your global CSS:
+ *
+ *      @font-face {
+ *        font-family: 'Inter';
+ *        src: url('/fonts/Inter.woff2') format('woff2');
+ *        font-weight: 100 900;
+ *        font-display: swap;
+ *      }
+ *
+ *    Always give `fallbacks` as well. A named family with no file loads
+ *    nothing and warns about nothing — the fallback silently becomes your
+ *    theme.
+ *
+ * 3. BUILD IT FOR PRODUCTION.
+ *
+ *      astryx-svelte theme build src/theme.ts
+ *
+ *    writes `<name>.css` (tokens, component overrides and prose styles in
+ *    `@scope` rules), `<name>.js` (the theme with `__built: true` and
+ *    pre-resolved values), `<name>.d.ts`, and `<name>.variants.d.ts` when the
+ *    theme adds custom prop values. Import the module and the CSS together:
+ *
+ *      import { myThemeTheme } from './theme/my-theme';
+ *      import './theme/my-theme.css';
+ *
+ *    Unbuilt, `<Theme>` injects a `<style>` tag at hydration instead — fine for
+ *    dev and client-only apps, but under SSR the component overrides flash on
+ *    hydration. Build for SvelteKit. Run the build after every edit: it also
+ *    validates the theme and regenerates the types for custom variants.
+ *
+ * 4. LOOK AT IT IN BOTH COLOUR MODES before you ship, including the states you
+ *    did not write. Full guide: `astryx-svelte docs theme`.
+ *
+ * SYNC: this template mirrors the theme system. When you change one of these,
+ * update it here:
+ * - /packages/core/src/lib/theme/define-theme.ts     (the fields)
+ * - /packages/core/src/lib/styles/tokens.stylex.ts   (the token families)
+ * - /packages/core/src/lib/theme/expand-color-scale.ts
+ * - /packages/core/src/lib/theme/expand-type-scale.ts
+ * - /packages/core/src/lib/theme/expand-radius-scale.ts
+ * - /packages/core/src/lib/theme/expand-motion-scale.ts
+ */
+
+import { defineTheme } from '@astryx-svelte/core/theme/define';
+// import { dracula } from '@astryx-svelte/core/theme/syntax';
+// import { neutralTheme } from '@astryx-svelte/theme-neutral';
+
+export const myTheme = defineTheme({
+	/** Required. Becomes the `data-astryx-theme` attribute and the registry key. */
+	name: 'my-theme',
+
+	/**
+	 * Start from another theme instead of the defaults. Tokens are copied then
+	 * overridden, `components` deep-merge, `icons` shallow-merge — but the scale
+	 * configs below REPLACE the base's rather than merging, because they are
+	 * inputs to a generator, not values.
+	 *
+	 * Reference: `astryx-svelte theme list` (themes you can install and extend).
+	 */
+	// extends: neutralTheme,
+
+	// ───────────────────────────────────────────────────────────────────────
+	// Scale configs — a few parameters generate a whole family of tokens.
+	// Reach for these first. They keep a theme internally consistent and cover
+	// far more ground than you would hand-write.
+	// ───────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Generates the neutral ramp and the accent tokens from one seed colour
+	 * using the HCT perceptual model: surfaces, text, icons, borders, muted
+	 * fills, hover and pressed overlays — light and dark both.
+	 *
+	 *   accent        seed hex; omit to keep the default accent and re-tone only
+	 *                 the neutrals
+	 *   neutralStyle  'warm' | 'cool' | 'neutral' — the temperature of the greys
+	 *   contrast      'standard' | 'high' — 'high' widens the text/surface tone
+	 *                 gap, for dense data UI or bright and clinical screens
+	 *
+	 * Whatever seed you pass, generated text holds >= 4.5:1 against its surface
+	 * and --color-border-emphasized >= 3:1. Two limits on that guarantee:
+	 *
+	 *   - It covers what this config generates. Write one side of a pair by hand
+	 *     in `tokens` below — an accent without its --color-on-accent, a surface
+	 *     without its text — and you own the contrast for that pair.
+	 *   - Status colours (success, warning, error) and the categorical data hues
+	 *     are not derived from the accent. They keep their defaults, which are
+	 *     tuned for the default surfaces; check them against yours.
+	 *
+	 * Either way the check is the same: resolve the pair in BOTH modes and
+	 * measure it. `useTheme()` and `resolveThemeTokens()` return the resolved
+	 * values, and the rendered DOM is the final word.
+	 *
+	 * Reference: `astryx-svelte docs color` for what each semantic role means,
+	 * `astryx-svelte docs tokens` for every colour token and its light/dark default.
+	 */
+	color: { accent: '#0064E0', neutralStyle: 'cool', contrast: 'standard' },
+
+	/**
+	 * Type scale and the three font roles.
+	 *   scale.base   body size in px; scale.ratio  step between sizes
+	 *                (1.125 tight/dense · 1.2 default · 1.333 dramatic)
+	 *   body / heading / code: {family, fallbacks, weight, weights}
+	 *   heading inherits family and fallbacks from body when omitted. `weight` is
+	 *   the role's default — on heading it fills every level `weights` does not
+	 *   name, on body and code it sets that text role directly. `weights` sets
+	 *   per-level weight for headings 1–6 and beats `weight` where both apply.
+	 *   Named weights (normal · medium · semibold · bold) become token references
+	 *   so retuning `--font-weight-*` moves them too; a raw CSS value ('800')
+	 *   passes through as an escape hatch.
+	 *
+	 * See §2 above — naming a family here does not load it.
+	 *
+	 * Reference: `astryx-svelte docs typography`.
+	 */
+	typography: {
+		scale: { base: 16, ratio: 1.2 },
+		body: { family: 'Inter', fallbacks: '-apple-system, system-ui, sans-serif' },
+		heading: { weight: 'semibold', weights: { 1: 'bold', 2: 'bold' } },
+		code: {
+			family: 'Geist Mono',
+			fallbacks: '"SF Mono", ui-monospace, monospace'
+		}
+	},
+
+	/**
+	 * Radius scale. `base` is the unit in px; `multiplier` scales every step
+	 * (0 = square and brutalist, 2 = very soft). --radius-none and --radius-full
+	 * are fixed and never scaled.
+	 *
+	 * Reference: `astryx-svelte docs shape`.
+	 */
+	radius: { base: 4, multiplier: 1 },
+
+	/**
+	 * Duration scale in ms. Each of fast/medium/slow also gets a -min and -max
+	 * sibling computed with `ratio` (min = base × ratio, max = base ÷ ratio), so
+	 * a component can pick a longer or shorter variant of the same tempo.
+	 *   Snappy {fast: 100, medium: 250} · Default {fast: 175, medium: 410, slow: 975}
+	 *   Cinematic {fast: 200, medium: 500, slow: 1200}
+	 * `easing` overrides --ease-standard.
+	 *
+	 * Reference: `astryx-svelte docs motion`.
+	 */
+	motion: { fast: 175, medium: 410, slow: 975, ratio: 0.75 },
+
+	// ───────────────────────────────────────────────────────────────────────
+	// tokens — explicit overrides, which beat anything the scales generated.
+	// A string applies to both colour modes; a [light, dark] tuple compiles to
+	// CSS light-dark(). List only what you want to change.
+	//
+	// `astryx-svelte docs tokens` PRINTS THE WHOLE TABLE — every token with its
+	// light and dark default. Read it before hand-writing colours: most of what
+	// you want already has a semantic name, and the defaults tell you what you
+	// are moving away from.
+	//
+	// The families, so you know what exists:
+	//   --color-*        accent, on-accent · background-{body,surface,card,popover,
+	//                    muted,inverted} · text-* · icon-* · border,
+	//                    border-emphasized · overlay{,-hover,-pressed} ·
+	//                    success/warning/error (+ -muted, on-*) · skeleton, track,
+	//                    shadow, tint-hover · categorical {blue,cyan,gray,green,
+	//                    orange,pink,purple,red,teal,yellow} ×
+	//                    {background,border,icon,text}
+	//   --spacing-*      0 · 0-5 · 1 … 12
+	//   --size-element-* sm · md · lg (control heights)
+	//   --focus-outline-* width · style · color · offset
+	//   --border-width   hairline thickness shared by bordered surfaces
+	//   --radius-*       none · inner · element · container · page · chat · full
+	//   --shadow-*       low/med/high + inset-{hover,selected,success,warning,error}
+	//   --duration-*     {fast,medium,slow} × {-min, base, -max}
+	//   --ease-standard
+	//   --font-family-*  body · heading · code
+	//   --font-size-*    4xs … 5xl
+	//   --font-weight-*  normal · medium · semibold · bold
+	//   --text-*         {heading-1…6, body, large, label, code, supporting,
+	//                    display-1…3} × {-size, -weight, -leading}
+	//   --color-syntax-* code highlighting
+	// ───────────────────────────────────────────────────────────────────────
+	tokens: {
+		'--color-accent': ['#0064E0', '#2694FE'],
+		// Changing an accent means owning its on-colour: this is the label that
+		// sits on top of the fill above, in each mode.
+		'--color-on-accent': ['#FFFFFF', '#FFFFFF'],
+		'--color-background-body': ['#F1F4F7', '#111112'],
+		'--color-background-surface': ['#FFFFFF', '#1F1F22'],
+		'--focus-outline-color': 'var(--color-accent)',
+		'--shadow-low': '0 1px 2px light-dark(#0000001A, #00000066)'
+	},
+
+	// ───────────────────────────────────────────────────────────────────────
+	// components — per-component CSS, emitted inside
+	// `@scope ([data-astryx-theme="my-theme"])`, so it only touches your theme.
+	//
+	// Keys are the component's stable class minus the `astryx-` prefix
+	// (`astryx-button` → `button`, `astryx-side-nav-item` → `side-nav-item`),
+	// including inner parts like `progressbar-fill`.
+	//
+	// `astryx-svelte component <Name>` IS THE REFERENCE HERE. It prints that
+	// component's theming targets, the visual props and states you can key on,
+	// its public CSS variables with defaults, and which standard CSS properties
+	// it expands. `astryx-svelte component --list` names every component, and
+	// `astryx-svelte docs styling` covers the escape hatches outside a theme.
+	//
+	// Style-key forms:
+	//   'base'                    every instance
+	//   'variant:ghost'           one prop value (any visual prop, not just variant)
+	//   'variant:ghost+size:sm'   intersection of two
+	//   'checked'                 a state the component reflects
+	//   ':hover' / ':focus-visible' / ':disabled' — nested inside any of the above
+	//
+	// Write ordinary CSS properties: `borderRadius` and `padding` expand into
+	// the component's internal vars for you, concentric radius math included.
+	// Set a public CSS var directly when no standard property reaches it — take
+	// the name from `astryx-svelte component <Name>`, since a var no component
+	// defines compiles to CSS that never applies. Never set a private
+	// `--_`-prefixed var; the build rejects it.
+	// ───────────────────────────────────────────────────────────────────────
+	components: {
+		button: {
+			base: {
+				borderRadius: 'var(--radius-full)',
+				fontWeight: 'var(--font-weight-semibold)',
+				// A public var from `astryx-svelte component Button` — no
+				// CSS-property equivalent exists for it.
+				'--button-focus-offset': '2px',
+				// Interaction states live inside the same block.
+				':hover': { transform: 'translateY(-1px)' },
+				':active': { transform: 'translateY(0)' }
+			},
+			'variant:ghost': { borderWidth: '1px', borderStyle: 'solid' },
+			'variant:destructive+size:sm': { letterSpacing: '0.02em' },
+			// A value that is not built in becomes a NEW variant: `astryx-svelte
+			// theme build` writes the module augmentation, so <Button
+			// variant="quiet" /> typechecks wherever this theme is active. Add one
+			// only where the product will render it — an unused variant is
+			// invisible work.
+			'variant:quiet': {
+				backgroundColor: 'var(--color-background-muted)',
+				color: 'var(--color-text-secondary)'
+			}
+		},
+		// Container components take `padding` too; it expands to their layout tokens.
+		card: {
+			base: {
+				borderRadius: 'var(--radius-container)',
+				padding: 'var(--spacing-6)'
+			}
+		},
+		// The same mechanism adds custom Text types: <Text type="hero" />.
+		text: { 'type:hero': { fontSize: 'var(--font-size-4xl)', lineHeight: '1.05' } }
+	}
+
+	// ───────────────────────────────────────────────────────────────────────
+	// Everything below takes a Svelte component or snippet as its value, so it
+	// needs an imported module. Commented out for that reason.
+	// ───────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Swap the artwork behind semantic icon names — every component that asks
+	 * for `check`, `close`, `chevron-down` gets yours.
+	 * Reference: `astryx-svelte docs icons` lists the names.
+	 */
+	// icons: { check: MyCheck, close: MyClose },
+
+	/**
+	 * Replace the small components that DRAW control state — the checkbox box,
+	 * the radio dot, the mark on a chosen option — by indicator name rather than
+	 * per call site. Replacing `check` re-skins every single-selection mark in
+	 * the app at once.
+	 * Reference: `astryx-svelte component Indicator`.
+	 */
+	// indicators: { check: RadioIndicator },
+
+	/**
+	 * Code highlighting: sets the --color-syntax-* tokens. Presets live in
+	 * `@astryx-svelte/core/theme/syntax`.
+	 */
+	// syntax: dracula,
+
+	/**
+	 * Content sitting on an inverted surface — a dark toast in light mode, a
+	 * light popover in dark mode. Same shape as the theme itself (tokens and
+	 * components). Sensible values are generated if you say nothing, so override
+	 * only where your palette needs it.
+	 * Reference: `astryx-svelte component MediaTheme`, which reads these.
+	 */
+	// onDark: { tokens: { '--color-accent': '#90CAF9' }, components: { button: { 'variant:ghost': { borderWidth: '1px' } } } },
+	// onLight: { tokens: { '--color-accent': '#0B5FCC' } },
+});

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -116,6 +116,14 @@ export interface ComponentPlaygroundConfig {
 	 *  the component is visible on load and knobs stay usable, whereas a real
 	 *  top-layer modal makes the rest of the page inert (#3657). */
 	overlay?: boolean;
+	/** The component reads AppShell mobile context and renders nothing
+	 *  without it (e.g. `MobileNavToggle` returns null unless the context
+	 *  reports an enabled mobile viewport — the default value outside
+	 *  AppShell never does). The interactive preview provides a simulated
+	 *  mobile AppShell context so the stage is not an empty box, keeps the
+	 *  drawer open state interactive, and notes the simulation under the
+	 *  rendered component (#4983). */
+	appShellMobile?: boolean;
 	/** Required parent wrapper for sub-components that depend on a parent
 	 *  context provider (e.g. `Tab` calls `useTabListContext()` and throws
 	 *  standalone). The preview wraps the component in this parent before
@@ -338,7 +346,7 @@ export interface ComponentThemingTarget {
  * ```
  */
 export interface ComponentThemingVar {
-	/** CSS custom property name, e.g. '--_card-radius' or '--button-press-scale' */
+	/** CSS custom property name, e.g. '--_card-radius' or '--button-focus-offset' */
 	name: string;
 	/** What this var controls */
 	description: string;

--- a/packages/cli/clients/cli/commands/build-theme.font-warning.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.font-warning.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * @file End-to-end test for the `astryx-svelte theme build` font-loading warning
+ * (#5015). A theme that names webfont families gets, AFTER the install
+ * instructions, a stdout notice naming the fonts plus the copy-pasteable
+ * fix — the Google Fonts <link> pair and a self-hosted @font-face with
+ * font-display: swap — and still exits 0 (it is a warning, not an error).
+ * Themes that only name generics or known system stacks get none of it.
+ *
+ * Ported case-for-case from Astryx's
+ * `clients/cli/commands/build-theme.font-warning.test.mjs` (3 cases).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { ensureCoreBuilt } from '../../../test-utils/ensure-core-built.mjs';
+import { runCli } from '../../../test-utils/run-cli.mjs';
+
+function writeTheme(dir, name, source) {
+	fs.mkdirSync(dir, { recursive: true });
+	const file = path.join(dir, `${name}.mjs`);
+	fs.writeFileSync(file, source);
+	return file;
+}
+
+// `astryx-svelte theme build` imports the compiled @astryxdesign/core/theme entry.
+// Build core once if it isn't already present so the suite works in any CI
+// job, regardless of job ordering.
+beforeAll(() => {
+	ensureCoreBuilt();
+}, 200_000);
+
+let tmpDir;
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-fonts-'));
+});
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('theme build font-loading warning', () => {
+	it('prints the unloaded fonts and the <link>/@font-face fix after the install instructions', async () => {
+		const project = path.join(tmpDir, 'project');
+		const themeFile = writeTheme(
+			project,
+			'fonty',
+			`export default {
+  name: 'fonty',
+  typography: {
+    body: {family: 'Space Grotesk', fallbacks: 'Arial, sans-serif'},
+    code: {family: 'JetBrains Mono'},
+  },
+};\n`
+		);
+
+		const result = await runCli(['theme', 'build', path.relative(project, themeFile)], project);
+
+		expect(result.code).toBe(0);
+		// The install instructions still come out intact…
+		expect(result.stdout).toContain("from './fonty'");
+		// …followed by the warning naming the theme and every unloaded family…
+		expect(result.stdout).toContain('names fonts it does not load');
+		expect(result.stdout).toContain('"Space Grotesk"');
+		expect(result.stdout).toContain('"JetBrains Mono"');
+		// …and the copy-pasteable fix, both flavors.
+		expect(result.stdout).toContain('<link rel="preconnect" href="https://fonts.googleapis.com"');
+		expect(result.stdout).toContain('family=Space+Grotesk');
+		expect(result.stdout).toContain('family=JetBrains+Mono');
+		expect(result.stdout).toContain('display=swap');
+		expect(result.stdout).toContain('@font-face');
+		expect(result.stdout).toContain('font-display: swap');
+		expect(result.stdout).toContain('astryx-svelte docs typography');
+		// The one-line summaries follow the CLI's stream contract: warnings on
+		// stderr, like the override-validation warnings in the same build.
+		expect(result.stderr).toContain('Font "Space Grotesk"');
+		expect(result.stderr).toContain('Font "JetBrains Mono"');
+	});
+
+	it('keeps --json stdout one valid envelope: warnings inside, snippet suppressed', async () => {
+		const project = path.join(tmpDir, 'project');
+		const themeFile = writeTheme(
+			project,
+			'fonty',
+			`export default { name: 'fonty', tokens: { '--font-family-body': '"Space Grotesk", sans-serif' } };\n`
+		);
+
+		const result = await runCli(
+			['--json', 'theme', 'build', path.relative(project, themeFile)],
+			project
+		);
+
+		expect(result.code).toBe(0);
+		// The whole stdout must parse — any human snippet leaking into --json
+		// mode corrupts the envelope, so this asserts the "JSON is always JSON"
+		// contract, not just substring presence.
+		const envelope = JSON.parse(result.stdout);
+		expect(envelope.type).toBe('theme.build');
+		expect(envelope.data.warnings).toEqual(
+			expect.arrayContaining([expect.stringContaining('Font "Space Grotesk"')])
+		);
+		expect(result.stdout).not.toContain('fonts.googleapis.com');
+		// Human one-liners are silenced too — machine mode stays quiet.
+		expect(result.stderr).not.toContain('Font "');
+	});
+
+	it('prints nothing font-related for a theme of generics and system stacks', async () => {
+		const project = path.join(tmpDir, 'project');
+		const themeFile = writeTheme(
+			project,
+			'sys',
+			`export default {
+  name: 'sys',
+  tokens: {
+    '--color-bg': '#fff',
+    '--font-family-body': 'Helvetica, Arial, sans-serif',
+    '--font-family-code': 'ui-monospace',
+  },
+};\n`
+		);
+
+		const result = await runCli(['theme', 'build', path.relative(project, themeFile)], project);
+
+		expect(result.code).toBe(0);
+		expect(result.stdout).toContain("from './sys'");
+		expect(result.stdout).not.toContain('names fonts it does not load');
+		expect(result.stdout).not.toContain('fonts.googleapis.com');
+		expect(result.stdout).not.toContain('@font-face');
+		expect(result.stderr).not.toContain('Font "');
+	});
+});

--- a/packages/cli/clients/cli/commands/build-theme.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.mjs
@@ -25,6 +25,7 @@ import { logger } from '../../../api/logger.mjs';
 import { cliError } from '../lib/cli-error.mjs';
 import { ERROR_CODES } from '../../../foundation/response/error-codes.mjs';
 import { themeAdd } from '../../../api/theme/add/add.mjs';
+import { themeTemplate } from '../../../api/theme/template/template.mjs';
 import { themeList } from '../../../api/theme/list/list.mjs';
 import { themeBuild, importSpecifier } from '../../../api/theme/build/build.mjs';
 
@@ -359,6 +360,57 @@ export function registerTheme(program) {
 							`<Theme theme={${exportName}}>\n  <App />\n</Theme>`
 					),
 					text(`This is your copy of the ${displayName} theme — edit ${entry} to make it your own.`)
+				);
+			}
+		);
+
+	theme
+		.command('template [path]')
+		.description('Write the annotated theme template into your project')
+		.option('-f, --overwrite', 'Replace an existing file')
+		.action(
+			async (
+				/** @type {string | undefined} */ targetPath,
+				/** @type {{overwrite?: boolean}} */ options
+			) => {
+				const json = program.opts().json || false;
+
+				/** @type {import('../../../api/theme/theme.type.mjs').ThemeTemplateResponse} */
+				let result;
+				try {
+					result = themeTemplate({
+						targetPath,
+						overwrite: options.overwrite,
+						cwd: process.cwd()
+					});
+				} catch (e) {
+					const err = /** @type {import('../../../api/error.mjs').AstryxError} */ (e);
+					cliError(err.message, {
+						suggestions: err.suggestions || [],
+						code: err.code
+					});
+					return;
+				}
+
+				if (json) return jsonOut(result);
+
+				// Leaving an edited file alone is a success, not a failure: this command
+				// is safe to re-run, and `init --features theme` calls it every time.
+				if (!result.data.written) {
+					emit(
+						text(`[ok] ${result.data.path} already exists — left untouched.`),
+						text('Pass --overwrite to replace it.')
+					);
+					return;
+				}
+
+				emit(
+					text(`[ok] Wrote ${result.data.path}`),
+					text(
+						'Every defineTheme field, the token families, and the component override syntax — ' +
+							'annotated, with the CLI command that prints the authoritative reference for each.'
+					),
+					text('Copy what you need into your own theme file, then delete it.')
 				);
 			}
 		);

--- a/packages/cli/clients/cli/commands/init.behavior.test.mjs
+++ b/packages/cli/clients/cli/commands/init.behavior.test.mjs
@@ -75,11 +75,22 @@ describe('astryx-svelte init --features', () => {
 		expect(exists('AGENTS.md')).toBe(true);
 	});
 
-	it('--features theme writes no files and points at the theme workflow', async () => {
+	it('--features theme writes the annotated theme template', async () => {
 		const { status, stdout } = await runCli(['init', '--features', 'theme'], { cwd: tmpDir });
 		expect(status).toBe(0);
-		expect(fs.readdirSync(tmpDir)).toEqual([]);
+		expect(exists('theme.template.ts')).toBe(true);
+		expect(read('theme.template.ts')).toMatch(/defineTheme/);
+		expect(read('theme.template.ts')).not.toMatch(/Copyright \(c\) Meta Platforms/);
 		expect(stdout).toMatch(/theme/i);
+	});
+
+	it('--features theme never clobbers an existing theme.template.ts', async () => {
+		// Someone's edited copy outranks ours; re-running init must be safe.
+		fs.writeFileSync(path.join(tmpDir, 'theme.template.ts'), '// mine\n');
+		const { status, stdout } = await runCli(['init', '--features', 'theme'], { cwd: tmpDir });
+		expect(status).toBe(0);
+		expect(read('theme.template.ts')).toBe('// mine\n');
+		expect(stdout).toMatch(/already exists/);
 	});
 
 	it('rejects an unknown feature with exit 1 and a helpful message', async () => {

--- a/packages/cli/clients/cli/commands/theme-template.behavior.test.mjs
+++ b/packages/cli/clients/cli/commands/theme-template.behavior.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * @file CLI behavior for `astryx-svelte theme template`.
+ *
+ * The API leaf is covered by api/theme/template/template.test.mjs; what is only
+ * reachable here is the terminal binding — which message the user sees, and the
+ * JSON envelope. The first version of this command read `result.written`
+ * instead of `result.data.written`, so it wrote the file and then told the user
+ * it had skipped: a receipt read at the wrong depth is invisible to a unit test
+ * of the leaf.
+ *
+ * Ported case-for-case from Astryx's
+ * `clients/cli/commands/theme-template.behavior.test.mjs` (5 cases).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runCli } from '../../../test-utils/run-cli.mjs';
+
+let tmpDir;
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-cli-theme-template-'));
+	fs.writeFileSync(
+		path.join(tmpDir, 'package.json'),
+		JSON.stringify({ name: 'tmp', private: true })
+	);
+});
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const read = (f) => fs.readFileSync(path.join(tmpDir, f), 'utf-8');
+
+describe('astryx-svelte theme template', () => {
+	it('writes the template and says it wrote it', async () => {
+		const { status, stdout } = await runCli(['theme', 'template'], { cwd: tmpDir });
+
+		expect(status).toBe(0);
+		expect(stdout).toMatch(/Wrote theme\.template\.ts/);
+		expect(stdout).not.toMatch(/already exists/);
+		expect(read('theme.template.ts')).toMatch(/defineTheme/);
+	});
+
+	it('leaves an existing file alone, and says that instead', async () => {
+		fs.writeFileSync(path.join(tmpDir, 'theme.template.ts'), '// mine\n');
+
+		const { status, stdout } = await runCli(['theme', 'template'], { cwd: tmpDir });
+
+		expect(status).toBe(0);
+		expect(stdout).toMatch(/already exists/);
+		expect(read('theme.template.ts')).toBe('// mine\n');
+	});
+
+	it('replaces it with --overwrite', async () => {
+		fs.writeFileSync(path.join(tmpDir, 'theme.template.ts'), '// mine\n');
+
+		const { status } = await runCli(['theme', 'template', '--overwrite'], { cwd: tmpDir });
+
+		expect(status).toBe(0);
+		expect(read('theme.template.ts')).toMatch(/defineTheme/);
+	});
+
+	it('returns a theme.template envelope under --json', async () => {
+		const { status, stdout } = await runCli(['--json', 'theme', 'template'], { cwd: tmpDir });
+
+		expect(status).toBe(0);
+		const payload = JSON.parse(stdout);
+		expect(payload.type).toBe('theme.template');
+		expect(payload.data).toEqual({
+			path: 'theme.template.ts',
+			written: true,
+			reason: null
+		});
+	});
+
+	it('refuses a path that escapes the project', async () => {
+		const { status, stderr } = await runCli(['theme', 'template', '../escaped.ts'], {
+			cwd: tmpDir
+		});
+
+		expect(status).toBe(1);
+		expect(stderr).toMatch(/outside the project root/);
+		expect(fs.existsSync(path.join(path.dirname(tmpDir), 'escaped.ts'))).toBe(false);
+	});
+});

--- a/packages/cli/clients/cli/index.mjs
+++ b/packages/cli/clients/cli/index.mjs
@@ -92,6 +92,7 @@ export const JSON_SUPPORTED = new Set([
 	'theme build',
 	'theme list',
 	'theme add',
+	'theme template',
 	'upgrade',
 	'util',
 	'validate-integration'

--- a/packages/cli/clients/cli/lib/manifest.mjs
+++ b/packages/cli/clients/cli/lib/manifest.mjs
@@ -73,6 +73,7 @@ export const RESPONSE_TYPES = {
 	'theme build': ['theme.build', 'theme.build.check'],
 	'theme list': ['theme.list'],
 	'theme add': ['theme.list', 'theme.add'],
+	'theme template': ['theme.template'],
 	upgrade: ['upgrade.list', 'upgrade.status', 'upgrade.run'],
 	util: ['util.list', 'util.detail', 'util.detail.params'],
 	'validate-integration': ['integration.validate']
@@ -129,6 +130,7 @@ const EXAMPLES = {
 		'astryx-svelte theme add matcha',
 		'astryx-svelte theme add matcha ./src/themes/matcha'
 	],
+	'theme template': ['astryx-svelte theme template', 'astryx-svelte theme template --json'],
 	// Upstream's single example is the bare `astryx upgrade --json`. The second
 	// one here shows the flag that writes, because dry-run is the default and the
 	// most common mistake is expecting the first form to have changed something.

--- a/packages/cli/foundation/text/copyright-header.mjs
+++ b/packages/cli/foundation/text/copyright-header.mjs
@@ -1,0 +1,37 @@
+/**
+ * @file Strips the upstream repo's copyright header from files we scaffold into
+ * someone else's project.
+ *
+ * Every file in Astryx carries the Meta copyright header, and several commands
+ * copy repo files out verbatim — `theme add` (bundled theme sources),
+ * `theme template` / `init --features theme` (the annotated theme template). A
+ * consumer's own source tree should not inherit that boilerplate, and their lint
+ * may well reject it.
+ *
+ * **It is a guard rather than a transform in this port.** This repo's own
+ * sources carry no Meta copyright line, so the pattern matches nothing today. It
+ * is kept because the scaffolded assets are copies of files adapted from
+ * upstream, and one arriving with the header attached is exactly the case this
+ * exists for.
+ *
+ * Extracted from `api/theme/add/add.mjs` at upstream 0.4.2, when `theme
+ * template` became a second caller (#5048).
+ */
+
+/**
+ * Matches the header at the very start of a file, with the leading BOM and/or
+ * shebang captured so they survive the strip.
+ */
+const META_COPYRIGHT_HEADER_RE =
+	/^(\uFEFF?(?:#![^\r\n]*(?:\r?\n))?)\/\/ Copyright \(c\) Meta Platforms, Inc\. and affiliates\.\r?\n(?:\r?\n)*/;
+
+/**
+ * Remove the leading Meta copyright header, preserving any BOM/shebang before
+ * it. Returns the source unchanged when the header is absent.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function stripCopyrightHeader(source) {
+	return source.replace(META_COPYRIGHT_HEADER_RE, '$1');
+}

--- a/packages/cli/foundation/text/copyright-header.test.mjs
+++ b/packages/cli/foundation/text/copyright-header.test.mjs
@@ -1,0 +1,56 @@
+/**
+ * @file Unit tests for the shared copyright-header stripper.
+ *
+ * Two commands copy repo files into a consumer's project (`theme add`,
+ * `theme template` / `init --features theme`); this is what keeps upstream's
+ * boilerplate out of their tree. The BOM/shebang cases are the ones worth
+ * pinning — a naive strip corrupts the file rather than merely leaving a stray
+ * comment.
+ *
+ * Ported case-for-case from Astryx's `foundation/text/copyright-header.test.mjs`
+ * (7 cases).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripCopyrightHeader } from './copyright-header.mjs';
+
+const HEADER = '// Copyright (c) Meta Platforms, Inc. and affiliates.\n';
+
+describe('stripCopyrightHeader', () => {
+	it('removes the header and the blank line after it', () => {
+		expect(stripCopyrightHeader(`${HEADER}\nexport const a = 1;\n`)).toBe('export const a = 1;\n');
+	});
+
+	it('removes it with no blank line after', () => {
+		expect(stripCopyrightHeader(`${HEADER}export const a = 1;\n`)).toBe('export const a = 1;\n');
+	});
+
+	it('keeps a shebang, which must stay on line 1', () => {
+		expect(stripCopyrightHeader(`#!/usr/bin/env node\n${HEADER}\nrun();\n`)).toBe(
+			'#!/usr/bin/env node\nrun();\n'
+		);
+	});
+
+	it('keeps a BOM', () => {
+		expect(stripCopyrightHeader(`\uFEFF${HEADER}\nexport const a = 1;\n`)).toBe(
+			'\uFEFFexport const a = 1;\n'
+		);
+	});
+
+	it('handles CRLF line endings', () => {
+		expect(
+			stripCopyrightHeader(
+				'// Copyright (c) Meta Platforms, Inc. and affiliates.\r\n\r\nexport const a = 1;\r\n'
+			)
+		).toBe('export const a = 1;\r\n');
+	});
+
+	it('leaves a file without the header alone', () => {
+		expect(stripCopyrightHeader('export const a = 1;\n')).toBe('export const a = 1;\n');
+	});
+
+	it('only strips at the top — a mention further down is content', () => {
+		const source = `export const a = 1;\n${HEADER}`;
+		expect(stripCopyrightHeader(source)).toBe(source);
+	});
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@astryx-svelte/cli",
 	"displayName": "CLI",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Scaffold projects, browse templates, generate themes, and get agent-ready docs from the command line.",
 	"type": "module",
 	"license": "MIT",

--- a/packages/cli/scripts/check-theme-template.test.mjs
+++ b/packages/cli/scripts/check-theme-template.test.mjs
@@ -1,0 +1,305 @@
+/**
+ * @file Drift guard for the shipped theme template.
+ *
+ * `packages/cli/assets/theme.template.ts` is the annotated map of the theme
+ * surface: every `defineTheme` field, the token families, the component
+ * override syntax. `astryx-svelte theme template` copies it into a consumer's
+ * project, so a claim that has rotted is not a stale comment in this repo — it
+ * is wrong instruction sitting in someone else's.
+ *
+ * Documentation rots silently, and this kind especially: upstream's theme docs
+ * shipped `--button-press-scale` (#5012) for long enough that a generated theme
+ * carried a declaration no component could ever read. SYNC comments in the
+ * theme sources point here; this file is what makes them more than a wish.
+ *
+ * What is checked — all of it derived from live sources, never hardcoded:
+ *   1. Every `ThemeConfig` field is documented (and nothing invented).
+ *   2. Every settable token family appears in the inventory.
+ *   3. Every `--token` the template names is a real token.
+ *   4. Every component key is a real theming target, and every public
+ *      `--var` it sets is one that component declares.
+ *   5. Every `astryx-svelte docs <topic>` it cites exists.
+ *   6. Every theme source carrying a SYNC reference here still exists.
+ *
+ * Ported from Astryx's root `scripts/check-theme-template.test.mjs`. Four
+ * things differ, all of them this port's shape rather than a change of intent:
+ *
+ * - It lives under `packages/cli`, because this repo has no root-level test
+ *   runner — the CLI's vitest picks up `**\/*.test.mjs`, and the template it
+ *   guards is a CLI asset.
+ * - The interface is `ThemeConfig`, not `DefineThemeInput`.
+ * - The token families are read from `styles/tokens.stylex.ts` and the settable
+ *   set from `theme/tokens.ts`'s `tokenDefaults` spread. This port has no
+ *   `CoreTokenName` union; that spread is the same fact in the shape it takes
+ *   here, and reading it keeps the guard honest about what a theme may set.
+ * - Sources are kebab-case, and the template is tab-indented.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const TEMPLATE = path.join(REPO_ROOT, 'packages/cli/assets/theme.template.ts');
+const THEME_SRC = path.join(REPO_ROOT, 'packages/core/src/lib/theme');
+const STYLES_SRC = path.join(REPO_ROOT, 'packages/core/src/lib/styles');
+const CORE_SRC = path.join(REPO_ROOT, 'packages/core/src/lib');
+const DOCS_DIR = path.join(REPO_ROOT, 'packages/cli/assets/docs');
+
+const template = fs.readFileSync(TEMPLATE, 'utf-8');
+
+/** Theme sources whose SYNC comments name the template. */
+const SYNC_SOURCES = [
+	{ dir: THEME_SRC, file: 'define-theme.ts' },
+	{ dir: STYLES_SRC, file: 'tokens.stylex.ts' },
+	{ dir: THEME_SRC, file: 'expand-color-scale.ts' },
+	{ dir: THEME_SRC, file: 'expand-type-scale.ts' },
+	{ dir: THEME_SRC, file: 'expand-radius-scale.ts' },
+	{ dir: THEME_SRC, file: 'expand-motion-scale.ts' }
+];
+
+// ---------------------------------------------------------------------------
+// Live facts
+// ---------------------------------------------------------------------------
+
+const defineThemeSrc = fs.readFileSync(path.join(THEME_SRC, 'define-theme.ts'), 'utf-8');
+const tokensStylexSrc = fs.readFileSync(path.join(STYLES_SRC, 'tokens.stylex.ts'), 'utf-8');
+const tokenDefaultsSrc = fs.readFileSync(path.join(THEME_SRC, 'tokens.ts'), 'utf-8');
+
+/** Field names declared on `ThemeConfig`. */
+function themeConfigFields() {
+	const body = defineThemeSrc.match(/export interface ThemeConfig \{([\s\S]*?)\n\}/);
+	if (!body) throw new Error('ThemeConfig not found in define-theme.ts');
+	return [...body[1].matchAll(/^\t(\w+)\??:/gm)].map((m) => m[1]);
+}
+
+/** Every `*Defaults` group in tokens.stylex.ts, with its token names. */
+function tokenGroups() {
+	/** @type {Record<string, string[]>} */
+	const groups = {};
+	for (const chunk of tokensStylexSrc.split('export const ').slice(1)) {
+		const name = chunk.split(/[\s:=]/)[0];
+		if (!name.endsWith('Defaults')) continue;
+		const body = chunk.split('export const')[0];
+		groups[name] = [...body.matchAll(/'(--[a-zA-Z0-9-]+)'\s*:/g)].map((m) => m[1]);
+	}
+	return groups;
+}
+
+/**
+ * The token groups a theme can actually set. Upstream reads the `CoreTokenName`
+ * union; this port's counterpart is the `tokenDefaults` spread in
+ * `theme/tokens.ts`, which is the same list expressed as values rather than
+ * types — and is what `defineTheme` actually resolves against.
+ */
+function settableTokenGroups() {
+	const body = tokenDefaultsSrc.match(
+		/export const tokenDefaults: Record<string, string> = \{([\s\S]*?)\n\};/
+	);
+	if (!body) throw new Error('tokenDefaults not found in theme/tokens.ts');
+	return [...body[1].matchAll(/\.\.\.(\w+Defaults)/g)].map((m) => m[1]);
+}
+
+/** Every documented theming target, and the public vars it declares. */
+function themingTargets() {
+	/** @type {Record<string, Set<string>>} */
+	const targets = {};
+	/** @type {Set<string>} */
+	const publicVars = new Set();
+	const walk = (dir) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const p = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(p);
+				continue;
+			}
+			if (!entry.name.endsWith('.doc.mjs')) continue;
+			const src = fs.readFileSync(p, 'utf-8');
+			for (const m of src.matchAll(/className:\s*'astryx-([a-z0-9-]+)'/g)) {
+				targets[m[1]] ??= new Set();
+			}
+			// `vars: [{name: '--button-focus-offset', ...}]` — private `--_` vars are
+			// not a theme's to set, so they are not collected.
+			for (const m of src.matchAll(/name:\s*'(--[a-z0-9-]+)'/g)) {
+				publicVars.add(m[1]);
+			}
+		}
+	};
+	walk(CORE_SRC);
+	return { targets, publicVars };
+}
+
+/** Doc topics `astryx-svelte docs <topic>` can print. */
+function docTopics() {
+	return fs
+		.readdirSync(DOCS_DIR)
+		.map((f) => f.match(/^([\w-]+)\.doc\.mjs$/))
+		.filter(Boolean)
+		.map((m) => m[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Template claims
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level keys the template sets, plus the optional ones it shows commented
+ * out (`// syntax: dracula,`). A commented field must carry a value, so an
+ * ordinary prose comment is not mistaken for one.
+ */
+function templateFields() {
+	const set = [...template.matchAll(/^\t(\w+):/gm)].map((m) => m[1]);
+	const commented = [...template.matchAll(/^\t\/\/ (\w+): .+,$/gm)].map((m) => m[1]);
+	return [...new Set([...set, ...commented])];
+}
+
+/**
+ * Every CSS variable the template uses in a code position — set as a property
+ * (`'--x': …`) or read (`var(--x)`). Prose mentions of a family (`--spacing-*`)
+ * and CLI flags (`--list`) are not claims about a variable's existence.
+ */
+function templateVars() {
+	const set = [...template.matchAll(/'(--[a-z][a-z0-9-]*)':/g)].map((m) => m[1]);
+	const read = [...template.matchAll(/var\((--[a-z][a-z0-9-]*)\)/g)].map((m) => m[1]);
+	return [...new Set([...set, ...read])];
+}
+
+/**
+ * The inventory block — the comment listing what token families exist. Scoped
+ * deliberately: a family named only in a passing example (`var(--spacing-6)`)
+ * is not an inventory an author can read to learn what the system has.
+ */
+function templateInventory() {
+	const marker = '// The families, so you know what exists:';
+	const start = template.indexOf(marker);
+	if (start === -1) {
+		throw new Error(
+			`The token inventory marker ("${marker}") is gone from the template. ` +
+				`If the inventory moved, point this guard at its new home.`
+		);
+	}
+	return template.slice(start, template.indexOf('\n\ttokens: {', start));
+}
+
+/**
+ * The prefix a family shares — `--spacing-`, `--font-weight-`, `--ease-standard`.
+ * A family is only "covered" when the template names this, which keeps the
+ * three `--font-*` families (family, size, weight) distinguishable instead of
+ * collapsing them into one prefix that any of them satisfies.
+ *
+ * @param {string[]} names
+ */
+function commonPrefix(names) {
+	return names.reduce((prefix, name) => {
+		let i = 0;
+		while (i < prefix.length && i < name.length && prefix[i] === name[i]) i++;
+		return prefix.slice(0, i);
+	});
+}
+
+/** Component keys in the template's `components` block. */
+function templateComponentKeys() {
+	const block = template.match(/\n\tcomponents: \{([\s\S]*?)\n\t\}/);
+	if (!block) throw new Error('components block not found in the template');
+	return [...block[1].matchAll(/^\t\t'?([a-z][a-z0-9-]*)'?: \{/gm)].map((m) => m[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+describe('theme template stays in sync with the theme system', () => {
+	it('documents every defineTheme field', () => {
+		const documented = new Set(templateFields());
+		const missing = themeConfigFields().filter((f) => !documented.has(f));
+		expect(
+			missing,
+			`packages/cli/assets/theme.template.ts documents no ${missing.join(', ')} — ` +
+				`ThemeConfig gained a field the template never mentions, so every ` +
+				`author who reads the template will not know it exists.`
+		).toEqual([]);
+	});
+
+	it('invents no field that defineTheme does not accept', () => {
+		const real = new Set([...themeConfigFields(), 'name']);
+		const invented = templateFields().filter((f) => !real.has(f));
+		expect(
+			invented,
+			`The template shows ${invented.join(', ')}, which ThemeConfig does ` +
+				`not accept — a field was renamed or removed and the template kept teaching it.`
+		).toEqual([]);
+	});
+
+	it('lists every settable token family in its inventory', () => {
+		const groups = tokenGroups();
+		const inventory = templateInventory();
+		const missing = settableTokenGroups().filter((group) => {
+			const tokens = groups[group] ?? [];
+			if (tokens.length === 0) return false;
+			return !inventory.includes(commonPrefix(tokens));
+		});
+		expect(
+			missing,
+			`The template's token inventory covers no ${missing.join(', ')}. A whole ` +
+				`token family exists that an author reading the template cannot discover.`
+		).toEqual([]);
+	});
+
+	it('names only tokens and public vars that exist', () => {
+		const known = new Set(Object.values(tokenGroups()).flat());
+		const { publicVars } = themingTargets();
+		// Domain tokens (syntax highlighting) live outside tokens.stylex.ts and are
+		// referenced by prefix in the inventory, not by full name.
+		const domainPrefixes = ['--color-syntax-'];
+		const bogus = templateVars().filter(
+			(v) =>
+				!known.has(v) &&
+				!publicVars.has(v) &&
+				!domainPrefixes.some((p) => v.startsWith(p) || p.startsWith(v))
+		);
+		expect(
+			bogus,
+			`The template names ${bogus.join(', ')}, which no token group and no ` +
+				`component declares. A CSS variable nothing defines compiles to a ` +
+				`declaration that never applies (#5012).`
+		).toEqual([]);
+	});
+
+	it('overrides only real theming targets', () => {
+		const { targets } = themingTargets();
+		const unknown = templateComponentKeys().filter((k) => !(k in targets));
+		expect(
+			unknown,
+			`The template themes ${unknown.join(', ')}, which is not a documented ` +
+				`theming target — the component was renamed or its class changed.`
+		).toEqual([]);
+	});
+
+	it('cites only doc topics that exist', () => {
+		const topics = new Set(docTopics());
+		const cited = [
+			...new Set([...template.matchAll(/astryx-svelte docs ([a-z-]+)/g)].map((m) => m[1]))
+		];
+		const dead = cited.filter((t) => !topics.has(t));
+		expect(
+			dead,
+			`The template tells authors to run \`astryx-svelte docs ${dead.join('`, `astryx-svelte docs ')}\`, ` +
+				`which prints nothing — the topic was renamed or removed.`
+		).toEqual([]);
+	});
+
+	it('is still named by the SYNC comment in every theme source that points here', () => {
+		const relTemplate = 'packages/cli/assets/theme.template.ts';
+		const orphaned = SYNC_SOURCES.filter(
+			({ dir, file }) => !fs.readFileSync(path.join(dir, file), 'utf-8').includes(relTemplate)
+		).map(({ file }) => file);
+		expect(
+			orphaned,
+			`${orphaned.join(', ')} lost the SYNC reference to the template. The ` +
+				`reference is how the next person editing the theme system learns the ` +
+				`template mirrors it.`
+		).toEqual([]);
+	});
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@astryx-svelte/core",
 	"displayName": "Astryx Core",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -120,7 +120,7 @@
 		"vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
 	},
 	"devDependencies": {
-		"@astryxdesign/core": "0.4.1",
+		"@astryxdesign/core": "0.4.2",
 		"@babel/core": "^7.29.7",
 		"@babel/plugin-syntax-typescript": "^7.29.7",
 		"@eslint/js": "^10.0.1",

--- a/packages/core/scripts/compare-upstream-classes.mjs
+++ b/packages/core/scripts/compare-upstream-classes.mjs
@@ -399,10 +399,11 @@ const CASES = [
 	{
 		file: 'src/lib/components/avatar/avatar.stylex.js',
 		upstreamFile: 'Avatar/Avatar.js',
-		// `image` and the icon plate's bare `fallback` are each applied at one
-		// call site with no dynamic style beside them, so the compiler resolved
+		// `image`, the icon plate's bare `fallback`, and — as of 0.4.2, which moved
+		// the size off it onto the wrapper (#5030) — `content` are each applied at
+		// one call site with no dynamic style beside them, so the compiler resolved
 		// them and left no object entry behind.
-		inline: [['styles.image'], ['styles.fallback']]
+		inline: [['styles.image'], ['styles.fallback'], ['styles.content']]
 	},
 	{
 		file: 'src/lib/components/avatar/avatar-status-dot.stylex.js',
@@ -2807,10 +2808,20 @@ const CASES = [
 		// `chevronGlyph` is object mode for the same reason and, being new with
 		// #4838, never had an inline claim to delete.
 		//
-		// `['styles.chevron', 'styles.interactive']` **stays**: that pair is not an
-		// `<Icon>` at all but the chevron's own `<button>`, which upstream still
-		// folds into a literal (`x2lah0s x78zum5 … x1yc453h xe9uy6x`). The glyph
-		// inside it is what moved, and it moved to `chevronGlyph`.
+		// `['styles.chevron', 'styles.interactive']` used to stay: that pair is not
+		// an `<Icon>` at all but the chevron's own `<button>`, which upstream once
+		// folded into a literal. The glyph inside it is what moved for #4838, and
+		// it moved to `chevronGlyph`.
+		//
+		// **Three more pairs joined the objects at 0.4.2**, when the SideNav
+		// hardening pass put every focusable row on the shared focus ring: a call
+		// site that reads `focusOutlineProps.focusVisible(a, b)` passes its styles
+		// through a *runtime function*, which the compiler cannot fold, so `dist/`
+		// keeps the keys as objects and emits no inline string. That is the same
+		// mechanism as an `xstyle` crossing a component boundary. `styles.icon`
+		// **stays** inline: it has two call sites, and only the link variant
+		// (`sideNavHeadingIconLinkAttrs`) took the ring — the plain span is not
+		// focusable, still folds, and is what the inline entry matches.
 		file: 'src/lib/components/side-nav/side-nav-heading.stylex.js',
 		upstreamFile: 'SideNav/SideNavHeading.js',
 		inline: [
@@ -2818,12 +2829,9 @@ const CASES = [
 			['styles.textContainer'],
 			['styles.superheading'],
 			['styles.heading'],
-			['styles.heading', 'styles.headingLink'],
 			['styles.headingRow'],
-			['styles.chevron', 'styles.interactive'],
 			['styles.headerEndContent'],
-			['styles.popoverContent'],
-			['styles.popoverHeading']
+			['styles.popoverContent']
 		]
 	},
 	{
@@ -2846,14 +2854,19 @@ const CASES = [
 		// `styles.root` is object-only since 0.2.0 — all three of its call sites
 		// take `xstyle`, so none folds to a literal. The object diff above still
 		// covers it.
+		//
+		// **`expandToggle` and `splitAction` joined the objects at 0.4.2**: the
+		// hardening pass put both on the shared focus ring, and a call site that
+		// reads `focusOutlineProps.focusVisible(...)` passes its styles through a
+		// runtime function the compiler cannot fold. Same mechanism as the three
+		// `side-nav-heading` pairs above. Their inline claims are deleted rather
+		// than repaired — there is no literal left upstream to match.
 		inline: [
 			['styles.label'],
 			['styles.endContent'],
 			['styles.childrenCollapsible'],
 			['styles.childrenCollapsible', 'styles.childrenCollapsed'],
 			['styles.childrenInner'],
-			['styles.expandToggle'],
-			['styles.splitAction'],
 			['styles.popoverSurface'],
 			['styles.popoverHeader']
 		]

--- a/packages/core/src/lib/components/avatar-group/AvatarGroup.doc.mjs
+++ b/packages/core/src/lib/components/avatar-group/AvatarGroup.doc.mjs
@@ -28,7 +28,8 @@ export default {
 				visualProps: ['size']
 			},
 			{
-				className: 'astryx-avatar-group-overflow'
+				className: 'astryx-avatar-group-overflow',
+				visualProps: ['size']
 			}
 		]
 	},
@@ -83,7 +84,7 @@ export default {
 		},
 		{
 			name: 'size',
-			type: "'sm' | 'md' | 'lg' | 'xl' | 'xsm' | 16 | 20 | 24 | 32 | 36 | 40 | 48 | 60 | 64 | 72 | 96 | 128 | 144 | 180",
+			type: "'sm' | 'md' | 'lg' | 20 | 'xl' | 'xsm' | 16 | 24 | 32 | 36 | 40 | 48 | 60 | 64 | 72 | 96 | 128 | 144 | 180",
 			description: 'Size applied to all avatars via context.',
 			default: "'md'"
 		},

--- a/packages/core/src/lib/components/avatar-group/avatar-group-overflow.svelte
+++ b/packages/core/src/lib/components/avatar-group/avatar-group-overflow.svelte
@@ -54,7 +54,12 @@
 	// The `{count, number}` argument means `en` renders a grouping separator
 	// ("4,912 more"), which the raw template literal never did.
 	const label = $derived(t('@astryx.avatarGroup.overflow', { count }));
-	const theme = themeProps('avatar-group-overflow');
+	// `size` is a documented theming axis on this target (`AvatarGroup.doc.mjs`
+	// declares `visualProps: ['size']`), so it has to reach `themeProps` — and it
+	// arrives through the group context, which makes it `$derived` rather than a
+	// mount-time `const`.
+	const size = $derived(group?.().size ?? 'md');
+	const theme = $derived(themeProps('avatar-group-overflow', { size }));
 </script>
 
 {#snippet content()}

--- a/packages/core/src/lib/components/avatar/Avatar.doc.mjs
+++ b/packages/core/src/lib/components/avatar/Avatar.doc.mjs
@@ -39,6 +39,15 @@ export default {
 				className: 'astryx-avatar-status-dot-glyph',
 				visualProps: ['shape']
 			}
+		],
+		vars: [
+			{
+				name: '--_avatar-group-overlap',
+				description:
+					'Negative inline offset applied to every avatar after the first when avatars are stacked in an AvatarGroup. Set from the group size; a more negative value tightens the stack.',
+				default: 'set at runtime from the group avatar size (px)',
+				private: true
+			}
 		]
 	},
 	usage: {
@@ -123,9 +132,9 @@ export default {
 		},
 		{
 			name: 'size',
-			type: "'sm' | 'md' | 'lg' | 'xl' | 'xsm' | 16 | 20 | 24 | 32 | 36 | 40 | 48 | 60 | 64 | 72 | 96 | 128 | 144 | 180",
+			type: "'sm' | 'md' | 'lg' | 20 | 'xl' | 'xsm' | 16 | 24 | 32 | 36 | 40 | 48 | 60 | 64 | 72 | 96 | 128 | 144 | 180",
 			description:
-				"Avatar size. Use a named size ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or a numeric pixel value. Avatar shares Icon's abbreviated scale, but its tiers are larger because avatars align with media rather than glyphs.",
+				"Avatar size. Use a named size ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or a numeric pixel value. Avatar shares Icon's abbreviated scale, but its tiers are larger because avatars align with media rather than glyphs. Inside an AvatarGroup the group's size wins and this prop is ignored.",
 			default: "'md'"
 		},
 		{

--- a/packages/core/src/lib/components/avatar/avatar.stylex.ts
+++ b/packages/core/src/lib/components/avatar/avatar.stylex.ts
@@ -82,16 +82,17 @@ const styles = stylex.create({
 		position: 'relative',
 		display: 'inline-flex',
 		flexShrink: 0,
-		// The wrapper is not clipped (so the status dot can overflow), so it must be
-		// rounded itself: a themed fallback background lands on `.astryx-avatar` (the
-		// class-bearing wrapper) as well as the internal var, and an unrounded
-		// wrapper would show that fill as square corners behind the circular content.
+		// The wrapper carries the avatar's box as well as its radius, so a theme
+		// rule on the `.astryx-avatar` target reaches both: the size the `size`
+		// visual prop selects on is set here, and the content below fills it.
 		borderRadius: radiusVars['--radius-full']
 	},
 	content: {
 		display: 'flex',
 		alignItems: 'center',
 		justifyContent: 'center',
+		width: '100%',
+		height: '100%',
 		borderRadius: radiusVars['--radius-full'],
 		overflow: 'hidden',
 		userSelect: 'none'
@@ -194,6 +195,12 @@ const groupDynamicStyles = stylex.create({
 });
 
 export interface AvatarWrapperAttrsOptions {
+	/**
+	 * The resolved pixel size. It sits on the wrapper as of 0.4.2 so that a theme
+	 * rule on the documented `size` axis of `.astryx-avatar` resizes the whole
+	 * avatar, rather than growing a wrapper around a fixed-size circle (#5030).
+	 */
+	size: number;
 	/** The group's overlap in pixels, or null outside a group. */
 	groupOverlap: number | null;
 	/** Whether the root renders as an `<a>`/`<button>` rather than a `<div>`. */
@@ -217,11 +224,12 @@ export interface AvatarWrapperAttrsOptions {
  * reason the element swap is invisible to layout.
  */
 export function avatarWrapperAttrs(
-	{ groupOverlap, isInteractive }: AvatarWrapperAttrsOptions,
+	{ size, groupOverlap, isInteractive }: AvatarWrapperAttrsOptions,
 	xstyle?: StyleArg
 ): SvelteStyleAttrs {
 	return focusOutlineProps.focusVisible(
 		styles.wrapper,
+		dynamicStyles.size(size),
 		isInteractive && styles.interactive,
 		groupOverlap != null && groupStyles.ring,
 		groupOverlap != null && groupStyles.overlap,
@@ -230,9 +238,13 @@ export function avatarWrapperAttrs(
 	);
 }
 
-/** The clipping circle the image, initials or icon sits inside. */
-export function avatarContentAttrs(size: number): SvelteStyleAttrs {
-	return sx(styles.content, dynamicStyles.size(size));
+/**
+ * The clipping circle the image, initials or icon sits inside. It fills the
+ * wrapper rather than sizing itself — as of 0.4.2 the box lives on the wrapper,
+ * which is the element carrying the `astryx-avatar` theme target (#5030).
+ */
+export function avatarContentAttrs(): SvelteStyleAttrs {
+	return sx(styles.content);
 }
 
 export function avatarImageAttrs(): SvelteStyleAttrs {

--- a/packages/core/src/lib/components/avatar/avatar.svelte
+++ b/packages/core/src/lib/components/avatar/avatar.svelte
@@ -15,6 +15,9 @@
 		/**
 		 * A named size (`xsm` 20px, `sm` 24px, `md` 36px, `lg` 48px, `xl` 128px)
 		 * or a specific pixel value.
+		 *
+		 * Inside an `AvatarGroup` the group's `size` wins: a group sizes its members
+		 * uniformly, so this prop is ignored there.
 		 * @default 'md'
 		 */
 		size?: AvatarSize;
@@ -86,6 +89,7 @@
 	import { cx, mergeStyle } from '../../internal/sx.js';
 	import { themeProps } from '../../internal/theme-props.js';
 	import { useTranslator } from '../../i18n/use-translator.svelte.js';
+	import { useDevWarning } from '../../hooks/use-dev-warning.svelte.js';
 	import TooltipLayer from '../tooltip/tooltip-layer.svelte';
 	import { useTooltip } from '../tooltip/use-tooltip.svelte.js';
 	import { createAttachmentKey } from 'svelte/attachments';
@@ -142,8 +146,13 @@
 	const showFallbackImage = $derived(
 		!showImage && !!fallbackSrc && erroredFallbackSrc !== fallbackSrc
 	);
-	const showInitials = $derived(!showImage && !showFallbackImage && !!name);
-	const showIcon = $derived(!showImage && !showFallbackImage && !name);
+	// A whitespace-only string carries no identity. Without this it produces no
+	// initials (getInitials trims to nothing) and no default icon (a space is
+	// truthy), leaving an empty plate behind a blank accessible name.
+	const meaningfulName = $derived(name?.trim() ? name : undefined);
+	const meaningfulAlt = $derived(alt?.trim() ? alt : undefined);
+	const showInitials = $derived(!showImage && !showFallbackImage && !!meaningfulName);
+	const showIcon = $derived(!showImage && !showFallbackImage && !meaningfulName);
 
 	// The status element's accessible label, handed up by `AvatarStatusDot`
 	// rather than read off it — see `setAvatarStatusLabelSink`.
@@ -158,7 +167,7 @@
 	// name nor a labelled status, the avatar is decorative — expose it as
 	// `presentation`/`aria-hidden` rather than announcing a generic "Avatar".
 	const t = useTranslator();
-	const nameLabel = $derived(alt || name);
+	const nameLabel = $derived(meaningfulAlt || meaningfulName);
 	const accessibleName = $derived(
 		nameLabel && statusLabel
 			? t('@astryx.avatar.nameWithStatus', { name: nameLabel, status: statusLabel })
@@ -197,7 +206,7 @@
 	// Note: the *visible* tooltip prefers `name` (not `alt`); the *accessible
 	// name* on the root still uses `alt || name` above, independent of this.
 	const tooltipContent = $derived(
-		tooltip === false ? undefined : typeof tooltip === 'string' ? tooltip : name
+		tooltip === false ? undefined : typeof tooltip === 'string' ? tooltip : meaningfulName
 	);
 	const trimmedTooltip = $derived(tooltipContent?.trim());
 	const showTooltip = $derived(trimmedTooltip != null && trimmedTooltip !== '');
@@ -228,28 +237,23 @@
 	);
 
 	// An interactive control with no accessible name is an unacceptable control
-	// name. Warn in the same client-safe way sibling components do (Field,
-	// Timestamp, Popover) — a plain `console.warn`, never gated on `process.env`.
+	// name. `useDevWarning` is the shared guardrail: it warns once per mount
+	// rather than on every render, and compiles out of production builds.
 	//
-	// **Transcribed, not overlooked.** Every other warning in this package routes
-	// through `devWarn`/`useDevWarning`; upstream's `Avatar.tsx` is the one site
-	// that still writes a bare, ungated `console.warn`, and the comment above is
-	// its own justification for it. Its siblings have since moved on, so the
-	// reasoning no longer holds upstream either — but the code at v0.3.0 is what
-	// it is, and changing it here would be an invented improvement. Left alone
-	// deliberately; a sweep that "fixes" this is a parity regression.
-	$effect(() => {
-		if (isInteractive && !accessibleName) {
-			console.warn(
-				'Avatar: an interactive avatar (with `href` or `onclick`) needs a ' +
-					'meaningful accessible name. Pass `alt` or `name`.'
-			);
-		}
-	});
+	// Upstream's `Avatar.tsx` was the last site in the package still writing a
+	// bare, ungated `console.warn` — kept here verbatim while that was true, and
+	// moved onto the shared hook the moment 0.4.2 moved upstream's (#5030).
+	useDevWarning(
+		'Avatar',
+		'an interactive avatar (with `href` or `onclick`) needs a meaningful ' +
+			'accessible name. Pass `alt` or `name`.',
+		() => isInteractive && !accessibleName
+	);
 
 	const wrapper = $derived(
 		avatarWrapperAttrs(
 			{
+				size: numericSize,
 				groupOverlap: group?.().overlap ?? null,
 				isInteractive
 			},
@@ -263,7 +267,7 @@
 	// Upstream needs the identical cast (`props as React.HTMLAttributes<HTMLElement>`).
 	const interactivePassthrough = $derived(rest as HTMLAttributes<HTMLElement>);
 
-	const content = $derived(avatarContentAttrs(numericSize));
+	const content = avatarContentAttrs();
 	const image = avatarImageAttrs();
 	const initials = $derived(avatarInitialsAttrs(numericSize));
 	const icon = avatarIconAttrs();
@@ -347,7 +351,7 @@
 			/>
 		{:else if showInitials}
 			<div class={cx(fallbackTheme.class, initials.class)} style={initials.style}>
-				{getInitials(name as string)}
+				{getInitials(meaningfulName as string)}
 			</div>
 		{:else if showIcon}
 			<div class={cx(fallbackTheme.class, icon.class)} style={icon.style}>

--- a/packages/core/src/lib/components/breadcrumbs/breadcrumbs.svelte
+++ b/packages/core/src/lib/components/breadcrumbs/breadcrumbs.svelte
@@ -69,11 +69,11 @@
 </script>
 
 <nav
-	{...rest}
 	aria-label={label}
 	{...theme}
 	class={cx(theme.class, navAttrs.class, className)}
 	style={mergeStyle(navAttrs.style, styleProp as string | undefined)}
+	{...rest}
 >
 	<ol class={listAttrs.class} style={listAttrs.style}>{@render children()}</ol>
 </nav>

--- a/packages/core/src/lib/components/button/button.stylex.ts
+++ b/packages/core/src/lib/components/button/button.stylex.ts
@@ -269,10 +269,12 @@ const loadingStyles = stylex.create({
  * their button (a tooltip'd Button renders button + layer; DropdownMenu renders
  * trigger + popover), so the layer would take the `:last-child` slot and the real
  * trailing button would keep square corners. Layers always carry the native
- * `popover` attribute and are never in-flow, so "last member" means: no following
- * element sibling that isn't a popover.
+ * `popover` attribute and are never in-flow. Context layers also retain an inert
+ * `<template>` marker so they can re-resolve their position. Neither element is a
+ * group member, so "last member" means: no following element sibling besides
+ * those two pieces of layer infrastructure.
  */
-const IS_LAST_ITEM = ':not(:has(~ *:not([popover])))';
+const IS_LAST_ITEM = ':not(:has(~ *:not([popover]):not(template)))';
 
 const groupStyles = stylex.create({
 	horizontal: {

--- a/packages/core/src/lib/components/card/Card.doc.mjs
+++ b/packages/core/src/lib/components/card/Card.doc.mjs
@@ -36,6 +36,20 @@ export default {
 				description: 'Border radius of the card',
 				default: 'var(--radius-container)',
 				private: true
+			},
+			{
+				name: '--_card-elevation',
+				description:
+					'Resting shadow of the card, set from the elevation prop. Composed into the card box-shadow list alongside --_card-ring rather than written as boxShadow directly, so a ring and an elevation can coexist.',
+				default: '0 0 transparent',
+				private: true
+			},
+			{
+				name: '--_card-ring',
+				description:
+					'Inset ring drawn in the card box-shadow list. SelectableCard sets it to show selection without taking over the shadow.',
+				default: '0 0 transparent',
+				private: true
 			}
 		],
 		derived: [

--- a/packages/core/src/lib/components/chat/ChatMessage.doc.mjs
+++ b/packages/core/src/lib/components/chat/ChatMessage.doc.mjs
@@ -40,7 +40,8 @@ export default {
 		{
 			name: 'children',
 			type: 'Snippet',
-			description: 'Free-form content: bubbles, asset lists, tool calls, images.',
+			description:
+				'Free-form content: bubbles, asset lists, tool calls, images. Custom (non-bubble) children render flush with the message edge; wrap them in a ghost ChatMessageBubble to align them with the bubble text column.',
 			required: true
 		},
 		{

--- a/packages/core/src/lib/components/chat/ChatMessageBubble.doc.mjs
+++ b/packages/core/src/lib/components/chat/ChatMessageBubble.doc.mjs
@@ -62,6 +62,12 @@ export default {
 			type: "'first' | 'middle' | 'last'",
 			description:
 				'Position within a multi-bubble group. Controls corner radius reduction on the sender side. Leave unset for standalone bubbles (full radius).'
+		},
+		{
+			name: 'width',
+			type: 'SizeValue',
+			description:
+				'Width of the bubble (number = pixels, string = used as-is). When set, replaces the default max(80%, 280px) width cap. Combine with variant="ghost" to let custom content (an artifact card, attachments) span the full message column.'
 		}
 	]
 };

--- a/packages/core/src/lib/components/chat/chat-composer-drawer.svelte
+++ b/packages/core/src/lib/components/chat/chat-composer-drawer.svelte
@@ -116,11 +116,12 @@
 	const content = $derived(chatComposerDrawerContentAttrs(canCollapse && isCollapsed));
 </script>
 
+<!-- `{...rest}` last, matching upstream's trailing `{...htmlProps}`. -->
 <div
-	{...rest}
 	{...theme}
 	class={cx(theme.class, root.class, className)}
 	style={mergeStyle(root.style, styleProp as string | undefined)}
+	{...rest}
 >
 	{#if count != null}
 		<div

--- a/packages/core/src/lib/components/chat/chat-message-bubble.stylex.ts
+++ b/packages/core/src/lib/components/chat/chat-message-bubble.stylex.ts
@@ -8,6 +8,7 @@ import {
 	typographyVars
 } from '../../styles/tokens.stylex.js';
 import type { ChatDensity, ChatMessageSender } from './chat-context.svelte.js';
+import type { SizeValue } from '../../internal/types.js';
 
 /** Ported from the `styles` block in Astryx's `Chat/ChatMessageBubble.tsx`. */
 export type ChatMessageBubbleVariant = 'filled' | 'ghost';
@@ -147,11 +148,22 @@ function groupFor(group: ChatMessageBubbleGroup | undefined, isUser: boolean) {
 				: null;
 }
 
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+	sizing: (width: SizeValue) => ({
+		width,
+		// An explicit width replaces the default cap — a full-column or
+		// fixed-width bubble shouldn't also be clamped by max(80%, 280px).
+		maxWidth: 'none'
+	})
+});
+
 export function chatMessageBubbleContentAttrs(
 	sender: ChatMessageSender,
 	density: ChatDensity,
 	variant: ChatMessageBubbleVariant,
 	group: ChatMessageBubbleGroup | undefined,
+	width: SizeValue | undefined,
 	xstyle?: StyleArg
 ): SvelteStyleAttrs {
 	const isUser = sender === 'user';
@@ -163,6 +175,7 @@ export function chatMessageBubbleContentAttrs(
 		paddingFor(density),
 		variant === 'ghost' && styles.paddingBlockNone,
 		groupFor(group, isUser),
+		width != null && dynamicStyles.sizing(width),
 		xstyle
 	);
 }

--- a/packages/core/src/lib/components/chat/chat-message-bubble.svelte
+++ b/packages/core/src/lib/components/chat/chat-message-bubble.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
 	import type { Snippet } from 'svelte';
 	import type { BaseProps } from '../../base-props.js';
+	import type { SizeValue } from '../../internal/types.js';
 	import type {
 		ChatMessageBubbleGroup,
 		ChatMessageBubbleVariant as ChatMessageBubbleVariantType
@@ -47,6 +48,15 @@
 		 * Leave unset for standalone bubbles (full radius).
 		 */
 		group?: ChatMessageBubbleGroup;
+
+		/**
+		 * Width of the bubble.
+		 * Numbers are treated as pixels, strings are used as-is (e.g. `"100%"`).
+		 * When set, replaces the default `max(80%, 280px)` width cap; leave unset
+		 * to keep the cap. Combine with `variant="ghost"` to let custom content
+		 * (an artifact card, attachments) span the full message column.
+		 */
+		width?: SizeValue;
 	}
 </script>
 
@@ -88,6 +98,7 @@
 		name,
 		metadata,
 		group,
+		width,
 		xstyle,
 		class: className,
 		style: styleProp,
@@ -100,7 +111,9 @@
 	const isUser = $derived(sender === 'user');
 
 	const theme = $derived(themeProps('chat-message-bubble', { sender, variant, density }));
-	const content = $derived(chatMessageBubbleContentAttrs(sender, density, variant, group, xstyle));
+	const content = $derived(
+		chatMessageBubbleContentAttrs(sender, density, variant, group, width, xstyle)
+	);
 	const nameAttrs = $derived(chatMessageBubbleNameAttrs(density, isUser));
 	const metadataAttrs = $derived(chatMessageBubbleMetadataAttrs(density, isUser));
 </script>

--- a/packages/core/src/lib/components/checkbox-input/checkbox-input.stylex.ts
+++ b/packages/core/src/lib/components/checkbox-input/checkbox-input.stylex.ts
@@ -45,7 +45,27 @@ const styles = stylex.create({
 		padding: 0,
 		opacity: 0,
 		cursor: 'pointer',
-		zIndex: 1
+		zIndex: 1,
+		minInlineSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
+		minBlockSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
+		insetBlockStart: {
+			default: null,
+			'@media (pointer: coarse)': '50%'
+		},
+		insetInlineStart: {
+			default: null,
+			'@media (pointer: coarse)': '50%'
+		},
+		transform: {
+			default: null,
+			'@media (pointer: coarse)': 'translate(-50%, -50%)'
+		}
 	},
 	inputDisabled: {
 		cursor: 'not-allowed'

--- a/packages/core/src/lib/components/code-block/CodeBlock.doc.mjs
+++ b/packages/core/src/lib/components/code-block/CodeBlock.doc.mjs
@@ -42,6 +42,15 @@ export default {
 			{
 				className: 'astryx-codeblock-copy-button'
 			}
+		],
+		vars: [
+			{
+				name: '--_codeblock-gutter-width',
+				description:
+					'Width of the line-number gutter, computed from the digit count of the last line so the code column starts at a stable offset.',
+				default: '2ch',
+				private: true
+			}
 		]
 	},
 	usage: {

--- a/packages/core/src/lib/components/code-block/code-block.svelte
+++ b/packages/core/src/lib/components/code-block/code-block.svelte
@@ -626,14 +626,12 @@
 	the tree looks fine.
 -->
 {#snippet block()}
+	<!-- `{...rest}` last, matching upstream's trailing `{...props}`. -->
 	<pre
-		{...rest}
 		{...theme}
 		class={cx(theme.class, rootAttrs.class, className)}
-		style={mergeStyle(
-			rootAttrs.style,
-			styleProp as string | undefined
-		)}>{#if showHeader}{@render headerRow()}{/if}{#if canCollapse}{@render collapsibleBody()}{:else}{@render codeBody()}{/if}{#if !showHeader && hasCopyButton}{@render copyButton()}{/if}</pre>
+		style={mergeStyle(rootAttrs.style, styleProp as string | undefined)}
+		{...rest}>{#if showHeader}{@render headerRow()}{/if}{#if canCollapse}{@render collapsibleBody()}{:else}{@render codeBody()}{/if}{#if !showHeader && hasCopyButton}{@render copyButton()}{/if}</pre>
 {/snippet}
 
 {#if syntaxTheme}

--- a/packages/core/src/lib/components/collapsible/collapsible.svelte
+++ b/packages/core/src/lib/components/collapsible/collapsible.svelte
@@ -114,11 +114,17 @@
 	const contentAttrs = $derived(collapsibleContentAttrs(density, collapsible.isOpen));
 </script>
 
+<!--
+	`{...rest}` last, as upstream spreads `{...props}` last — a consumer's `data-*`
+	or `aria-*` overrides the component's own reflection rather than being
+	overridden by it. `class`/`style` are destructured out, so they cannot be
+	clobbered from here.
+-->
 <div
-	{...rest}
 	{...theme}
 	class={cx(theme.class, rootAttrs.class, className)}
 	style={mergeStyle(rootAttrs.style, styleProp as string | undefined)}
+	{...rest}
 >
 	<button
 		type="button"

--- a/packages/core/src/lib/components/command-palette/command-palette-footer.svelte
+++ b/packages/core/src/lib/components/command-palette/command-palette-footer.svelte
@@ -16,6 +16,7 @@
 <script lang="ts">
 	import Kbd from '../kbd/kbd.svelte';
 	import { themeProps } from '../../internal/theme-props.js';
+	import { useTranslator } from '../../i18n/use-translator.svelte.js';
 	import { cx, mergeStyle } from '../../internal/sx.js';
 	import {
 		commandPaletteFooterAttrs,
@@ -27,10 +28,10 @@
 	 * from Astryx's `CommandPalette/CommandPaletteFooter.tsx`.
 	 *
 	 * When no children are provided, renders default hints using `Kbd` for arrow
-	 * keys, Enter to select, and Escape to close. The three hint labels are
-	 * hard-coded English on both sides — upstream's catalogue has no keys for
-	 * them, and inventing keys would be inventing API (the same standing
-	 * `FileInput`/`MultiSelector` record).
+	 * keys, Enter to select, and Escape to close. The three hint labels were
+	 * hard-coded English on both sides until upstream 0.4.2 added catalogue keys
+	 * for them (#4506); they now resolve from the locale catalogue like the rest
+	 * of the package.
 	 */
 	const {
 		children,
@@ -40,6 +41,7 @@
 		...rest
 	}: CommandPaletteFooterProps = $props();
 
+	const t = useTranslator();
 	const theme = $derived(themeProps('command-palette-footer'));
 	const attrs = $derived(commandPaletteFooterAttrs(xstyle));
 	const hintAttrs = $derived(commandPaletteFooterHintAttrs());
@@ -57,15 +59,15 @@
 		<span class={hintAttrs.class} style={hintAttrs.style}>
 			<Kbd keys="up" />
 			<Kbd keys="down" />
-			Navigate
+			{t('@astryx.commandPalette.footer.navigate')}
 		</span>
 		<span class={hintAttrs.class} style={hintAttrs.style}>
 			<Kbd keys="enter" />
-			Select
+			{t('@astryx.commandPalette.footer.select')}
 		</span>
 		<span class={hintAttrs.class} style={hintAttrs.style}>
 			<Kbd keys="escape" />
-			Close
+			{t('@astryx.commandPalette.footer.close')}
 		</span>
 	{/if}
 </div>

--- a/packages/core/src/lib/components/date-time-input/date-time-input.svelte
+++ b/packages/core/src/lib/components/date-time-input/date-time-input.svelte
@@ -463,7 +463,9 @@
 	// writes both hints as bare English literals with no translator key.
 	const resolvedTimePlaceholder = $derived.by(() => {
 		if (isTimeFocused && !timeDisplayValue) {
-			return hourFormat === '12h' ? 'e.g., 2:30 PM' : 'e.g., 14:30';
+			return hourFormat === '12h'
+				? t('@astryx.dateTimeInput.timeHint12h')
+				: t('@astryx.dateTimeInput.timeHint24h');
 		}
 		return timePlaceholder;
 	});

--- a/packages/core/src/lib/components/dropdown-menu/dropdown-menu-sub-menu.svelte
+++ b/packages/core/src/lib/components/dropdown-menu/dropdown-menu-sub-menu.svelte
@@ -170,18 +170,12 @@
 		}
 		layer.show();
 		if (options?.focusFirst) {
-			requestAnimationFrame(() => {
-				// Move focus into the flyout. When it has no focusable items yet
-				// (e.g. an async submenu showing only a disabled "Loading…" row via
-				// hasSpinner), focusFirst() finds nothing — fall back to focusing the
-				// flyout container itself so keyboard ownership still transfers off
-				// the parent list. Otherwise the parent would keep focus, letting
-				// arrow keys rove the parent while the empty flyout stays open.
-				const focusedItem = list.focusFirst();
-				if (!focusedItem) {
-					menuEl?.focus();
-				}
-			});
+			// Synchronous by design — see the focus note in `useMenuHover`. A
+			// still-loading flyout has no focusable item, so fall back to the
+			// container: keyboard ownership must leave the parent list either way.
+			if (!list.focusFirst()) {
+				menuEl?.focus();
+			}
 		}
 	}
 
@@ -214,6 +208,10 @@
 
 	// Hover-intent: entering the trigger opens after a short delay; leaving
 	// either surface closes after a delay. Hover-open does not steal focus.
+	//
+	// Hover intent and the shared hover→click guard only: this level owns its own
+	// click handling, roving focus and typeahead. `popover="manual"`, so the
+	// invoker wiring other consumers need does not apply.
 	const menuHover = useMenuHover(() => ({
 		show: showLayer,
 		hide: hideLayer,
@@ -225,8 +223,14 @@
 		if (isDisabled) {
 			return;
 		}
-		// Click toggles the flyout, moving focus into it on open.
+		// Toggles, except for the click that follows a hover-open (#3121).
 		if (isOpen) {
+			if (menuHover.confirmHoverOpen()) {
+				if (!list.focusFirst()) {
+					menuEl?.focus();
+				}
+				return;
+			}
 			close({ focusTrigger: true });
 		} else {
 			open({ focusFirst: true });

--- a/packages/core/src/lib/components/form-layout/form-layout-context.svelte.ts
+++ b/packages/core/src/lib/components/form-layout/form-layout-context.svelte.ts
@@ -17,10 +17,16 @@ import { Context } from '../../internal/context.js';
  */
 export type FormLayoutDirection = 'vertical' | 'horizontal' | 'horizontal-labels';
 
-const formLayoutContext = new Context<() => FormLayoutDirection>('astryx.formLayout');
+/**
+ * Published, because upstream publishes `FormLayoutContext` from
+ * `FormLayout/index.ts` — `setFormLayoutContext`/`useFormLayout` are the Svelte
+ * wrappers around it, not a replacement for it. Same shape as
+ * `RadioListContext` and `SizeContext`.
+ */
+export const FormLayoutContext = new Context<() => FormLayoutDirection>('astryx.formLayout');
 
 export function setFormLayoutContext(get: () => FormLayoutDirection): void {
-	formLayoutContext.set(get);
+	FormLayoutContext.set(get);
 }
 
 /**
@@ -33,5 +39,5 @@ export function setFormLayoutContext(get: () => FormLayoutDirection): void {
  * descendants at whatever the provider held on mount.
  */
 export function useFormLayout(): () => FormLayoutDirection {
-	return formLayoutContext.getOr(() => 'vertical');
+	return FormLayoutContext.getOr(() => 'vertical');
 }

--- a/packages/core/src/lib/components/heading/heading.svelte
+++ b/packages/core/src/lib/components/heading/heading.svelte
@@ -51,7 +51,7 @@
 <script lang="ts">
 	import { cx, mergeStyle } from '../../internal/sx.js';
 	import { themeProps } from '../../internal/theme-props.js';
-	import { createTruncation } from '../../internal/truncation.svelte.js';
+	import { useTruncation } from '../../internal/truncation.svelte.js';
 	import { lineClampStyle, truncationTooltipContentAttrs } from '../text/text.stylex.js';
 	import { LEVEL_TO_TAG, headingAttrs } from './heading.stylex.js';
 
@@ -82,7 +82,7 @@
 	const resolvedWordBreak = $derived(wordBreak ?? (maxLines === 1 ? 'break-all' : 'break-word'));
 	const resolvedDisplay = $derived(maxLines > 0 || hasCapsize ? 'block' : display);
 
-	const truncation = createTruncation(() => maxLines);
+	const truncation = useTruncation(() => maxLines);
 
 	const tooltipPlacement = $derived<LayerPlacement>(
 		typeof hasTruncateTooltip === 'string' ? hasTruncateTooltip : 'above'
@@ -122,12 +122,12 @@
 <svelte:element
 	this={LEVEL_TO_TAG[level]}
 	bind:this={headingEl}
-	{...rest}
 	{...theme}
 	class={cx(theme.class, attrs.class, className)}
 	style={mergeStyle(attrs.style, lineClampStyle(maxLines), styleProp as string | undefined)}
 	title={tooltipEnabled ? truncation.fullText : undefined}
 	aria-level={accessibilityLevel && accessibilityLevel !== level ? accessibilityLevel : undefined}
+	{...rest}
 	{@attach truncation.attach}
 >
 	{@render children()}

--- a/packages/core/src/lib/components/hover-card/HoverCard.doc.mjs
+++ b/packages/core/src/lib/components/hover-card/HoverCard.doc.mjs
@@ -75,9 +75,9 @@ export default {
 					'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.'
 			},
 			{
-				guidance: false,
+				guidance: true,
 				description:
-					'Nest a HoverCard whose content has block elements directly inside phrasing-only contexts such as a <p>, <label>, or heading. The card renders inline, so block content there is invalid HTML the browser reparents. Wrap the surrounding text in a block element (e.g. a <div>) instead.'
+					'Prefer placing HoverCard in a block context rather than directly in a <p>, heading, or link. Those placements are supported when necessary through a corrective portal, but the DOM and tab order may differ.'
 			}
 		],
 		anatomy: [

--- a/packages/core/src/lib/components/hover-card/hover-card-layer.svelte
+++ b/packages/core/src/lib/components/hover-card/hover-card-layer.svelte
@@ -87,7 +87,6 @@
 	alignment={renderAlignment}
 	role={hoverCard.role}
 	aria-label={hoverCard.label}
-	as="span"
 	xstyle={[hoverCard.xstyle, layerAnimations[renderPlacement], xstyle]}
 	class={cx(themeProps('hovercard').class, className)}
 	style={style ?? undefined}
@@ -100,18 +99,24 @@
 		descendant. Native `blur` does not bubble, so `onblur` would never fire for
 		the case the handler exists to serve.
 
-		The keydown handler is why the a11y rule fires: the span is a styling and
+		A `<div>` as of 0.4.2: `useLayer` mounts the container only after verifying
+		or correcting its parent, so the card's content no longer has to be
+		phrasing-safe and can use block markup (#5039).
+
+		The keydown handler is why the a11y rule fires: the div is a styling and
 		event surface, and the ARIA pattern is completed by the `role="dialog"` on
-		the layer container above it. Giving this span a role of its own would put
+		the layer container above it. Giving this div a role of its own would put
 		a second element in the accessibility tree where upstream has one.
 	-->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<span
+	<div
 		class={content.class}
 		style={content.style}
 		onmouseenter={hoverCard.handleContentMouseEnter}
 		onmouseleave={hoverCard.handleContentMouseLeave}
 		onkeydown={hoverCard.handleContentKeyDown}
-		onfocusout={hoverCard.handleContentFocusOut}>{@render children()}</span
+		onfocusout={hoverCard.handleContentFocusOut}
 	>
+		{@render children()}
+	</div>
 </Layer>

--- a/packages/core/src/lib/components/hover-card/use-hover-card.svelte.ts
+++ b/packages/core/src/lib/components/hover-card/use-hover-card.svelte.ts
@@ -277,6 +277,10 @@ export function useHoverCard(options: () => HoverCardOptions): HoverCardReturn {
 
 	const layer = useLayer(() => ({
 		mode: 'context',
+		// Rich card content must never enter an invalid paragraph, even briefly:
+		// nothing but the inert marker exists while the card is closed, and the
+		// container's position is resolved at the moment it opens (#5039).
+		lazyMount: true,
 		id: options().id,
 		onShow: options().onShow,
 		onHide: options().onHide

--- a/packages/core/src/lib/components/input-group/group-styles.stylex.ts
+++ b/packages/core/src/lib/components/input-group/group-styles.stylex.ts
@@ -14,12 +14,18 @@ import { radiusVars, borderVars } from '../../styles/tokens.stylex.js';
  * Upstream keeps this out of the public `InputGroup/index.ts` barrel — consumers
  * import `./groupStyles` directly — so this module is likewise internal.
  *
- * The four-class radius corners are load-bearing: the `:has(+ [popover]…)`
- * selectors round the trailing member even when the *last* DOM sibling is a
- * popover it owns (a `Selector`/`DateInput`'s dropdown). `InputGroupText` drops
- * those variants because a text addon never has a popover sibling — do not copy
- * one shape onto the other.
+ * The trailing-corner selector is load-bearing: it rounds the trailing member
+ * even when the *last* DOM sibling is layer infrastructure the member owns (a
+ * `Selector`/`DateInput`'s dropdown). `InputGroupText` uses a plain `:last-child`
+ * because a text addon never has a layer sibling — do not copy one shape onto
+ * the other.
  */
+
+// A grouped control may be followed by context-layer infrastructure rather
+// than another control. Neither the inert marker nor the popover is a visual
+// group member, so skip both when finding the trailing edge.
+const IS_LAST_ITEM = ':not(:has(~ *:not([popover]):not(template)))';
+
 export const groupStyles = stylex.create({
 	inGroup: {
 		flex: 1,
@@ -39,15 +45,11 @@ export const groupStyles = stylex.create({
 		},
 		borderStartEndRadius: {
 			default: 0,
-			':last-child': radiusVars['--radius-element'],
-			':has(+ [popover]:last-child)': radiusVars['--radius-element'],
-			':has(+ [popover] + [popover]:last-child)': radiusVars['--radius-element']
+			[IS_LAST_ITEM]: radiusVars['--radius-element']
 		},
 		borderEndEndRadius: {
 			default: 0,
-			':last-child': radiusVars['--radius-element'],
-			':has(+ [popover]:last-child)': radiusVars['--radius-element'],
-			':has(+ [popover] + [popover]:last-child)': radiusVars['--radius-element']
+			[IS_LAST_ITEM]: radiusVars['--radius-element']
 		},
 		':focus-within': {
 			zIndex: 1

--- a/packages/core/src/lib/components/input-group/input-group-text.stylex.ts
+++ b/packages/core/src/lib/components/input-group/input-group-text.stylex.ts
@@ -14,9 +14,9 @@ import {
  *
  * A static text/icon addon that sits flush against a member control. It carries
  * a muted surface and the same border-collapsing margin as the group members —
- * but with only the two-class radius corners (`:first-child`/`:last-child`),
- * since a text addon never owns a popover sibling the way `group-styles`'
- * `:has(+ [popover])` variants account for.
+ * but with a plain `:first-child`/`:last-child` pair for the radius corners,
+ * since a text addon never owns the layer siblings that `group-styles`'
+ * `IS_LAST_ITEM` selector accounts for.
  */
 const styles = stylex.create({
 	text: {

--- a/packages/core/src/lib/components/item/Item.doc.mjs
+++ b/packages/core/src/lib/components/item/Item.doc.mjs
@@ -27,6 +27,21 @@ export default {
 				className: 'astryx-item',
 				visualProps: ['density', 'align']
 			}
+		],
+		vars: [
+			{
+				name: '--_item-label-color',
+				description:
+					'Color of the label line. Unset by default (the label uses the primary text token); a parent sets it to recolor the label it renders, as the destructive dropdown/context menu item does.',
+				default: 'var(--color-text-primary)',
+				private: true
+			},
+			{
+				name: '--_item-description-color',
+				description: 'Companion to --_item-label-color for the secondary description line.',
+				default: 'var(--color-text-secondary)',
+				private: true
+			}
 		]
 	},
 	usage: {

--- a/packages/core/src/lib/components/layer/layer-host.ts
+++ b/packages/core/src/lib/components/layer/layer-host.ts
@@ -1,0 +1,138 @@
+/**
+ * Ported from Astryx's `Layer/layerHost.ts`.
+ *
+ * The corrective-portal target for a context layer: given the element the layer
+ * would render inside, decide whether that position is safe and, when it is not,
+ * name the nearest element outside every unsafe ancestor.
+ *
+ * A pure DOM function with no framework surface, so it transcribes unchanged.
+ * Internal on both sides — upstream's `Layer/index.ts` does not export it.
+ */
+
+/**
+ * Ancestors a layer must not be hosted inside.
+ *
+ * Two overlapping reasons, both verified in Chrome:
+ *
+ * 1. The HTML parser owns server markup. `<p>` and the heading-ish elements
+ *    take phrasing content only, so a block element inside one makes the
+ *    parser close the paragraph and reparent the rest — the layer's content
+ *    ends up in the page instead of the popover. A nested `<a>` triggers the
+ *    same tearing through the adoption agency algorithm.
+ * 2. Interactive ancestors capture the layer's own interactions. A card
+ *    hosted inside an `<a>` or `<button>` puts its links and buttons inside
+ *    that control: clicking one navigates the wrapping link, and every
+ *    focusable in the card joins the control's own tab stop.
+ *
+ * Inline formatting elements are on the list for a third, milder reason: a
+ * layer hosted in one inherits its typography (font-size, text-align), so a
+ * card in a 13px centered paragraph renders 13px and centered.
+ */
+const UNSAFE_HOSTS = new Set([
+	// Phrasing-content-only containers
+	'p',
+	'h1',
+	'h2',
+	'h3',
+	'h4',
+	'h5',
+	'h6',
+	'dt',
+	'pre',
+	'legend',
+	'data',
+	'dfn',
+	'meter',
+	'output',
+	'progress',
+	'option',
+	'optgroup',
+	// Structural containers whose direct children are restricted. An inert
+	// <template> marker is valid script-supporting content in these positions,
+	// but the eventual div/span layer is not.
+	'table',
+	'thead',
+	'tbody',
+	'tfoot',
+	'tr',
+	'colgroup',
+	'ul',
+	'ol',
+	'menu',
+	'dl',
+	'select',
+	'datalist',
+	'picture',
+	'hgroup',
+	'ruby',
+	'rt',
+	'rp',
+	// Interactive containers
+	'a',
+	'button',
+	'label',
+	'summary',
+	// Inline formatting context
+	'span',
+	'em',
+	'strong',
+	'b',
+	'i',
+	'u',
+	's',
+	'small',
+	'mark',
+	'code',
+	'kbd',
+	'samp',
+	'var',
+	'sub',
+	'sup',
+	'abbr',
+	'cite',
+	'q',
+	'time',
+	'bdi',
+	'bdo',
+	'ins',
+	'del'
+]);
+
+/**
+ * Return the corrective portal target for a layer's intended inline parent.
+ *
+ * A null result means the inline parent and all of its ancestors are safe, so
+ * the layer should stay at its render position. Otherwise the result is the
+ * nearest element outside every unsafe ancestor around that position.
+ *
+ * Walking up from the actual render position (rather than the trigger, or
+ * portaling to `document.body`) keeps the two things a layer inherits there:
+ *
+ * - **Theme.** Theme scopes live on DOM ancestors. Staying as close as
+ *   possible to the intended render position preserves their component rules
+ *   and custom properties; `document.body` may sit outside a nested scope.
+ * - **Tab order.** Sequential focus follows DOM order, so a host near the
+ *   trigger keeps the layer's focusables next to it. (`show()` also passes
+ *   the trigger as the popover's invoker `source`, which pins focus order to
+ *   the invoker in browsers that support it.)
+ *
+ * The outermost unsafe ancestor matters. A safe div may itself sit inside an
+ * anchor; stopping at that div would still put the layer's buttons inside the
+ * link. Walking the whole chain ensures the target is outside both.
+ */
+export function resolveLayerPortalTarget(inlineParent: HTMLElement | null): HTMLElement | null {
+	if (!inlineParent) {
+		return null;
+	}
+
+	let outermostUnsafe: HTMLElement | null = null;
+	let node: HTMLElement | null = inlineParent;
+	while (node) {
+		if (UNSAFE_HOSTS.has(node.tagName.toLowerCase())) {
+			outermostUnsafe = node;
+		}
+		node = node.parentElement;
+	}
+
+	return outermostUnsafe?.parentElement ?? null;
+}

--- a/packages/core/src/lib/components/layer/layer.stylex.ts
+++ b/packages/core/src/lib/components/layer/layer.stylex.ts
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import { sx, type StyleArg, type SvelteStyleAttrs } from '../../internal/sx.js';
-import { typographyVars } from '../../styles/tokens.stylex.js';
+import { typeScaleVars, typographyVars } from '../../styles/tokens.stylex.js';
 
 /**
  * The layer container's own styles, from Astryx's `Layer/useLayer.tsx`.
@@ -24,7 +24,12 @@ const styles = stylex.create({
 		borderWidth: 0,
 		borderStyle: 'none',
 		overflow: 'visible',
+		// A layer is hosted wherever its trigger happens to sit, so type that is
+		// inherited rather than declared makes the same component render at a
+		// different size in different callers.
 		fontFamily: typographyVars['--font-family-body'],
+		fontSize: typeScaleVars['--text-body-size'],
+		lineHeight: typeScaleVars['--text-body-leading'],
 		// Override browser default [popover] background (canvas color)
 		backgroundColor: 'transparent'
 	},

--- a/packages/core/src/lib/components/layer/layer.svelte
+++ b/packages/core/src/lib/components/layer/layer.svelte
@@ -2,7 +2,9 @@
 	import type { Snippet } from 'svelte';
 	import type { MouseEventHandler } from 'svelte/elements';
 	import type { StyleArg } from '../../internal/sx.js';
+	import type { Attachment } from 'svelte/attachments';
 	import type {
+		ContextLayerMount,
 		ContextLayerReturn,
 		FixedLayerReturn,
 		LayerAlignment,
@@ -89,12 +91,12 @@
 		/**
 		 * HTML tag to render the popover container as.
 		 *
-		 * Defaults to `'div'`. Pass `'span'` when the layer must render inline-safe
-		 * markup — e.g. a `HoverCard` wrapping inline text inside a `<p>`. A `<span>`
-		 * is phrasing content, so it stays put in the DOM tree instead of being
-		 * reparented out of a paragraph by the HTML parser, which keeps server and
-		 * client markup identical. The Popover API and CSS anchor positioning work
-		 * the same on either tag.
+		 * Defaults to `'div'`. Context layers render an inert `<template>` marker at
+		 * the layer's position in the template. The marker's parent is checked
+		 * before the requested container mounts there or portals outside ancestors
+		 * that cannot safely contain it. The marker remains available to detect a
+		 * new parent if the render call moves. With `lazyMount`, the first check
+		 * waits until `show()`.
 		 *
 		 * @default 'div'
 		 */
@@ -169,24 +171,105 @@
 					p.alignment ?? 'center'
 				)
 	);
+
+	// Context mode resolves where the container may live before rendering it;
+	// fixed mode has no marker and always renders. Null means "not resolved yet"
+	// — on first render, and again after a `lazyMount` hide.
+	const contextMount = $derived(isFixed ? null : (p.layer as ContextLayerReturn).contextMount);
+	const shouldRender = $derived(isFixed || contextMount !== null);
+	const portalStyle = $derived(contextMount?.portalStyle);
+
+	/**
+	 * Where Svelte actually rendered the container, captured on the first attach.
+	 * A node this component moved away has to be *put back* when the resolve says
+	 * inline, and Svelte will not do it: as far as the runtime is concerned the
+	 * element is already rendered, so nothing re-inserts it.
+	 */
+	let portalHome: { parent: Node; next: Node | null } | null = null;
+
+	/**
+	 * Move the container to its corrective portal target. Svelte has no
+	 * `createPortal`, so the element renders in place and is relocated — the same
+	 * device `ChatComposerInput` uses to move a token's content into its span.
+	 *
+	 * **The cleanup is load-bearing here, where that one needs none.** Svelte
+	 * tears an `{#if}` block down by clearing the range between its anchors in the
+	 * block's *original* parent; a node moved out of that range is never reached,
+	 * so a portaled layer survived its own unmount and a hidden `lazyMount` card
+	 * stayed in the DOM. Removing it explicitly is idempotent — a node Svelte
+	 * already removed is simply not in a tree any more.
+	 *
+	 * **The `null` target is a move, not a no-op.** `target` is `null` whenever the
+	 * resolve lands on a safe parent, and it can *become* null while mounted — a
+	 * persistent render call that moves from a `<p>` into a `<section>` re-resolves
+	 * from host to inline. Returning early there left the previous cleanup's
+	 * `node.remove()` as the last word and the container vanished, which is
+	 * precisely what upstream's `re-resolves the host when a persistent render call
+	 * moves` covers; that case had never been ported.
+	 */
+	/**
+	 * Re-run the hook's popover attachment whenever the resolved mount changes.
+	 *
+	 * `p.layer.attachPopover` is a stable function, so Svelte runs it once per
+	 * element and never again — but a mount change *moves* the container, and a
+	 * popover moved in the DOM leaves the top layer. The hook already knows how to
+	 * repair that (`attachPopover`'s "changing a portal target remounts the
+	 * container" branch re-shows without re-firing `onShow`); it simply never got
+	 * the chance, because nothing re-ran it. Threading the mount through gives the
+	 * attachment a new identity per mount, which is the trigger that branch needs.
+	 *
+	 * Without this, upstream's `reopens an open lazy layer after its render call
+	 * moves` fails: the layer lands in the right parent, closed.
+	 */
+	function reattachOnMount(
+		_mount: ContextLayerMount | null | undefined,
+		attach: Attachment<HTMLElement>
+	) {
+		return (node: HTMLElement) => attach(node);
+	}
+
+	function intoPortal(target: HTMLElement | null | undefined) {
+		return (node: HTMLElement) => {
+			portalHome ??= { parent: node.parentNode as Node, next: node.nextSibling };
+			if (target) {
+				target.appendChild(node);
+			} else if (node.parentNode !== portalHome.parent && portalHome.parent.isConnected) {
+				portalHome.parent.insertBefore(node, portalHome.next);
+			}
+			return () => node.remove();
+		};
+	}
 </script>
 
 <!--
-	Render as the requested tag. A `span` keeps the layer phrasing content so it
-	is valid (and stays put on hydration) inside inline contexts like a `<p>`;
-	`div` remains the default for block layers.
+	The inert marker gives the hook the layer's *real* parent without mounting
+	arbitrary children there. A `<template>` is script-supporting content, so it
+	is valid in every position a layer might be written into — including the
+	structurally restricted ones (`<tr>`, `<ul>`, `<select>`) where the eventual
+	container is not — and it renders nothing.
 -->
-<svelte:element
-	this={isFixed ? 'div' : (p.as ?? 'div')}
-	{@attach p.layer.attachPopover}
-	id={p.layer.id}
-	role={isFixed ? undefined : p.role}
-	aria-label={isFixed ? undefined : p['aria-label']}
-	popover={p.layer.lightDismiss ? 'auto' : 'manual'}
-	class={cx(p.class, attrs.class)}
-	style={mergeStyle(attrs.style, positionStyle, p.style, p.layer.fallbackStyle)}
-	onmouseenter={isFixed ? undefined : p.onmouseenter}
-	onmouseleave={isFixed ? undefined : p.onmouseleave}
->
-	{@render p.children()}
-</svelte:element>
+{#if !isFixed}
+	<template {@attach (p.layer as ContextLayerReturn).attachSentinel}></template>
+{/if}
+<!--
+	Render as the requested tag. Safe positions preserve the existing DOM order
+	and cascade; unsafe positions move to the nearest corrective portal target,
+	carrying the writing context that move would otherwise lose.
+-->
+{#if shouldRender}
+	<svelte:element
+		this={isFixed ? 'div' : (p.as ?? 'div')}
+		{@attach intoPortal(contextMount?.portalTarget)}
+		{@attach reattachOnMount(contextMount, p.layer.attachPopover)}
+		id={p.layer.id}
+		role={isFixed ? undefined : p.role}
+		aria-label={isFixed ? undefined : p['aria-label']}
+		popover={p.layer.lightDismiss ? 'auto' : 'manual'}
+		class={cx(p.class, attrs.class)}
+		style={mergeStyle(attrs.style, positionStyle, portalStyle, p.style, p.layer.fallbackStyle)}
+		onmouseenter={isFixed ? undefined : p.onmouseenter}
+		onmouseleave={isFixed ? undefined : p.onmouseleave}
+	>
+		{@render p.children()}
+	</svelte:element>
+{/if}

--- a/packages/core/src/lib/components/layer/use-layer.svelte.ts
+++ b/packages/core/src/lib/components/layer/use-layer.svelte.ts
@@ -1,5 +1,7 @@
+import { untrack } from 'svelte';
 import type { Attachment } from 'svelte/attachments';
 import { addAnchorName, readAnchorNames, removeAnchorName } from './anchor-name.js';
+import { resolveLayerPortalTarget } from './layer-host.js';
 
 /**
  * The core layer primitive, ported from Astryx's `Layer/useLayer.tsx`. Every
@@ -79,6 +81,16 @@ interface BaseLayerOptions {
 /** Options for context mode (CSS anchor positioning) */
 export interface ContextLayerOptions extends BaseLayerOptions {
 	mode: 'context';
+	/**
+	 * Defer mounting the final layer and resolving its inline/portal position
+	 * until `show()` is requested. Hiding unmounts it while the inert marker
+	 * remains at the render position. Use this when rich content must never
+	 * enter an unsafe ancestor, even briefly, and does not need to exist while
+	 * closed.
+	 *
+	 * @default false
+	 */
+	lazyMount?: boolean;
 }
 
 /** Options for fixed mode (manual positioning) */
@@ -118,8 +130,42 @@ interface LayerRenderable {
 	readonly fallbackStyle: string | undefined;
 }
 
+/**
+ * Where a context layer's container should mount, resolved from the inert
+ * marker's real position in the DOM.
+ */
+export interface ContextLayerMount {
+	/** Null means the marker's parent is safe and the layer stays inline. */
+	portalTarget: HTMLElement | null;
+	/**
+	 * Logical writing context lost when moving outside an unsafe ancestor, as a
+	 * CSS declaration string. Upstream builds a `CSSProperties` object; `<Layer>`
+	 * merges inline styles as strings, so this is the same content in the shape
+	 * this port's style pipeline consumes.
+	 */
+	portalStyle: string;
+}
+
 /** Return type for context mode */
 export interface ContextLayerReturn extends LayerRenderable {
+	/**
+	 * Attach to the inert `<template>` marker `<Layer>` renders at the layer's
+	 * real position in the template. Its parent is what decides whether the
+	 * container can stay inline or needs a corrective portal — and, because the
+	 * marker outlives the container, it also reports a move if the render call
+	 * relocates while the hook stays mounted. Upstream's `sentinelRef`.
+	 *
+	 * Typed `Attachment<HTMLElement>`, not `HTMLTemplateElement`: attachments are
+	 * contravariant in their element, so Svelte's `<template>` slot only accepts
+	 * the wider type — and nothing here reads a template-specific member.
+	 */
+	readonly attachSentinel: Attachment<HTMLElement>;
+
+	/**
+	 * Null until the marker resolves (and again after a `lazyMount` hide), which
+	 * is `<Layer>`'s signal not to render the container yet.
+	 */
+	readonly contextMount: ContextLayerMount | null;
 	/**
 	 * Attach to the trigger element. Injects this layer's anchor name for CSS
 	 * anchor positioning, and removes it again on detach. Upstream's `ref`.
@@ -162,12 +208,40 @@ export interface FixedLayerReturn extends LayerRenderable {
 }
 
 /**
+ * The two properties a corrective portal would silently change.
+ *
+ * Custom properties are deliberately NOT snapshotted: the portal target is the
+ * closest safe ancestor, so theme variables continue to inherit and update
+ * there. These two can be set on the unsafe chain itself and directly affect the
+ * logical anchor-positioning keywords the layer uses. Only values the portal
+ * would actually lose are overridden; matching values keep inheriting from the
+ * target so a later direction change stays live.
+ */
+function readPortalWritingContext(element: HTMLElement, portalTarget: HTMLElement): string {
+	const view = element.ownerDocument.defaultView;
+	if (!view) {
+		return '';
+	}
+	const sourceStyle = view.getComputedStyle(element);
+	const targetStyle = view.getComputedStyle(portalTarget);
+
+	const declarations: string[] = [];
+	if (sourceStyle.direction !== targetStyle.direction) {
+		declarations.push(`direction:${sourceStyle.direction}`);
+	}
+	if (sourceStyle.writingMode !== targetStyle.writingMode) {
+		declarations.push(`writing-mode:${sourceStyle.writingMode}`);
+	}
+	return declarations.join(';');
+}
+
+/**
  * Map logical placement/alignment to a CSS position-area value.
  *
  * Uses the self-* logical keyword family: the inline axis resolves against
- * the popover's own inherited direction (the layer renders inside the
- * trigger's subtree, so it inherits `direction` and mirrors in RTL with no
- * JS). The block axis is direction-neutral but must come from the same
+ * the popover's own direction (inherited inline, or preserved when portaled),
+ * so it mirrors in RTL without placement-specific JS. The block axis is
+ * direction-neutral but must come from the same
  * keyword family — mixing physical `top` with `self-inline-*` produces an
  * invalid position-area (computes to `none`, which pins the popover to the
  * viewport corner because the base styles zero the UA margins).
@@ -285,8 +359,28 @@ export function useLayer(
 	const anchorId = $derived(`--astryx-layer-${options().id.replace(/:/g, '')}`);
 	const lightDismiss = $derived(options().lightDismiss ?? false);
 
+	// `lazyMount` is context-only, and read reactively for the same reason
+	// upstream re-reads it every render: a consumer may flip it with a prop.
+	const lazyMount = $derived(
+		mode === 'context' ? ((options() as ContextLayerOptions).lazyMount ?? false) : false
+	);
+
 	let isOpen = $state(false);
 	let popover: HTMLElement | null = null;
+	// The element the current logical open state was applied to. A portal-target
+	// change replaces the popover element; keeping the old reference lets the
+	// attachment recognise and reopen its replacement.
+	let openedPopover: HTMLElement | null = null;
+	// The trigger, kept so `showPopover` can name it as the popover's invoker
+	// `source`. It was not needed before 0.4.2 — the anchor-name attachment does
+	// its own cleanup, so nothing else read the element.
+	let triggerEl: HTMLElement | null = null;
+	// The inert marker at the layer's real position in the template.
+	let sentinel: HTMLElement | null = null;
+	let contextMount = $state<ContextLayerMount | null>(null);
+	// A show() that arrives before the container mounts is replayed when its
+	// popover attachment runs.
+	let pendingShow = false;
 
 	// Rendered visibility for the no-Popover-API fallback; `undefined` whenever
 	// the API is present, so nothing is emitted on a supporting browser. See
@@ -294,28 +388,94 @@ export function useLayer(
 	// `popover.style.display` write.
 	let fallbackDisplay = $state<'block' | 'none' | undefined>(undefined);
 
-	function show(): void {
+	function showPopoverElement(element: HTMLElement): void {
 		// Finding infra-4: the Popover API is unsupported on Safari <17 and
 		// Firefox <125. On those browsers `showPopover` does not exist, so
 		// calling it unconditionally throws a TypeError and the layer never
 		// opens. Guard behind a feature check; when the API is missing, fall
 		// back to plain visibility (the [popover] attribute is inert there, so
 		// the element sits in normal flow) so the layer still becomes visible.
-		if (popover && !isOpen) {
-			if (typeof popover.showPopover === 'function') {
-				popover.showPopover();
-			} else {
-				fallbackDisplay = 'block';
-			}
+		if (typeof element.showPopover === 'function') {
+			// The trigger is passed as the popover's invoker `source`: a layer
+			// hosted away from its trigger then still takes its sequential focus
+			// order (and its popover nesting) from the trigger rather than from
+			// its own DOM position. Browsers without the option ignore it.
+			element.showPopover({ source: triggerEl ?? undefined });
+		} else {
+			fallbackDisplay = 'block';
+		}
+		openedPopover = element;
+	}
+
+	/**
+	 * Whether `element` is the container the *current* mount resolves to. A
+	 * context popover left over from a previous mount must not be reopened.
+	 */
+	function isCurrentContextPopover(element: HTMLElement): boolean {
+		if (mode !== 'context') {
+			return true;
+		}
+		const mount = contextMount;
+		if (mount === null) {
+			return false;
+		}
+		const expectedParent = mount.portalTarget ?? sentinel?.parentElement ?? null;
+		return element.parentElement === expectedParent;
+	}
+
+	function requestContextMount(): void {
+		if (mode !== 'context') {
+			return;
+		}
+		const inlineParent = sentinel?.parentElement ?? null;
+		if (!sentinel || !inlineParent) {
+			return;
+		}
+		const portalTarget = resolveLayerPortalTarget(inlineParent);
+		const portalStyle = portalTarget ? readPortalWritingContext(sentinel, portalTarget) : '';
+		// Bail out when the resolve lands on the mount we already have. Upstream
+		// re-sets an equal `contextMount` freely: React re-renders into the *same*
+		// `createPortal` container and no DOM moves. Here the object's identity is
+		// what `<Layer>`'s `{@attach intoPortal(...)}` is keyed on, so a new-but-equal
+		// mount tears the attachment down — running its `() => node.remove()` — and
+		// re-appends. Removing a *showing* popover evicts it from the top layer
+		// without firing `toggle`, and `attachPopover` does not re-run to re-show it,
+		// so the layer is hidden for good. Equality here makes every re-resolve that
+		// changes nothing cost nothing.
+		const current = contextMount;
+		if (current && current.portalTarget === portalTarget && current.portalStyle === portalStyle) {
+			return;
+		}
+		contextMount = { portalTarget, portalStyle };
+	}
+
+	function clearContextMount(): void {
+		if (mode !== 'context' || !lazyMount) {
+			return;
+		}
+		contextMount = null;
+	}
+
+	function show(): void {
+		const candidate = popover;
+		const element = candidate && isCurrentContextPopover(candidate) ? candidate : null;
+		if (!element) {
+			pendingShow = true;
+			requestContextMount();
+			return;
+		}
+		if (!isOpen) {
+			showPopoverElement(element);
 			isOpen = true;
 			options().onShow?.();
 		}
 	}
 
 	function hide(): void {
+		pendingShow = false;
 		if (isOpen) {
-			// See the infra-4 note in `show`: mirror the same guard on hide so
-			// unsupported browsers degrade gracefully instead of throwing.
+			// See the infra-4 note in `showPopoverElement`: mirror the same guard on
+			// hide so unsupported browsers degrade gracefully instead of throwing.
 			if (popover) {
 				if (typeof popover.hidePopover === 'function') {
 					popover.hidePopover();
@@ -323,9 +483,11 @@ export function useLayer(
 					fallbackDisplay = 'none';
 				}
 			}
+			openedPopover = null;
 			isOpen = false;
 			options().onHide?.();
 		}
+		clearContextMount();
 	}
 
 	/**
@@ -336,6 +498,7 @@ export function useLayer(
 	 */
 	const attachTrigger: Attachment<HTMLElement> = (element) => {
 		const name = anchorId;
+		triggerEl = element;
 		addAnchorName(element, name);
 
 		// `anchor-name` lives in the element's *inline style*, and that element
@@ -360,6 +523,37 @@ export function useLayer(
 		return () => {
 			observer.disconnect();
 			removeAnchorName(element, name);
+			if (triggerEl === element) {
+				triggerEl = null;
+			}
+		};
+	};
+
+	/**
+	 * The inert marker's attachment. Reading `lazyMount` is the only tracked read
+	 * here; the resolve itself runs untracked so the attachment does not
+	 * subscribe to whatever `getComputedStyle` and the options getter touch.
+	 *
+	 * `isOpen` is `$state` and must be read through `untrack`. Upstream reads
+	 * `isOpenRef.current` — a ref, which cannot schedule anything — so its
+	 * callback depends only on `[lazyMount, requestContextMount]`. Reading the
+	 * `$state` directly subscribes this attachment to it, and then opening the
+	 * layer re-runs the attachment, re-resolves the mount and moves the popover
+	 * out of the top layer mid-open. `pendingShow` is a plain `let` and is safe
+	 * either way; it is inside the `untrack` because the two are one condition.
+	 */
+	const attachSentinel: Attachment<HTMLElement> = (element) => {
+		sentinel = element;
+		if (!lazyMount || untrack(() => pendingShow || isOpen)) {
+			// The render call may have moved while the hook stayed mounted. Resolve
+			// again from the newly attached marker rather than reusing a portal
+			// target from its previous position.
+			untrack(requestContextMount);
+		}
+		return () => {
+			if (sentinel === element) {
+				sentinel = null;
+			}
 		};
 	};
 
@@ -381,12 +575,23 @@ export function useLayer(
 		const handleToggle = (event: Event) => {
 			const toggleEvent = event as ToggleEvent;
 			if (toggleEvent.newState === 'closed' && isOpen) {
+				openedPopover = null;
 				isOpen = false;
 				options().onHide?.();
+				clearContextMount();
 			}
 		};
 
 		element.addEventListener('toggle', handleToggle);
+
+		if (pendingShow) {
+			pendingShow = false;
+			untrack(show);
+		} else if (isOpen && openedPopover !== element && isCurrentContextPopover(element)) {
+			// Changing a portal target remounts the container. Preserve the logical
+			// open state without firing `onShow` again for the replacement element.
+			untrack(() => showPopoverElement(element));
+		}
 
 		return () => {
 			element.removeEventListener('toggle', handleToggle);
@@ -400,6 +605,10 @@ export function useLayer(
 		return {
 			attachTrigger,
 			attachPopover,
+			attachSentinel,
+			get contextMount() {
+				return contextMount;
+			},
 			get anchorId() {
 				return anchorId;
 			},

--- a/packages/core/src/lib/components/layer/useLayer.doc.mjs
+++ b/packages/core/src/lib/components/layer/useLayer.doc.mjs
@@ -45,6 +45,13 @@ export default {
 			description:
 				'Whether clicking outside should dismiss the layer using native popover light-dismiss behavior.',
 			default: 'false'
+		},
+		{
+			name: 'lazyMount',
+			type: 'boolean',
+			description:
+				'Context mode only. Wait until show() to resolve the inline/portal position and mount content; hide unmounts the content while the inert marker remains.',
+			default: 'false'
 		}
 	],
 	returns: [
@@ -82,7 +89,7 @@ export default {
 			name: 'render',
 			type: '(children: string | Snippet, props: ContextRenderProps | FixedRenderProps) => string | Snippet',
 			description:
-				'Render function for the popover element. Pass placement/alignment in context mode or x/y in fixed mode. Placement/alignment are logical: they map to the self-* position-area keyword family, which resolves against the popover\'s own inherited direction, so RTL contexts mirror automatically in pure CSS. Pass `positioning: "custom"` in context mode to author position styles yourself via `style` (e.g. explicit anchor() insets or an anchor-size() cover): the hook keeps the popover behavior and position-anchor wiring but derives no position styles, including the automatic RTL mirroring, which becomes your responsibility. Pass `offset` (a CSS length; a number is px) in context mode for clearance from the anchor: it applies to both edges of the placement axis, so the gap survives a flip. Layers are flush by default. In context mode, pass `as: "span"` to render an inline-safe layer (e.g. inside a paragraph). The layer renders inline in the React tree; the Popover API promotes it to the top layer when shown, so it escapes ancestor clipping and stacking without a portal. When the layer would overflow the viewport, position-try fallbacks flip it to the opposite side; centered layers additionally slide along the alignment axis (span fallbacks) so they stay on-screen near viewport edges.'
+				'Render function for the popover element. Pass placement/alignment in context mode or x/y in fixed mode. Placement/alignment are logical: they map to the self-* position-area keyword family, which resolves against the popover\'s own inherited direction, so RTL contexts mirror automatically in pure CSS. Pass `positioning: "custom"` in context mode to author position styles yourself via `style` (e.g. explicit anchor() insets or an anchor-size() cover): the hook keeps the popover behavior and position-anchor wiring but derives no position styles, including the automatic RTL mirroring, which becomes your responsibility. Pass `offset` (a CSS length; a number is px) in context mode for clearance from the anchor: it applies to both edges of the placement axis, so the gap survives a flip. Layers are flush by default. Context mode first renders an inert `<template>` marker in matching server and client markup. The final layer stays at that JSX position if its parent is safe; otherwise it is portaled to the nearest ancestor outside paragraphs, links, buttons, inline formatting, and structurally restricted containers. The nearest safe host keeps CSS custom properties inheriting live, while the layer preserves direction and writing mode from its JSX position. By default this resolution occurs after hydration so closed-layer DOM remains available; `lazyMount` defers it until `show()` and unmounts the content again on hide while the marker remains. The Popover API promotes the layer to the top layer when shown, so it escapes ancestor clipping and stacking wherever it is hosted. When the layer would overflow the viewport, position-try fallbacks flip it to the opposite side; centered layers additionally slide along the alignment axis (span fallbacks) so they stay on-screen near viewport edges.'
 		}
 	],
 	usage: {
@@ -102,7 +109,7 @@ export default {
 			{
 				guidance: true,
 				description:
-					'Rely on the Popover API top layer to escape ancestor clipping and stacking: render the layer inline (no portal) so it inherits the trigger\'s theme cascade and keeps a natural focus order. Use `as: "span"` when the layer must be valid inside inline contexts like a paragraph.'
+					"Rely on the Popover API top layer to escape ancestor clipping and stacking, and host the layer near its trigger rather than in the body so it inherits the trigger's theme cascade and keeps a natural focus order."
 			},
 			{
 				guidance: false,

--- a/packages/core/src/lib/components/lightbox/lightbox.svelte
+++ b/packages/core/src/lib/components/lightbox/lightbox.svelte
@@ -116,6 +116,7 @@
 		style: styleProp,
 		onclick: onclickProp,
 		onkeydown: onkeydownProp,
+		oncancel: oncancelProp,
 		...rest
 	}: LightboxProps = $props();
 
@@ -253,6 +254,18 @@
 	}
 
 	function handleCancel(e: Event): void {
+		// Composed, not replaced. Upstream spreads `{...props}` last, so a consumer's
+		// `onCancel` *replaces* this one and Escape silently stops calling
+		// `onOpenChange(false)` — the divergence `port/debts.md` used to record as
+		// "ours is the safer order". Destructuring the handler out and invoking it
+		// explicitly is what `CLAUDE.md` requires anyway, and it makes the rest
+		// spread's position a non-question: the consumer is heard *and* the dialog
+		// still closes.
+		oncancelProp?.(e as Event & { currentTarget: EventTarget & HTMLDialogElement });
+		if (e.defaultPrevented) {
+			// A consumer that called `preventDefault()` is pinning the dialog open.
+			return;
+		}
 		e.preventDefault();
 		handleClose();
 	}
@@ -435,7 +448,6 @@
 {#if currentItem}
 	<dialog
 		bind:this={dialogEl}
-		{...rest}
 		oncancel={handleCancel}
 		onclick={(e) => {
 			handleBackdropClick(e);
@@ -449,6 +461,7 @@
 		{...theme}
 		class={cx(theme.class, dialogAttrs.class, className)}
 		style={mergeStyle(dialogAttrs.style, styleProp as string | undefined)}
+		{...rest}
 	>
 		<div bind:this={containerEl} class={container.class} style={container.style}>
 			<IconButton

--- a/packages/core/src/lib/components/mobile-nav/mobile-nav.svelte
+++ b/packages/core/src/lib/components/mobile-nav/mobile-nav.svelte
@@ -252,13 +252,20 @@
 	<Icon icon="close" color="inherit" />
 {/snippet}
 
+<!--
+	`{...rest}` sits after the theme/class/style block and before the explicit
+	attributes, which is upstream's position exactly: a consumer's `data-*` beats
+	the theme reflection, while `aria-label`, `onclick` and `oncancel` — which this
+	component owns — beat a consumer's. `onclick` is composed rather than
+	overridden (`handleDialogClick` calls `onclickProp` first).
+-->
 <dialog
 	bind:this={dialogEl}
 	id={dialogId}
-	{...rest}
 	{...theme}
 	class={cx(theme.class, dialogAttrs.class, className)}
 	style={mergeStyle(dialogAttrs.style, styleProp as string | undefined)}
+	{...rest}
 	aria-label={label ?? (hasStringHeader ? (header as string) : t('@astryx.mobileNav.navigation'))}
 	onclick={handleDialogClick}
 	oncancel={handleCancel}

--- a/packages/core/src/lib/components/nav-item/nav-item.stylex.ts
+++ b/packages/core/src/lib/components/nav-item/nav-item.stylex.ts
@@ -33,6 +33,11 @@ import {
  *
  * `borderStyle: 'none'` and `borderWidth: 0` are written out longhand upstream,
  * not as the `border` shorthand StyleX silently drops — see port/todo.md → Phase 0.
+ *
+ * The focus ring is not defined here. Compose `focusOutlineProps.focusVisible`
+ * (`utils/focus-outline.stylex.ts`) at the call site, on whichever element
+ * actually takes focus — in a split-action row that is the link and the toggle,
+ * not the row that contains them.
  */
 
 /** Size ramp shared by every nav item. Upstream's `NavItemSize`. */
@@ -73,15 +78,36 @@ export const navItemStyles = stylex.create({
 
 	/** Selected/active page indicator — deemphasized background, medium weight */
 	selected: {
-		backgroundColor: colorVars['--color-neutral'],
+		// Forced colors flatten `--color-neutral` away, leaving the current page
+		// unmarked; Highlight/HighlightText is the platform convention, as in
+		// ToggleButton and SegmentedControlItem. No `forced-color-adjust: none`
+		// here — a nav row is not a native control, so the keywords land without
+		// it, and it would inherit into `endContent` and pin a Badge's own fill.
+		backgroundColor: {
+			default: colorVars['--color-neutral'],
+			'@media (forced-colors: active)': 'Highlight'
+		},
+		color: {
+			default: null,
+			'@media (forced-colors: active)': 'HighlightText'
+		},
 		fontWeight: fontWeightVars['--font-weight-medium'],
 		':hover': {
 			'@media (hover: hover)': {
-				backgroundColor: colorVars['--color-neutral']
+				backgroundColor: {
+					default: colorVars['--color-neutral'],
+					// Nested, not a sibling `(hover: hover) and (forced-colors: active)`
+					// block: as siblings `item`'s hover overlay ties on specificity and
+					// wins on source order, erasing the fill.
+					'@media (forced-colors: active)': 'Highlight'
+				}
 			}
 		},
 		':active': {
-			backgroundColor: colorVars['--color-neutral']
+			backgroundColor: {
+				default: colorVars['--color-neutral'],
+				'@media (forced-colors: active)': 'Highlight'
+			}
 		}
 	},
 

--- a/packages/core/src/lib/components/radio-list/radio-list-item.stylex.ts
+++ b/packages/core/src/lib/components/radio-list/radio-list-item.stylex.ts
@@ -36,7 +36,27 @@ const styles = stylex.create({
 		padding: 0,
 		opacity: 0,
 		cursor: 'pointer',
-		zIndex: 1
+		zIndex: 1,
+		minInlineSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
+		minBlockSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
+		insetBlockStart: {
+			default: null,
+			'@media (pointer: coarse)': '50%'
+		},
+		insetInlineStart: {
+			default: null,
+			'@media (pointer: coarse)': '50%'
+		},
+		transform: {
+			default: null,
+			'@media (pointer: coarse)': 'translate(-50%, -50%)'
+		}
 	},
 	inputDisabled: {
 		cursor: 'not-allowed'

--- a/packages/core/src/lib/components/side-nav/SideNav.doc.mjs
+++ b/packages/core/src/lib/components/side-nav/SideNav.doc.mjs
@@ -35,7 +35,7 @@ export default {
 			{
 				className: 'astryx-side-nav-item',
 				visualProps: ['size'],
-				states: ['selected']
+				states: ['selected', 'disabled']
 			},
 			{
 				className: 'astryx-side-nav-section'
@@ -55,6 +55,21 @@ export default {
 				guidance: true,
 				description:
 					'Pair outline and filled icon variants so the selected state is visually distinct.'
+			},
+			{
+				guidance: true,
+				description:
+					'Mark the current page with isSelected — it sets aria-current="page", so the current destination is announced rather than carried by color alone.'
+			},
+			{
+				guidance: true,
+				description:
+					'SideNav renders a navigation landmark, and a collapsible item follows the WAI-ARIA APG Disclosure pattern (https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/): the toggle carries aria-expanded and aria-controls, and the group it owns is inert while collapsed. Keep item labels short — they are the accessible name in both expanded and icon-only modes.'
+			},
+			{
+				guidance: true,
+				description:
+					'While the nav is collapsed, an item with children shows them in a submenu flyout. On a device that can hover, pointing at the item opens it after a short delay and moving away closes it; a flyout opened by clicking stays open until it is dismissed. On touch, it opens on tap. Do not put an action in there that has no other route to it.'
 			},
 			{
 				guidance: false,
@@ -108,13 +123,14 @@ export default {
 		{
 			name: 'footerIcons',
 			type: 'Snippet',
-			description: 'Footer icon bar.'
+			description:
+				"Footer icon bar. The row cascades a 'sm' size to the interactive children it contains, so its icons and the built-in collapse button come out one height; pass an explicit size on a child to opt out."
 		},
 		{
 			name: 'collapsible',
-			type: 'boolean | { defaultIsCollapsed?: boolean; isCollapsed?: boolean; onCollapsedChange?: (isCollapsed: boolean) => void; hasButton?: boolean; buttonLabel?: string; }',
+			type: 'boolean | SideNavCollapsibleConfig',
 			description:
-				'Enables collapse behavior. true for uncontrolled with default toggle button, or an object for controlled mode and advanced config (defaultIsCollapsed, isCollapsed + onCollapsedChange, hasButton, buttonLabel).',
+				'Enables collapse behavior. true for uncontrolled with default toggle button, or an object for controlled mode and advanced config (defaultIsCollapsed, isCollapsed + onCollapsedChange, hasButton, buttonLabel). A controlled config can also be passed to a SideNavCollapseButton rendered outside this SideNav, so both share one state.',
 			default: 'false'
 		},
 		{
@@ -128,7 +144,7 @@ export default {
 			name: 'handleRef',
 			type: 'SideNavImperativeCollapseHandle | null',
 			description:
-				'Imperative collapse handle for SideNavCollapseButton instances rendered outside this SideNav. Separate from `ref`, which continues to expose the root HTMLElement.'
+				'Deprecated. Imperative collapse handle for SideNavCollapseButton instances rendered outside this SideNav; hand both the same controlled collapsible config instead. Separate from `ref`, which continues to expose the root HTMLElement.'
 		},
 		{
 			name: 'xstyle',

--- a/packages/core/src/lib/components/side-nav/SideNavCollapseButton.doc.mjs
+++ b/packages/core/src/lib/components/side-nav/SideNavCollapseButton.doc.mjs
@@ -10,7 +10,7 @@ export default {
 	displayName: 'Side Nav Collapse Button',
 	subComponentOf: 'SideNav',
 	description:
-		'Toggle button for sidenav collapse. Place inside SideNav (reads context automatically) or outside (pass handleRef). Renders as an icon-only ghost button by default.',
+		'Toggle button for sidenav collapse. Place inside SideNav (reads context automatically) or outside it (hand the same controlled collapsible config to both). Renders as an icon-only ghost button by default.',
 	keywords: [
 		'sidenav',
 		'sidebar',
@@ -29,16 +29,27 @@ export default {
 	isHiddenFromOverview: true,
 	props: [
 		{
+			name: 'collapsible',
+			type: 'SideNavControlledCollapsible',
+			description:
+				'The same controlled collapsible config passed to SideNav. Only needed when the button is rendered outside the sidenav, where collapse context cannot reach it.'
+		},
+		{
 			name: 'handleRef',
 			type: 'SideNavImperativeCollapseHandle | null',
-			description:
-				'Imperative collapse handle from SideNav. Only needed when the button is rendered outside the sidenav.'
+			description: 'Deprecated. Imperative collapse handle from SideNav; pass collapsible instead.'
 		},
 		{
 			name: 'label',
 			type: 'string',
 			description:
 				'Custom button label. When provided, renders as a text button with chevron. When omitted, renders icon-only.'
+		},
+		{
+			name: 'size',
+			type: "'sm' | 'md' | 'lg'",
+			description:
+				"Button size. Defaults to the size its container cascades ('sm' inside a SideNav footer) and to 'md' with no container. Set it when the button sits outside a sized container and has to match its neighbours."
 		},
 		{
 			name: 'children',

--- a/packages/core/src/lib/components/side-nav/SideNavItem.doc.mjs
+++ b/packages/core/src/lib/components/side-nav/SideNavItem.doc.mjs
@@ -89,6 +89,12 @@ export default {
 			description:
 				'Enables collapse behavior for items with children. Pass true for uncontrolled (starts expanded), or an object for controlled mode.',
 			default: 'false'
+		},
+		{
+			name: 'size',
+			type: "'sm' | 'md' | 'lg'",
+			description: 'Size variant for the nav item row.',
+			default: "'md'"
 		}
 	]
 };

--- a/packages/core/src/lib/components/side-nav/side-nav-collapse-button.stylex.ts
+++ b/packages/core/src/lib/components/side-nav/side-nav-collapse-button.stylex.ts
@@ -1,4 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
+import { sx, type SvelteStyleAttrs } from '../../internal/sx.js';
+import { rtlStyles } from '../../utils/rtl.stylex.js';
 import { durationVars, easeVars } from '../../styles/tokens.stylex.js';
 
 /**
@@ -9,11 +11,22 @@ import { durationVars, easeVars } from '../../styles/tokens.stylex.js';
  * folds no class string at all.
  */
 const styles = stylex.create({
+	// A flex container, so the glyph is a flex item. Left to blockify as a flex
+	// item of Button's icon slot, this span gets a line box and seats the
+	// chevron on its text baseline — 2.42px above the button's centre.
+	chevronMirror: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center'
+	},
 	chevron: {
 		display: 'inline-flex',
 		alignItems: 'center',
 		transitionProperty: 'transform',
-		transitionDuration: durationVars['--duration-fast'],
+		transitionDuration: {
+			default: durationVars['--duration-fast'],
+			'@media (prefers-reduced-motion: reduce)': '0s'
+		},
 		transitionTimingFunction: easeVars['--ease-standard']
 	},
 	chevronCollapsed: {
@@ -28,3 +41,12 @@ const styles = stylex.create({
  */
 export const sideNavCollapseChevronStyle = styles.chevron;
 export const sideNavCollapseChevronCollapsedStyle = styles.chevronCollapsed;
+
+/**
+ * The mirror `<span>`, which also has to centre the glyph it wraps. One `sx()`
+ * call for both styles, matching upstream's single `stylex.props(...)` — the
+ * class oracle diffs the emitted list, so splitting it in two would not match.
+ */
+export function sideNavCollapseChevronMirrorAttrs(): SvelteStyleAttrs {
+	return sx(styles.chevronMirror, rtlStyles.mirror);
+}

--- a/packages/core/src/lib/components/side-nav/side-nav-collapse-button.svelte
+++ b/packages/core/src/lib/components/side-nav/side-nav-collapse-button.svelte
@@ -1,16 +1,28 @@
 <script lang="ts" module>
 	import type { Snippet } from 'svelte';
 	import type { BaseProps } from '../../base-props.js';
-	import type { SideNavImperativeCollapseHandle } from './side-nav-collapse-context.svelte.js';
+	import type { ElementSize } from '../../internal/contexts.svelte.js';
+	import type {
+		SideNavControlledCollapsible,
+		SideNavImperativeCollapseHandle
+	} from './side-nav-collapse-context.svelte.js';
 
 	export interface SideNavCollapseButtonProps extends BaseProps<HTMLButtonElement> {
 		/**
-		 * The imperative handle from a `SideNav`. Only needed when the button is
-		 * rendered *outside* the sidenav, where collapse context is unavailable.
+		 * The same controlled `collapsible` config given to `SideNav`
+		 * (`{isCollapsed, onCollapsedChange}`). Needed only when the button is
+		 * rendered outside the sidenav, where collapse context cannot reach it.
+		 */
+		collapsible?: SideNavControlledCollapsible;
+
+		/**
+		 * The imperative handle from a `SideNav`.
 		 *
 		 * Upstream takes a `RefObject`; Svelte has none, so this is the handle
 		 * itself — bind the `SideNav` with `bind:this` and pass it. The `Popover`
 		 * `anchorRef` translation, applied again.
+		 *
+		 * @deprecated Pass `collapsible` instead.
 		 */
 		handle?: SideNavImperativeCollapseHandle | null;
 
@@ -20,6 +32,13 @@
 		 * its source passes `isIconOnly` unconditionally, and source wins.)
 		 */
 		label?: string;
+
+		/**
+		 * Button size. Defaults to the size its container cascades — `sm` in a
+		 * `SideNav` footer — or `md` outside one. Set it for placements with no row
+		 * to inherit from, e.g. a button placed in a `TopNav`.
+		 */
+		size?: ElementSize;
 
 		/** Custom button content. Overrides the default chevron icon. */
 		children?: Snippet;
@@ -33,9 +52,9 @@
 	import Icon from '../icon/icon.svelte';
 	import {
 		sideNavCollapseChevronCollapsedStyle,
+		sideNavCollapseChevronMirrorAttrs,
 		sideNavCollapseChevronStyle
 	} from './side-nav-collapse-button.stylex.js';
-	import { rtlMirrorAttrs } from '../../utils/rtl.stylex.js';
 	import {
 		useSideNavCollapse,
 		type SideNavCollapseState
@@ -46,7 +65,8 @@
 	 *
 	 * Place it anywhere inside a `SideNav` — header, `topContent`, `footer`,
 	 * `footerIcons` — and it reads collapse state from context. To place it
-	 * outside (in a `TopNav`, say), bind the `SideNav` and pass it as `handle`.
+	 * outside (in a `TopNav`, say), hold the state yourself and hand the same
+	 * `collapsible` config to both.
 	 *
 	 * Renders nothing when collapse is not enabled, or on mobile, where the
 	 * sidebar lives in a drawer and collapsing has no meaning.
@@ -57,6 +77,26 @@
 	 *   {#snippet footerIcons()}<SideNavCollapseButton />{/snippet}
 	 * </SideNav>
 	 * ```
+	 *
+	 * Outside the sidenav, hold the state and hand the same config to both. (The
+	 * `<\/script>` escape below is only so this example can live inside a Svelte
+	 * `<script>` block — write it unescaped.)
+	 *
+	 * @example
+	 * ```svelte
+	 * <script>
+	 *   let isCollapsed = $state(false);
+	 *   const collapsible = $derived({
+	 *     isCollapsed,
+	 *     onCollapsedChange: (v) => (isCollapsed = v)
+	 *   });
+	 * <\/script>
+	 *
+	 * <TopNav>
+	 *   {#snippet endContent()}<SideNavCollapseButton {collapsible} />{/snippet}
+	 * </TopNav>
+	 * <SideNav collapsible={{ ...collapsible, hasButton: false }}>...</SideNav>
+	 * ```
 	 */
 	// `rest` is cast once where it crosses into `Button`. Our props type is
 	// `BaseProps<HTMLButtonElement>` (upstream's) while `ButtonProps` spans the
@@ -64,8 +104,10 @@
 	// type — so the two are incompatible even though the DOM agrees. Same seam,
 	// and same single-point cast, as `ListItem` → `Item`.
 	let {
+		collapsible,
 		handle,
 		label,
+		size,
 		children,
 		onclick: onclickProp,
 		...rest
@@ -75,28 +117,37 @@
 	const contextCollapse = useSideNavCollapse();
 	const appShellMobile = useAppShellMobile();
 
-	// Upstream's `useSideNavCollapseState`: context when there is no handle,
-	// otherwise the handle's live state. Note the `isCollapsible` fallback
-	// differs between the two branches — `false` from an absent context, `true`
-	// from a handle whose SideNav has not reported yet — which is what lets an
+	// Upstream's `useSideNavCollapseState`. Three sources, in priority order: the
+	// controlled `collapsible` config (0.4.2's replacement for the handle), then
+	// the deprecated handle, then context. Note the `isCollapsible` fallback
+	// differs between the branches — `false` from an absent context, `true` from
+	// a handle whose SideNav has not reported yet — which is what lets an
 	// externally-placed button render before the sidebar mounts.
-	const collapse = $derived<SideNavCollapseState>(
-		handle == null
-			? contextCollapse()
-			: {
-					isCollapsed: handle.getCollapseState()?.isCollapsed ?? false,
-					toggle: () => {
-						handle.getCollapseState()?.toggle();
-					},
-					isCollapsible: handle.getCollapseState()?.isCollapsible ?? true
-				}
-	);
+	const collapse = $derived.by<SideNavCollapseState>(() => {
+		if (collapsible != null) {
+			return {
+				isCollapsed: collapsible.isCollapsed ?? false,
+				toggle: () => collapsible.onCollapsedChange?.(!collapsible.isCollapsed),
+				isCollapsible: true
+			};
+		}
+		if (handle == null) {
+			return contextCollapse();
+		}
+		return {
+			isCollapsed: handle.getCollapseState()?.isCollapsed ?? false,
+			toggle: () => {
+				handle.getCollapseState()?.toggle();
+			},
+			isCollapsible: handle.getCollapseState()?.isCollapsible ?? true
+		};
+	});
 
 	// Hide when not collapsible, or when in mobile mode (the sidenav is in the
 	// mobile drawer — collapse doesn't apply there).
 	const isVisible = $derived(collapse.isCollapsible && !appShellMobile().isMobile);
 
-	const mirror = rtlMirrorAttrs();
+	const mirror = sideNavCollapseChevronMirrorAttrs();
 
 	// Upstream's `composeEventHandlers(onClickProp, toggle)`: the caller's handler
 	// runs first and can veto the toggle. Typed against the bare `MouseEvent` so it
@@ -143,6 +194,7 @@
 				? t('@astryx.sideNavCollapseButton.expandSidebar')
 				: t('@astryx.sideNavCollapseButton.collapseSidebar'))}
 		variant="ghost"
+		{size}
 		{...rest as Partial<ButtonProps>}
 		onclick={handleClick}
 		icon={children ?? chevron}

--- a/packages/core/src/lib/components/side-nav/side-nav-collapse-context.svelte.ts
+++ b/packages/core/src/lib/components/side-nav/side-nav-collapse-context.svelte.ts
@@ -26,6 +26,24 @@ export interface SideNavCollapseState {
 	isCollapsible: boolean;
 }
 
+/** Object form of `SideNav`'s `collapsible` prop. */
+export interface SideNavCollapsibleConfig {
+	defaultIsCollapsed?: boolean;
+	isCollapsed?: boolean;
+	onCollapsedChange?: (isCollapsed: boolean) => void;
+	hasButton?: boolean;
+	buttonLabel?: string;
+}
+
+/**
+ * The controlled form: the consumer holds the state, so it can be handed to
+ * both `SideNav` and a `SideNavCollapseButton` rendered outside it.
+ */
+export interface SideNavControlledCollapsible extends SideNavCollapsibleConfig {
+	isCollapsed: boolean;
+	onCollapsedChange: (isCollapsed: boolean) => void;
+}
+
 /**
  * The imperative handle a `SideNav` exposes for `SideNavCollapseButton`
  * instances rendered *outside* its tree, where context is unavailable.
@@ -36,6 +54,10 @@ export interface SideNavCollapseState {
  * export reached through `bind:this`, and `SideNavCollapseButton` takes the
  * handle *object* rather than a ref to one. Same translation `Popover`'s
  * `anchorRef` took: bind the thing, not a box holding it.
+ *
+ * @deprecated Pass the same controlled `collapsible` config to `SideNav` and to
+ * the out-of-tree `SideNavCollapseButton` instead. The state then reaches the
+ * button through props rather than through a handle.
  */
 export interface SideNavImperativeCollapseHandle {
 	getCollapseState: () => SideNavCollapseState | null;

--- a/packages/core/src/lib/components/side-nav/side-nav-heading.stylex.ts
+++ b/packages/core/src/lib/components/side-nav/side-nav-heading.stylex.ts
@@ -1,6 +1,7 @@
 import * as stylex from '@stylexjs/stylex';
 import { sx, type StyleArg, type SvelteStyleAttrs } from '../../internal/sx.js';
 import { navItemStyles } from '../nav-item/nav-item.stylex.js';
+import { focusOutlineProps } from '../../utils/focus-outline.stylex.js';
 import {
 	colorVars,
 	fontWeightVars,
@@ -235,7 +236,7 @@ export function sideNavHeadingRootAttrs(xstyle: StyleArg): SvelteStyleAttrs {
 
 /** The heading root when the whole block is a link or a popover trigger. */
 export function sideNavHeadingTriggerRootAttrs(xstyle: StyleArg): SvelteStyleAttrs {
-	return sx(styles.root, styles.menuTrigger, xstyle);
+	return focusOutlineProps.focusVisible(styles.root, styles.menuTrigger, xstyle);
 }
 
 /** The collapsed static heading — centred, unpadded. */
@@ -245,12 +246,25 @@ export function sideNavHeadingCollapsedRootAttrs(xstyle: StyleArg): SvelteStyleA
 
 /** The collapsed heading as a link — the shared nav item, centred. */
 export function sideNavHeadingCollapsedLinkAttrs(xstyle: StyleArg): SvelteStyleAttrs {
-	return sx(navItemStyles.item, styles.rootCollapsed, xstyle);
+	return focusOutlineProps.focusVisible(navItemStyles.item, styles.rootCollapsed, xstyle);
 }
 
 /** The collapsed heading as a menu trigger. */
 export function sideNavHeadingCollapsedTriggerAttrs(xstyle: StyleArg): SvelteStyleAttrs {
-	return sx(navItemStyles.item, styles.rootCollapsed, styles.menuTrigger, xstyle);
+	return focusOutlineProps.focusVisible(
+		navItemStyles.item,
+		styles.rootCollapsed,
+		styles.menuTrigger,
+		xstyle
+	);
+}
+
+/**
+ * The icon slot when it is a link — a separate tab stop, so it rings. The plain
+ * `sideNavHeadingIconAttrs` span below is not focusable and must not.
+ */
+export function sideNavHeadingIconLinkAttrs(): SvelteStyleAttrs {
+	return focusOutlineProps.focusVisible(styles.icon);
 }
 
 /** The icon slot. */
@@ -275,7 +289,7 @@ export function sideNavHeadingHeadingAttrs(isCompact = false): SvelteStyleAttrs 
 
 /** The heading rendered as its own link, inside the mixed-mode row. */
 export function sideNavHeadingHeadingLinkAttrs(): SvelteStyleAttrs {
-	return sx(styles.heading, styles.headingLink);
+	return focusOutlineProps.focusVisible(styles.heading, styles.headingLink);
 }
 
 /** The subheading line. */
@@ -297,7 +311,7 @@ export const sideNavHeadingChevronStyle = styles.chevron;
 
 /** The chevron as its own focusable button, inside a heading that has links. */
 export function sideNavHeadingChevronButtonAttrs(): SvelteStyleAttrs {
-	return sx(styles.chevron, styles.interactive);
+	return focusOutlineProps.focusVisible(styles.chevron, styles.interactive);
 }
 
 /**
@@ -318,7 +332,7 @@ export function sideNavHeadingPopoverContentAttrs(): SvelteStyleAttrs {
 
 /** The heading replica at the top of the popover, which closes it on click. */
 export function sideNavHeadingPopoverHeadingAttrs(): SvelteStyleAttrs {
-	return sx(styles.popoverHeading);
+	return focusOutlineProps.focusVisible(styles.popoverHeading);
 }
 
 /** The replica's chevron, flipped to point back up at the trigger. */

--- a/packages/core/src/lib/components/side-nav/side-nav-heading.svelte
+++ b/packages/core/src/lib/components/side-nav/side-nav-heading.svelte
@@ -65,6 +65,7 @@
 		sideNavHeadingHeadingAttrs,
 		sideNavHeadingHeadingLinkAttrs,
 		sideNavHeadingIconAttrs,
+		sideNavHeadingIconLinkAttrs,
 		sideNavHeadingPopover,
 		sideNavHeadingPopoverChevronStyle,
 		sideNavHeadingPopoverContentAttrs,
@@ -178,6 +179,7 @@
 	const collapsedLinkAttrs = $derived(sideNavHeadingCollapsedLinkAttrs(xstyle));
 	const collapsedTriggerAttrs = $derived(sideNavHeadingCollapsedTriggerAttrs(xstyle));
 	const iconAttrs = sideNavHeadingIconAttrs();
+	const iconLinkAttrs = sideNavHeadingIconLinkAttrs();
 	const textContainerAttrs = sideNavHeadingTextContainerAttrs();
 	const superheadingAttrs = sideNavHeadingSuperheadingAttrs();
 	const headingAttrs = sideNavHeadingHeadingAttrs();
@@ -227,8 +229,8 @@
 		href: headingHref,
 		...(linkResolved.isNative ? {} : { to: headingHref }),
 		'aria-label': heading,
-		class: iconAttrs.class,
-		style: iconAttrs.style
+		class: iconLinkAttrs.class,
+		style: iconLinkAttrs.style
 	});
 </script>
 
@@ -281,7 +283,14 @@
 {/snippet}
 
 {#snippet chevronTriggerButton()}
+	<!--
+		The hover hook's trigger attachment belongs on this chevron button, not the
+		heading root: it is the focus-restore target, and the root is a `<div>`,
+		which cannot take focus. The popover's own trigger attachment stays on the
+		root because the panel anchors to the whole heading.
+	-->
 	<button
+		{@attach menuHover.attachTrigger}
 		type="button"
 		aria-label={t('@astryx.sideNav.heading.openMenu')}
 		onclick={openMenuFromChevron}
@@ -302,7 +311,7 @@
 		type="button"
 		class={popoverHeadingAttrs.class}
 		style={popoverHeadingAttrs.style}
-		onclick={menuHover.triggerProps.onclick}
+		onclick={menuHover.close}
 	>
 		{#if icon}
 			<span class={iconAttrs.class} style={iconAttrs.style}>{@render icon()}</span>
@@ -344,9 +353,17 @@
 			</span>
 		</LinkElement>
 	{:else if menu}
+		<!--
+			Collapsed, this button is the trigger for *both* hooks, so it takes both
+			attachments — upstream's `collapsedSetRef` combines the popover ref with
+			`menu ? setTriggerEl : undefined`, and this branch only renders when `menu`
+			is set. Without the hover hook's, its `triggerEl` stays null and
+			`hideAndRestoreFocus` restores focus to nothing after a hover-open.
+		-->
 		<button
 			bind:this={collapsedItemEl}
 			{@attach popover.attachTrigger}
+			{@attach menuHover.attachTrigger}
 			type="button"
 			aria-label={heading}
 			data-testid={testId}
@@ -375,7 +392,7 @@
 					type="button"
 					class={popoverHeadingAttrs.class}
 					style={popoverHeadingAttrs.style}
-					onclick={menuHover.triggerProps.onclick}
+					onclick={menuHover.close}
 				>
 					{#if icon}
 						<span class={iconAttrs.class} style={iconAttrs.style}>{@render icon()}</span>
@@ -406,7 +423,7 @@
 				-->
 				<div role="menu" aria-label={heading}>
 					{#if menu}
-						<NavHeadingCloseScope closeMenu={popover.hide}>
+						<NavHeadingCloseScope closeMenu={menuHover.close}>
 							{@render menu()}
 						</NavHeadingCloseScope>
 					{/if}

--- a/packages/core/src/lib/components/side-nav/side-nav-item.stylex.ts
+++ b/packages/core/src/lib/components/side-nav/side-nav-item.stylex.ts
@@ -1,8 +1,8 @@
 import * as stylex from '@stylexjs/stylex';
 import { sx, type StyleArg, type SvelteStyleAttrs } from '../../internal/sx.js';
 import { navItemStyles, type NavItemSize } from '../nav-item/nav-item.stylex.js';
+import { focusOutlineProps } from '../../utils/focus-outline.stylex.js';
 import {
-	borderVars,
 	colorVars,
 	durationVars,
 	easeVars,
@@ -63,7 +63,10 @@ const styles = stylex.create({
 		display: 'grid',
 		gridTemplateRows: '1fr',
 		transitionProperty: 'grid-template-rows',
-		transitionDuration: durationVars['--duration-medium'],
+		transitionDuration: {
+			default: durationVars['--duration-medium'],
+			'@media (prefers-reduced-motion: reduce)': '0s'
+		},
 		transitionTimingFunction: easeVars['--ease-standard']
 	},
 	childrenCollapsed: {
@@ -86,7 +89,10 @@ const styles = stylex.create({
 		// target, not the glyph size, so keep the glyph on the inherited size.
 		fontSize: 'inherit',
 		transitionProperty: 'transform',
-		transitionDuration: durationVars['--duration-fast'],
+		transitionDuration: {
+			default: durationVars['--duration-fast'],
+			'@media (prefers-reduced-motion: reduce)': '0s'
+		},
 		transitionTimingFunction: easeVars['--ease-standard'],
 		flexShrink: 0
 	},
@@ -122,6 +128,7 @@ const styles = stylex.create({
 	splitAction: {
 		display: 'flex',
 		alignItems: 'center',
+		alignSelf: 'stretch',
 		gap: spacingVars['--spacing-2'],
 		flex: 1,
 		minWidth: 0,
@@ -140,14 +147,22 @@ const styles = stylex.create({
 		cursor: 'pointer'
 	},
 	// Popover surface for collapsed items with children
+	// No border and no background: `usePopover` paints the panel this renders
+	// into. Drawing a second surface here put square corners inside its rounded
+	// ones. The radius matches so a theme retargeting `--radius-container`
+	// keeps the two in step.
 	popoverSurface: {
-		borderWidth: borderVars['--border-width'],
-		borderStyle: 'solid',
-		borderColor: colorVars['--color-border'],
+		borderRadius: radiusVars['--radius-container'],
 		paddingBlock: spacingVars['--spacing-1'],
 		paddingInline: spacingVars['--spacing-1'],
-		marginInlineStart: spacingVars['--spacing-1'],
 		minWidth: 180
+	},
+	// The gap from the rail belongs on the positioned layer, where
+	// `DropdownMenu` keeps it. On the content div it insets the content instead,
+	// leaving the panel flush against the rail.
+	popoverGap: {
+		marginInlineStart: spacingVars['--spacing-1'],
+		marginInlineEnd: spacingVars['--spacing-1']
 	},
 	popoverHeader: {
 		paddingInline: spacingVars['--spacing-2'],
@@ -168,18 +183,38 @@ export function sideNavItemRootAttrs(xstyle?: StyleArg): SvelteStyleAttrs {
 	return sx(styles.root, xstyle);
 }
 
-/** The expanded row: the shared nav item with selected/disabled applied. */
+/**
+ * The expanded row: the shared nav item with selected/disabled applied.
+ *
+ * Two shapes of one appearance. On the split-action path the row is a plain
+ * `<div>` container and its *children* take focus, so the ring belongs on them
+ * and this builder must not draw it; everywhere else the row element is itself
+ * the focusable control and `sideNavItemFocusableRowAttrs` is the one to use.
+ */
 export function sideNavItemRowAttrs(
 	size: NavItemSize,
 	isSelected: boolean,
 	isDisabled: boolean
 ): SvelteStyleAttrs {
-	return sx(
+	return sx(...rowStyleArgs(size, isSelected, isDisabled));
+}
+
+function rowStyleArgs(size: NavItemSize, isSelected: boolean, isDisabled: boolean): StyleArg[] {
+	return [
 		navItemStyles.item,
 		navItemStyles[size],
 		isSelected && navItemStyles.selected,
 		isDisabled && navItemStyles.disabled
-	);
+	];
+}
+
+/** The expanded row when the row element is the focusable control. */
+export function sideNavItemFocusableRowAttrs(
+	size: NavItemSize,
+	isSelected: boolean,
+	isDisabled: boolean
+): SvelteStyleAttrs {
+	return focusOutlineProps.focusVisible(...rowStyleArgs(size, isSelected, isDisabled));
 }
 
 /** The collapsed icon-only square — a fixed width matching the size ramp. */
@@ -188,7 +223,9 @@ export function sideNavItemCollapsedAttrs(
 	isSelected: boolean,
 	isDisabled: boolean
 ): SvelteStyleAttrs {
-	return sx(
+	// All three collapsed shapes — trigger, link and button — render a focusable
+	// element, so each draws the shared ring.
+	return focusOutlineProps.focusVisible(
 		navItemStyles.item,
 		navItemStyles[size],
 		styles.itemCollapsed,
@@ -229,12 +266,12 @@ export const sideNavItemChevronExpandedStyle = styles.expandChevronExpanded;
 
 /** The chevron as its own button, in the split-action row. */
 export function sideNavItemExpandToggleAttrs(): SvelteStyleAttrs {
-	return sx(styles.expandToggle);
+	return focusOutlineProps.focusVisible(styles.expandToggle);
 }
 
 /** The primary link/button in the split-action row. */
 export function sideNavItemSplitActionAttrs(): SvelteStyleAttrs {
-	return sx(styles.splitAction);
+	return focusOutlineProps.focusVisible(styles.splitAction);
 }
 
 /** The flyout shown for a collapsed item that has children. */
@@ -246,3 +283,6 @@ export function sideNavItemPopoverSurfaceAttrs(): SvelteStyleAttrs {
 export function sideNavItemPopoverHeaderAttrs(): SvelteStyleAttrs {
 	return sx(styles.popoverHeader);
 }
+
+/** The gap from the rail, applied to the positioned layer rather than the content. */
+export const sideNavItemPopoverGapStyle = styles.popoverGap;

--- a/packages/core/src/lib/components/side-nav/side-nav-item.svelte
+++ b/packages/core/src/lib/components/side-nav/side-nav-item.svelte
@@ -75,6 +75,7 @@
 	import Icon from '../icon/icon.svelte';
 	import PopoverLayer from '../popover/popover-layer.svelte';
 	import { usePopover } from '../popover/use-popover.svelte.js';
+	import { useMenuHover } from '../../internal/use-menu-hover.svelte.js';
 	import Tooltip from '../tooltip/tooltip.svelte';
 	import NavItemElement from './nav-item-element.svelte';
 	import {
@@ -94,6 +95,8 @@
 		sideNavItemPopoverHeaderAttrs,
 		sideNavItemPopoverSurfaceAttrs,
 		sideNavItemRootAttrs,
+		sideNavItemFocusableRowAttrs,
+		sideNavItemPopoverGapStyle,
 		sideNavItemRowAttrs,
 		sideNavItemSplitActionAttrs
 	} from './side-nav-item.stylex.js';
@@ -119,12 +122,14 @@
 	 * - **Otherwise** → a single link or button; when it is collapsible without a
 	 *   primary action, clicking it toggles the children instead of navigating.
 	 *
-	 * **Rest props reach the wrapper `<div>`, where upstream drops them.**
-	 * `SideNavItemProps extends BaseProps<HTMLElement>` on both sides, but upstream
-	 * destructures a closed list with no spread, so `id`/`aria-*`/handlers — and
-	 * `xstyle`/`class`/`style` — are all discarded. We forward, as `DropdownMenu`
-	 * and `Timestamp` do. `data-testid` stays on the *item* element, which is
-	 * where upstream routes it. See port/debts.md → Known debts.
+	 * **Rest props reach the item element**, which is where upstream lands them as
+	 * of 0.4.2. Upstream destructured a closed list with no spread until then, so
+	 * `id`/`aria-*`/handlers were all discarded; this port forwarded them to the
+	 * wrapper `<div>` in the meantime, as the nearest working home. The 0.4.2
+	 * hardening pass added `...rest` to the trigger, the link and the button, and
+	 * this now matches. `xstyle`/`class`/`style` still reach the wrapper, which is
+	 * a remaining divergence — upstream's collapsed-with-children wrapper takes
+	 * neither. `data-testid` stays on the *item* element, as upstream routes it.
 	 */
 	let {
 		as,
@@ -174,7 +179,7 @@
 		hasLightDismiss: true,
 		hasAutoFocus: true,
 		hasCloseButton: false,
-		dialogLabel: `${label} submenu`
+		dialogLabel: t('@astryx.sideNavItem.submenuLabel', { label })
 	}));
 
 	// Collapse state for items with children.
@@ -199,7 +204,10 @@
 	}
 
 	const displayIcon = $derived(isSelected && selectedIcon ? selectedIcon : icon);
-	const iconColor = $derived(isSelected ? 'primary' : isDisabled ? 'disabled' : 'secondary');
+	// `inherit` so a selected row's icon follows the row to HighlightText under
+	// forced colors. Identical to `primary` otherwise: both token families are
+	// emitted from one expression.
+	const iconColor = $derived(isSelected ? 'inherit' : isDisabled ? 'disabled' : 'secondary');
 
 	// When collapsible *and* a primary action (href or onclick) are both set, the
 	// action and the toggle are independent: the label navigates, the chevron
@@ -230,43 +238,36 @@
 		toggleItemCollapse();
 	}
 
-	// Hover handlers for the collapsed popover (mirrors the TopNavMenu pattern).
-	// Plain `let`s — upstream's two refs.
-	let showTimeout: ReturnType<typeof setTimeout> | null = null;
-	let hideTimeout: ReturnType<typeof setTimeout> | null = null;
-
-	function clearPopoverTimeouts(): void {
-		if (showTimeout) {
-			clearTimeout(showTimeout);
-			showTimeout = null;
-		}
-		if (hideTimeout) {
-			clearTimeout(hideTimeout);
-			hideTimeout = null;
-		}
-	}
-
-	$effect(() => () => clearPopoverTimeouts());
-
-	function handlePopoverMouseEnter(): void {
-		clearPopoverTimeouts();
-		showTimeout = setTimeout(() => {
-			popover.show({ skipAutoFocus: true });
-		}, 150);
-	}
-
-	function handlePopoverMouseLeave(): void {
-		clearPopoverTimeouts();
-		hideTimeout = setTimeout(() => {
-			popover.hide();
-		}, 200);
-	}
+	// Pointer half only. The hook's `onkeydown`/`attachMenu` drive a `useListFocus`
+	// over `[role="menuitem"]`, and this flyout is a focus-trapped dialog of
+	// links — wiring them would swallow arrow keys rather than navigate with
+	// them. Keyboard stays with `usePopover`'s trap, as in `DropdownMenuSubMenu`.
+	const menuHover = useMenuHover(() => ({
+		show: popover.show,
+		hide: popover.hide,
+		isOpen: popover.isOpen,
+		isEnabled: isCollapsed && hasChildren,
+		// Standard popover toggling: the flyout opens beside the rail, not over
+		// the icon, so the click after a hover-open is a deliberate dismissal
+		// rather than the #3121 confirmation the nav menus need.
+		clickGuardMs: 0,
+		ownsFocus: false
+	}));
 
 	const theme = $derived(
-		themeProps('side-nav-item', { size, selected: isSelected ? 'selected' : null })
+		themeProps('side-nav-item', {
+			size,
+			selected: isSelected ? 'selected' : null,
+			disabled: isDisabled ? 'disabled' : null
+		})
 	);
 	const rootAttrs = $derived(sideNavItemRootAttrs(xstyle));
+	// Two shapes of the same row appearance: `rowAttrs` for the split-action path,
+	// where the row is a plain <div> container and its children take focus (so the
+	// ring belongs on them); `focusableRowAttrs` for every other path, where the
+	// row element is itself the focusable control.
 	const rowAttrs = $derived(sideNavItemRowAttrs(size, isSelected, isDisabled));
+	const focusableRowAttrs = $derived(sideNavItemFocusableRowAttrs(size, isSelected, isDisabled));
 	const collapsedAttrs = $derived(sideNavItemCollapsedAttrs(size, isSelected, isDisabled));
 	const labelAttrs = sideNavItemLabelAttrs();
 	const endContentAttrs = sideNavItemEndContentAttrs();
@@ -292,6 +293,11 @@
 		...theme,
 		class: cx(theme.class, rowAttrs.class),
 		style: rowAttrs.style
+	});
+	const focusableRowItemAttrs = $derived({
+		...theme,
+		class: cx(theme.class, focusableRowAttrs.class),
+		style: focusableRowAttrs.style
 	});
 </script>
 
@@ -321,18 +327,25 @@
 {#if isCollapsed && !icon}
 	<!-- In collapsed mode: hide items without icons. -->
 {:else if isCollapsed && hasChildren}
-	<!-- Collapsed, with children — an icon-only trigger and a flyout. -->
+	<!--
+		Collapsed, with children — an icon-only trigger and a flyout.
+
+		`{...rest}` sits on the trigger, not this wrapper. Upstream dropped rest
+		entirely until 0.4.2, so this port carried it on the wrapper as the nearest
+		working home; 0.4.2 landed it on the interactive element, which is where a
+		consumer's `aria-*`, `title` or handler actually belongs.
+	-->
 	<div
-		{...rest}
 		class={cx(rootAttrs.class, className)}
 		style={mergeStyle(rootAttrs.style, styleProp as string | undefined)}
 	>
 		<button
 			{@attach popover.attachTrigger}
 			type="button"
-			onclick={popover.toggle}
-			onmouseenter={handlePopoverMouseEnter}
-			onmouseleave={handlePopoverMouseLeave}
+			{...rest}
+			onclick={menuHover.triggerProps.onclick}
+			onmouseenter={menuHover.triggerProps.onmouseenter}
+			onmouseleave={menuHover.triggerProps.onmouseleave}
 			aria-label={label}
 			data-testid={testId}
 			{...popover.triggerProps}
@@ -340,12 +353,12 @@
 		>
 			{#if displayIcon}{@render iconSlot(displayIcon)}{/if}
 		</button>
-		<PopoverLayer {popover} placement="end" alignment="start">
+		<PopoverLayer {popover} placement="end" alignment="start" xstyle={sideNavItemPopoverGapStyle}>
 			<div
 				class={popoverSurfaceAttrs.class}
 				style={popoverSurfaceAttrs.style}
-				onmouseenter={handlePopoverMouseEnter}
-				onmouseleave={handlePopoverMouseLeave}
+				onmouseenter={menuHover.contentProps.onmouseenter}
+				onmouseleave={menuHover.contentProps.onmouseleave}
 				onclick={() => popover.hide()}
 			>
 				<div class={popoverHeaderAttrs.class} style={popoverHeaderAttrs.style}>{label}</div>
@@ -359,7 +372,6 @@
 	<!-- Collapsed, no children — an icon-only link/button with a tooltip. -->
 	<div
 		bind:this={itemEl}
-		{...rest}
 		class={cx(rootAttrs.class, className)}
 		style={mergeStyle(rootAttrs.style, styleProp as string | undefined)}
 	>
@@ -369,6 +381,7 @@
 			{isDisabled}
 			onclick={handleClick}
 			attrs={{
+				...rest,
 				'aria-current': isSelected ? 'page' : undefined,
 				'aria-disabled': isDisabled || undefined,
 				'aria-label': label,
@@ -383,7 +396,6 @@
 {:else}
 	<div
 		bind:this={itemEl}
-		{...rest}
 		class={cx(rootAttrs.class, className)}
 		style={mergeStyle(rootAttrs.style, styleProp as string | undefined)}
 	>
@@ -400,6 +412,7 @@
 					{isDisabled}
 					onclick={handleClick}
 					attrs={{
+						...rest,
 						'aria-current': isSelected ? 'page' : undefined,
 						class: splitActionAttrs.class,
 						style: splitActionAttrs.style
@@ -428,12 +441,13 @@
 				{isDisabled}
 				onclick={handleClick}
 				attrs={{
+					...rest,
 					'aria-current': isSelected ? 'page' : undefined,
 					'aria-disabled': isDisabled || undefined,
 					'aria-expanded': isItemCollapsible ? !isItemCollapsed : undefined,
 					'aria-controls': isItemCollapsible ? `${id}-children` : undefined,
 					'data-testid': testId,
-					...rowItemAttrs
+					...focusableRowItemAttrs
 				}}
 			>
 				{@render itemContent()}

--- a/packages/core/src/lib/components/side-nav/side-nav-section.stylex.ts
+++ b/packages/core/src/lib/components/side-nav/side-nav-section.stylex.ts
@@ -15,11 +15,10 @@ import {
  * group's `aria-labelledby` points at the title — removing it would leave the
  * group unnamed.
  *
- * That hiding is **not** StyleX on either side: upstream writes a plain inline
- * style object and merges it after `stylex.props`, so it wins over the atomic
- * classes without needing a specificity escape. {@link sideNavSectionHiddenStyle}
- * is the same declaration as a Svelte inline-style string, and it never enters
- * the class oracle.
+ * That hiding is **not** StyleX on either side, and as of upstream 0.4.2 it is
+ * not local either: both sides render the hidden branch through the shared
+ * `VisuallyHidden` component rather than a hand-rolled clip rectangle, so the
+ * treatment is maintained in one place. Nothing about it reaches this module.
  */
 const styles = stylex.create({
 	root: {
@@ -72,15 +71,6 @@ const styles = stylex.create({
 		gap: spacingVars['--spacing-0-5']
 	}
 });
-
-/**
- * Upstream's `visuallyHiddenStyle` — a plain `CSSProperties` literal merged
- * after `stylex.props`, transcribed as an inline-style string. Applied to the
- * header when the section header is hidden or the sidebar is collapsed.
- */
-export const sideNavSectionHiddenStyle =
-	'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;' +
-	'clip:rect(0, 0, 0, 0);white-space:nowrap;border-width:0';
 
 /** The section root. */
 export function sideNavSectionRootAttrs(xstyle: StyleArg): SvelteStyleAttrs {

--- a/packages/core/src/lib/components/side-nav/side-nav-section.svelte
+++ b/packages/core/src/lib/components/side-nav/side-nav-section.svelte
@@ -28,11 +28,11 @@
 <script lang="ts">
 	import { cx, mergeStyle } from '../../internal/sx.js';
 	import { themeProps } from '../../internal/theme-props.js';
+	import VisuallyHidden from '../visually-hidden/visually-hidden.svelte';
 	import { useSideNavCollapse } from './side-nav-collapse-context.svelte.js';
 	import {
 		sideNavSectionEndContentAttrs,
 		sideNavSectionHeaderAttrs,
-		sideNavSectionHiddenStyle,
 		sideNavSectionItemsAttrs,
 		sideNavSectionRootAttrs,
 		sideNavSectionSubtitleAttrs,
@@ -85,6 +85,20 @@
 	const itemsAttrs = sideNavSectionItemsAttrs();
 </script>
 
+{#snippet headerContent()}
+	<span class={titleContainerAttrs.class} style={titleContainerAttrs.style}>
+		<span id={titleId} class={titleAttrs.class} style={titleAttrs.style}>{title}</span>
+		{#if subtitle}
+			<span class={subtitleAttrs.class} style={subtitleAttrs.style}>{subtitle}</span>
+		{/if}
+	</span>
+	{#if endContent}
+		<span class={endContentAttrs.class} style={endContentAttrs.style}>
+			{@render endContent()}
+		</span>
+	{/if}
+{/snippet}
+
 <div
 	{...rest}
 	{...theme}
@@ -94,21 +108,21 @@
 	aria-labelledby={titleId}
 	data-testid={testId}
 >
-	<div
-		class={headerAttrs.class}
-		style={shouldHideHeader ? sideNavSectionHiddenStyle : headerAttrs.style}
-	>
-		<span class={titleContainerAttrs.class} style={titleContainerAttrs.style}>
-			<span id={titleId} class={titleAttrs.class} style={titleAttrs.style}>{title}</span>
-			{#if subtitle}
-				<span class={subtitleAttrs.class} style={subtitleAttrs.style}>{subtitle}</span>
-			{/if}
-		</span>
-		{#if endContent}
-			<span class={endContentAttrs.class} style={endContentAttrs.style}>
-				{@render endContent()}
-			</span>
-		{/if}
-	</div>
+	<!--
+		The hidden branch is `VisuallyHidden`, not a hand-rolled clip rectangle, as
+		of upstream 0.4.2: the shared component is the one place that treatment is
+		maintained, and the local copy had drifted from it. The two branches are
+		separate elements rather than one element with a conditional style, exactly
+		as upstream's are.
+	-->
+	{#if shouldHideHeader}
+		<VisuallyHidden as="div">
+			{@render headerContent()}
+		</VisuallyHidden>
+	{:else}
+		<div class={headerAttrs.class} style={headerAttrs.style}>
+			{@render headerContent()}
+		</div>
+	{/if}
 	<div class={itemsAttrs.class} style={itemsAttrs.style}>{@render children()}</div>
 </div>

--- a/packages/core/src/lib/components/side-nav/side-nav.svelte
+++ b/packages/core/src/lib/components/side-nav/side-nav.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
 	import type { Snippet } from 'svelte';
 	import type { BaseProps } from '../../base-props.js';
+	import type { SideNavCollapsibleConfig } from './side-nav-collapse-context.svelte.js';
 	import type { ResizableConfig } from '../resizable/use-resizable.svelte.js';
 
 	export interface SideNavProps extends BaseProps<HTMLElement> {
@@ -40,15 +41,7 @@
 		 *
 		 * @default false
 		 */
-		collapsible?:
-			| boolean
-			| {
-					defaultIsCollapsed?: boolean;
-					isCollapsed?: boolean;
-					onCollapsedChange?: (isCollapsed: boolean) => void;
-					hasButton?: boolean;
-					buttonLabel?: string;
-			  };
+		collapsible?: boolean | SideNavCollapsibleConfig;
 	}
 </script>
 
@@ -57,6 +50,7 @@
 	import { cx, mergeStyle } from '../../internal/sx.js';
 	import { themeProps } from '../../internal/theme-props.js';
 	import MobileNav from '../mobile-nav/mobile-nav.svelte';
+	import SizeScope from '../../internal/size-scope.svelte';
 	import ResizeHandle from '../resizable/resize-handle.svelte';
 	import { useResizable } from '../resizable/use-resizable.svelte.js';
 	import SideNavCollapseButton from './side-nav-collapse-button.svelte';
@@ -197,6 +191,13 @@
 	}
 
 	const showResizeHandle = $derived(isResizable && !collapsed);
+	/**
+	 * Cascaded to the icon rows through `SizeContext` so the built-in collapse
+	 * button and the consumer's `footerIcons` come out one height. An explicit
+	 * `size` on a child still wins.
+	 */
+	const FOOTER_ICON_SIZE = 'sm';
+
 	const hasDrawerFooter = $derived(!!(footer || footerIcons));
 	const hasStickyTop = $derived(!!(header || topContent));
 	const hasStickyBottom = $derived(!!(footer || footerIcons));
@@ -243,7 +244,7 @@
 			{#if footer}{@render footer()}{/if}
 			{#if footerIcons}
 				<div class={drawerFooterIconsAttrs.class} style={drawerFooterIconsAttrs.style}>
-					{@render footerIcons()}
+					<SizeScope value={FOOTER_ICON_SIZE}>{@render footerIcons()}</SizeScope>
 				</div>
 			{/if}
 		</div>
@@ -252,13 +253,13 @@
 
 {#snippet navElement()}
 	<nav
-		{...rest}
 		role="navigation"
 		aria-label={t('@astryx.sideNav.label')}
 		data-testid={testId}
 		{...theme}
 		class={cx(theme.class, rootAttrs.class, className)}
 		style={navStyle}
+		{...rest}
 	>
 		{#if hasStickyTop}
 			<div class={stickyTopAttrs.class} style={stickyTopAttrs.style}>
@@ -275,8 +276,10 @@
 			<div class={stickyBottomAttrs.class} style={stickyBottomAttrs.style}>
 				{#if footer}{@render footer()}{/if}
 				<div class={footerRowAttrs.class} style={footerRowAttrs.style}>
-					{#if showCollapseButton}<SideNavCollapseButton />{/if}
-					{#if footerIcons}{@render footerIcons()}{/if}
+					<SizeScope value={FOOTER_ICON_SIZE}>
+						{#if showCollapseButton}<SideNavCollapseButton />{/if}
+						{#if footerIcons}{@render footerIcons()}{/if}
+					</SizeScope>
 				</div>
 			</div>
 		{/if}
@@ -316,12 +319,19 @@
 	>
 		{#if header}{@render header()}{/if}
 		<div class={topbarIconsAttrs.class} style={topbarIconsAttrs.style}>
-			{#if footerIcons}{@render footerIcons()}{/if}
+			<SizeScope value={FOOTER_ICON_SIZE}>{@render footerIcons?.()}</SizeScope>
 		</div>
 	</div>
 {:else if isDrawer}
 	<!-- Drawer mode — the whole sidebar inside its own MobileNav. -->
-	<MobileNav {header} data-testid={testId}>
+	<MobileNav
+		{...rest}
+		{header}
+		data-testid={testId}
+		{xstyle}
+		class={className}
+		style={styleProp as string | undefined}
+	>
 		{#if topContent}{@render topContent()}{/if}
 		{@render children()}
 		{@render drawerFooterBlock()}

--- a/packages/core/src/lib/components/slider/slider.stylex.ts
+++ b/packages/core/src/lib/components/slider/slider.stylex.ts
@@ -23,7 +23,13 @@ import { focusOutlineStyles } from '../../utils/focus-outline.stylex.js';
  */
 
 const TRACK_SIZE = 4;
-const THUMB_SIZE = 20;
+/**
+ * Exported because the component needs the same number for its thumb-travel
+ * geometry. Upstream is one file, so it reads a module-private const; the split
+ * here means the number has to cross the module boundary rather than be written
+ * down twice.
+ */
+export const THUMB_SIZE = 20;
 
 const styles = stylex.create({
 	sliderRow: {
@@ -42,6 +48,15 @@ const styles = stylex.create({
 	},
 	trackContainerHorizontal: {
 		height: THUMB_SIZE,
+		// The whole track is the tap target (a click anywhere on it moves the
+		// slider), but it is only THUMB_SIZE (20px) tall — under the WCAG 2.5.8 AA
+		// 24px minimum. Floor its block size to 24px on touch pointers only. The
+		// rail and thumb center on 50%, so they stay put; only the invisible
+		// tappable area grows. Desktop (fine pointer) is unchanged.
+		minBlockSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
 		width: '100%',
 		cursor: 'pointer'
 	},

--- a/packages/core/src/lib/components/slider/slider.svelte
+++ b/packages/core/src/lib/components/slider/slider.svelte
@@ -2,6 +2,7 @@
 	import type { BaseProps } from '../../base-props.js';
 	import type { SizeValue } from '../../internal/types.js';
 	import type { InputStatus } from '../field/types.js';
+	import { THUMB_SIZE } from './slider.stylex.js';
 
 	/**
 	 * `onChange` is a custom callback (not forwarded to an element), so it keeps
@@ -174,6 +175,44 @@
 		}
 		return ((val - min) / (max - min)) * 100;
 	}
+
+	/**
+	 * Thumb travel is inset by half a thumb at each end — the geometry a native
+	 * `input[type=range]` uses — so the thumb stays inside the component box at
+	 * min and max instead of overhanging it by half its width (#5050). The fill
+	 * and the marks map through the same inset, and `travelFraction` inverts it,
+	 * so the thumb tracks the pointer that grabbed it. Both directions read
+	 * THUMB_SIZE, so a theme cannot resize the thumb through CSS alone.
+	 */
+	const THUMB_INSET = THUMB_SIZE / 2;
+
+	function cssLength(percent: number, px: number): string {
+		// Percentages of the box and step arithmetic both carry binary
+		// floating-point error into the DOM (`calc(33% + 3.3999999999999995px)`).
+		const round = (n: number) => Number(n.toFixed(3));
+		return `calc(${round(percent)}% ${px < 0 ? '-' : '+'} ${Math.abs(round(px))}px)`;
+	}
+
+	function insetPosition(percent: number): string {
+		return cssLength(percent, THUMB_INSET - (percent / 100) * THUMB_SIZE);
+	}
+
+	/** Distance between two inset positions; the inset itself cancels out. */
+	function insetSpan(fromPercent: number, toPercent: number): string {
+		const delta = toPercent - fromPercent;
+		return cssLength(delta, -(delta / 100) * THUMB_SIZE);
+	}
+
+	/** Inverse of `insetPosition`: an offset from the box start back to 0–1. */
+	function travelFraction(offset: number, size: number): number {
+		const travel = size - THUMB_SIZE;
+		if (travel > 0) {
+			return (offset - THUMB_INSET) / travel;
+		}
+		// Narrower than the thumb, so there is no travel to map onto: fall back to
+		// the raw fraction rather than dividing by zero.
+		return size > 0 ? offset / size : 0;
+	}
 </script>
 
 <script lang="ts">
@@ -322,17 +361,21 @@
 		}
 		const rect = track.getBoundingClientRect();
 
+		// Inverse of `insetPosition`: the pointer maps onto the thumb's travel
+		// (the box minus half a thumb at each end), so pressing on the thumb
+		// leaves it where it is instead of jumping.
 		let percent: number;
 		if (isHorizontal) {
 			// In RTL the inline-start (value = min) is the right edge, so measure
 			// the pointer fraction from the right instead of the left. Detected
 			// from the track's computed direction (lazy, only on pointer move).
-			percent = isRtlElement(track)
-				? (rect.right - clientX) / rect.width
-				: (clientX - rect.left) / rect.width;
+			percent = travelFraction(
+				isRtlElement(track) ? rect.right - clientX : clientX - rect.left,
+				rect.width
+			);
 		} else {
 			// Vertical: bottom = min, top = max
-			percent = 1 - (clientY - rect.top) / rect.height;
+			percent = 1 - travelFraction(clientY - rect.top, rect.height);
 		}
 		percent = clamp(percent, 0, 1);
 		const raw = min + percent * (max - min);
@@ -513,28 +556,32 @@
 	// The *vertical* `left: 50%` stays physical: it is a centring constant, and
 	// upstream writes it physically too.
 	const thumbInlineStart = $derived((val: number) =>
-		isHorizontal ? `${getPercent(val, min, max)}%` : null
+		isHorizontal ? insetPosition(getPercent(val, min, max)) : null
 	);
 	const thumbLeft = $derived(() => (isHorizontal ? null : '50%'));
 	const thumbBottom = $derived((val: number) =>
-		isHorizontal ? null : `${getPercent(val, min, max)}%`
+		isHorizontal ? null : insetPosition(getPercent(val, min, max))
 	);
 
 	function markPositionStyle(markValue: number): string {
-		const percent = getPercent(markValue, min, max);
-		return isHorizontal ? `inset-inline-start:${percent}%` : `bottom:${percent}%`;
+		const pos = insetPosition(getPercent(markValue, min, max));
+		return isHorizontal ? `inset-inline-start:${pos}` : `bottom:${pos}`;
 	}
 
+	// Filled track position — ends at the thumb centre, so it uses the same
+	// inset mapping as the thumb.
 	const filledStyle = $derived.by(() => {
 		if (isRange) {
 			const p0 = getPercent(values[0], min, max);
 			const p1 = getPercent(values[1], min, max);
 			return isHorizontal
-				? `inset-inline-start:${p0}%;width:${p1 - p0}%`
-				: `bottom:${p0}%;height:${p1 - p0}%`;
+				? `inset-inline-start:${insetPosition(p0)};width:${insetSpan(p0, p1)}`
+				: `bottom:${insetPosition(p0)};height:${insetSpan(p0, p1)}`;
 		}
 		const p = getPercent(values[0], min, max);
-		return isHorizontal ? `inset-inline-start:0%;width:${p}%` : `bottom:0%;height:${p}%`;
+		return isHorizontal
+			? `inset-inline-start:0%;width:${insetPosition(p)}`
+			: `bottom:0%;height:${insetPosition(p)}`;
 	});
 
 	// Suppress the per-thumb value bubble while the disabled-message tooltip is

--- a/packages/core/src/lib/components/switch/switch.stylex.ts
+++ b/packages/core/src/lib/components/switch/switch.stylex.ts
@@ -117,7 +117,27 @@ const styles = stylex.create({
 		padding: 0,
 		opacity: 0,
 		cursor: 'pointer',
-		zIndex: 1
+		zIndex: 1,
+		minInlineSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
+		minBlockSize: {
+			default: null,
+			'@media (pointer: coarse)': '24px'
+		},
+		insetBlockStart: {
+			default: null,
+			'@media (pointer: coarse)': '50%'
+		},
+		insetInlineStart: {
+			default: null,
+			'@media (pointer: coarse)': '50%'
+		},
+		transform: {
+			default: null,
+			'@media (pointer: coarse)': 'translate(-50%, -50%)'
+		}
 	},
 	inputDisabled: {
 		cursor: 'not-allowed'

--- a/packages/core/src/lib/components/switch/switch.svelte
+++ b/packages/core/src/lib/components/switch/switch.svelte
@@ -273,11 +273,14 @@
 	const trackTheme = $derived(
 		themeProps('switch', {
 			checked: isOn ? 'checked' : null,
-			disabled: isDisabled ? 'disabled' : null
+			disabled: isDisabled ? 'disabled' : null,
+			size
 		})
 	);
 	const trackAttrs = $derived(switchTrackAttrs(size, isOn, isDisabled));
-	const thumbTheme = $derived(themeProps('switch-thumb', { checked: isOn ? 'checked' : null }));
+	const thumbTheme = $derived(
+		themeProps('switch-thumb', { checked: isOn ? 'checked' : null, size })
+	);
 	const thumbAttrs = $derived(switchThumbAttrs(size, isOn));
 	const labelWrapperAttrs = $derived(switchLabelWrapperAttrs(size));
 </script>

--- a/packages/core/src/lib/components/tab-list/TabList.doc.mjs
+++ b/packages/core/src/lib/components/tab-list/TabList.doc.mjs
@@ -44,6 +44,15 @@ export default {
 			{
 				className: 'astryx-tab-menu-item'
 			}
+		],
+		vars: [
+			{
+				name: '--_tab-indicator-bottom',
+				description:
+					'Vertical offset of the selected-tab indicator from the tab bottom edge. A host that draws its own bottom divider (Toolbar) sets this so the indicator sits on the divider instead of above it.',
+				default: '-1px',
+				private: true
+			}
 		]
 	},
 	usage: {

--- a/packages/core/src/lib/components/text/Text.doc.mjs
+++ b/packages/core/src/lib/components/text/Text.doc.mjs
@@ -24,7 +24,7 @@ export default {
 		targets: [
 			{
 				className: 'astryx-heading',
-				visualProps: ['level', 'color']
+				visualProps: ['level', 'color', 'type']
 			},
 			{
 				className: 'astryx-text',

--- a/packages/core/src/lib/components/text/text.svelte
+++ b/packages/core/src/lib/components/text/text.svelte
@@ -53,7 +53,7 @@
 <script lang="ts">
 	import { cx, mergeStyle } from '../../internal/sx.js';
 	import { themeProps } from '../../internal/theme-props.js';
-	import { createTruncation } from '../../internal/truncation.svelte.js';
+	import { useTruncation } from '../../internal/truncation.svelte.js';
 	import {
 		lineClampStyle,
 		resolveStyleType,
@@ -95,7 +95,7 @@
 	const resolvedWordBreak = $derived(wordBreak ?? (maxLines === 1 ? 'break-all' : 'break-word'));
 	const resolvedDisplay = $derived(maxLines > 0 || hasCapsize ? 'block' : display);
 
-	const truncation = createTruncation(() => maxLines);
+	const truncation = useTruncation(() => maxLines);
 
 	const tooltipPlacement = $derived<LayerPlacement>(
 		typeof hasTruncateTooltip === 'string' ? hasTruncateTooltip : 'above'
@@ -136,14 +136,21 @@
 	<span class={tooltipContent.class} style={tooltipContent.style}>{truncation.fullText}</span>
 {/snippet}
 
+<!--
+	`title` before `{...rest}`, as upstream writes it before `{...props}`. The
+	order is load-bearing rather than cosmetic: `title` is `undefined` whenever the
+	text is not truncated, and a later `undefined` *removes* the attribute — so
+	spreading rest first threw away a consumer's own `title` on every untruncated
+	`Text`.
+-->
 <svelte:element
 	this={as}
 	bind:this={textEl}
-	{...rest}
 	{...theme}
 	class={cx(theme.class, attrs.class, className)}
 	style={mergeStyle(attrs.style, lineClampStyle(maxLines), styleProp as string | undefined)}
 	title={tooltipEnabled ? truncation.fullText : undefined}
+	{...rest}
 	{@attach truncation.attach}
 >
 	{@render children()}

--- a/packages/core/src/lib/components/thumbnail/Thumbnail.doc.mjs
+++ b/packages/core/src/lib/components/thumbnail/Thumbnail.doc.mjs
@@ -24,6 +24,15 @@ export default {
 			{
 				className: 'astryx-thumbnail'
 			}
+		],
+		vars: [
+			{
+				name: '--_thumbnail-hit-inset',
+				description:
+					'Outset of the remove button’s invisible hit area, applied to a ::after overlay. 0 on a fine pointer; negative on a coarse one, which grows the 20px button to the 24px touch target without changing what is drawn.',
+				default: '0px',
+				private: true
+			}
 		]
 	},
 	usage: {

--- a/packages/core/src/lib/components/thumbnail/thumbnail.stylex.ts
+++ b/packages/core/src/lib/components/thumbnail/thumbnail.stylex.ts
@@ -98,13 +98,23 @@ const styles = stylex.create({
 	},
 	removeButtonOverrides: {
 		'--_button-radius': `calc(${radiusVars['--radius-element']} - ${spacingVars['--spacing-1']})`,
+		position: 'relative',
 		height: 20,
 		minWidth: 20,
 		// Fixed colors instead of luminance-adapting theme: a translucent scrim
 		// (--color-overlay) plus an --color-on-dark icon reads on any image
 		// without sampling pixel brightness.
 		backgroundColor: colorVars['--color-overlay'],
-		color: colorVars['--color-on-dark']
+		color: colorVars['--color-on-dark'],
+		'--_thumbnail-hit-inset': {
+			default: '0px',
+			'@media (pointer: coarse)': '-2px'
+		},
+		'::after': {
+			content: '""',
+			position: 'absolute',
+			inset: 'var(--_thumbnail-hit-inset)'
+		}
 	},
 	disabled: {
 		opacity: 0.5,

--- a/packages/core/src/lib/components/timestamp/timestamp.svelte
+++ b/packages/core/src/lib/components/timestamp/timestamp.svelte
@@ -102,7 +102,7 @@
 	import { useTranslator } from '../../i18n/use-translator.svelte.js';
 	import { cx } from '../../internal/sx.js';
 	import { themeProps } from '../../internal/theme-props.js';
-	import { devWarn } from '../../utils/dev-warning.js';
+	import { useDevWarning } from '../../hooks/use-dev-warning.svelte.js';
 	import Text from '../text/text.svelte';
 	import { formatInstant } from './format-instant.js';
 	import {
@@ -235,22 +235,14 @@
 		return () => clearInterval(timer);
 	});
 
-	// Upstream's `useDevWarning('Timestamp', …)`: a ref latch inside an effect, so
-	// the warning fires at most once per mount and never during SSR. Expanded
-	// inline rather than calling our `useDevWarning`, because the message
-	// interpolates `value` and the hook takes `message` as a plain string —
-	// captured at init, it would report the mount-time value rather than the one
-	// that actually failed to parse.
-	let hasWarnedInvalidDate = false;
-	$effect(() => {
-		if (!isValidDate && !hasWarnedInvalidDate) {
-			hasWarnedInvalidDate = true;
-			devWarn(
-				'Timestamp',
-				`could not parse value ${JSON.stringify(value)} as a date. Rendering nothing.`
-			);
-		}
-	});
+	// Upstream's `useDevWarning('Timestamp', …)`, called rather than expanded: the
+	// hook's `message` takes a getter, so the interpolated value is read when the
+	// warning fires rather than captured at init. Latch and effect are the hook's.
+	useDevWarning(
+		'Timestamp',
+		() => `could not parse value ${JSON.stringify(value)} as a date. Rendering nothing.`,
+		() => !isValidDate
+	);
 
 	const attrs = timestampAttrs();
 	const theme = $derived(themeProps('timestamp', { format: effectiveFormat }));

--- a/packages/core/src/lib/components/top-nav/top-nav-heading.svelte
+++ b/packages/core/src/lib/components/top-nav/top-nav-heading.svelte
@@ -285,7 +285,14 @@
 		Stays a `<button>`: this box is the popover trigger, so it carries the
 		accessible name and the handlers — only the glyph moves to `Icon` (#4838).
 	-->
+	<!--
+		The hover hook's trigger attachment belongs on this chevron button, not the
+		heading root: it is the focus-restore target, and the root is a `<div>`,
+		which cannot take focus. The popover's own trigger attachment stays on the
+		root because the panel anchors to the whole heading.
+	-->
 	<button
+		{@attach menuHover.attachTrigger}
 		type="button"
 		aria-label={t('@astryx.topNav.heading.openMenu')}
 		onclick={openMenuFromChevron}
@@ -310,7 +317,7 @@
 		type="button"
 		class={popoverHeadingAttrs.class}
 		style={popoverHeadingAttrs.style}
-		onclick={menuHover.triggerProps.onclick}
+		onclick={menuHover.close}
 	>
 		{#if logo}
 			<span class={logoAttrs.class} style={logoAttrs.style}>{@render logo()}</span>
@@ -341,7 +348,7 @@
 			-->
 			<div role="menu" aria-label={heading ?? t('@astryx.topNav.heading.dialogLabel')}>
 				{#if menu}
-					<NavHeadingCloseScope closeMenu={popover.hide}>
+					<NavHeadingCloseScope closeMenu={menuHover.close}>
 						{@render menu()}
 					</NavHeadingCloseScope>
 				{/if}

--- a/packages/core/src/lib/components/top-nav/top-nav-mega-menu-item.stylex.ts
+++ b/packages/core/src/lib/components/top-nav/top-nav-mega-menu-item.stylex.ts
@@ -135,7 +135,7 @@ export function megaMenuItemDescriptionAttrs(): SvelteStyleAttrs {
 
 /** The drawer row — shared nav item plus the indent and top alignment. */
 export function megaMenuItemDrawerAttrs(xstyle?: StyleArg): SvelteStyleAttrs {
-	return sx(navItemStyles.item, styles.drawerItem, xstyle);
+	return focusOutlineProps.focusVisible(navItemStyles.item, styles.drawerItem, xstyle);
 }
 
 /** The 32px icon tile on the drawer row. */

--- a/packages/core/src/lib/components/top-nav/top-nav-mega-menu.stylex.ts
+++ b/packages/core/src/lib/components/top-nav/top-nav-mega-menu.stylex.ts
@@ -260,7 +260,7 @@ export function megaMenuDrawerSectionAttrs(): SvelteStyleAttrs {
 
 /** The drawer-mode disclosure header. */
 export function megaMenuDrawerHeaderAttrs(): SvelteStyleAttrs {
-	return sx(navItemStyles.item, styles.drawerHeader);
+	return focusOutlineProps.focusVisible(navItemStyles.item, styles.drawerHeader);
 }
 
 /** The drawer header's chevron, rotated while expanded. Also an `Icon` `xstyle` (#4838). */

--- a/packages/core/src/lib/components/top-nav/top-nav-mega-menu.svelte
+++ b/packages/core/src/lib/components/top-nav/top-nav-mega-menu.svelte
@@ -40,6 +40,7 @@
 	import Icon from '../icon/icon.svelte';
 	import PopoverLayer from '../popover/popover-layer.svelte';
 	import { usePopover } from '../popover/use-popover.svelte.js';
+	import { useMenuHover } from '../../internal/use-menu-hover.svelte.js';
 	import { useTopNavSlot } from './top-nav-context.svelte.js';
 	import {
 		megaMenuChevronStyle,
@@ -117,29 +118,10 @@
 	// Upstream's `mega-menu-${label.toLowerCase().replace(/\s+/g, '-')}`.
 	const drawerMenuId = $derived(`mega-menu-${label.toLowerCase().replace(/\s+/g, '-')}`);
 
-	/**
-	 * How long after a hover-open a click still counts as *confirming* that open
-	 * rather than toggling it shut. Upstream's `CLICK_GUARD_MS`.
-	 */
-	const CLICK_GUARD_MS = 500;
+	/** The panel is a grid of links, not `role="menuitem"` rows. */
+	const PANEL_ITEM_SELECTOR = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 	let triggerButton = $state<HTMLButtonElement>();
-	// Upstream reads the panel through `popover.contentRef.current`. Our
-	// `usePopover` exposes `attachContent` as an Attachment, with no ref to read,
-	// so the panel element is bound here instead. `<PopoverLayer>` renders the
-	// hidden close button *after* `children`, so the first focusable descendant is
-	// the same element from either box.
-	let panelElement = $state<HTMLDivElement>();
-	// Plain `let`s: upstream's refs, none of which drive a render.
-	let showTimeout: ReturnType<typeof setTimeout> | null = null;
-	let hideTimeout: ReturnType<typeof setTimeout> | null = null;
-	// When the current open came from hover, and whether it has been pinned.
-	// Upstream's `hoverOpenedAtRef` / `stickyRef`, which replaced the single
-	// `clickLocked` boolean: a hover open is transient, a click or keyboard open
-	// is pinned, and a click that lands inside the guard window promotes the
-	// first into the second instead of dismissing it.
-	let hoverOpenedAt = 0;
-	let sticky = false;
 
 	const popover = usePopover(() => ({
 		id: popoverId,
@@ -160,11 +142,24 @@
 		// treated as an ordinary outside interaction.
 		hasLightDismiss: true,
 		onShow: () => onOpenChange?.(true),
-		onHide: () => {
-			hoverOpenedAt = 0;
-			sticky = false;
-			onOpenChange?.(false);
-		}
+		onHide: () => onOpenChange?.(false)
+	}));
+
+	// The whole hover machine — open/hide delays, the hover→click guard, keyboard
+	// activation and focus restoration — is the shared `useMenuHover` as of 0.4.2.
+	// This component used to carry its own copy (#4555); #3121 moved that logic
+	// into the hook so every hover-opening menu behaves the same way.
+	const menuHover = useMenuHover(() => ({
+		show: popover.show,
+		hide: popover.hide,
+		isOpen: popover.isOpen,
+		isEnabled: true,
+		showDelay: delay,
+		hideDelay,
+		itemSelector: PANEL_ITEM_SELECTOR,
+		// Trigger sits outside an auto popover; the invoker relationship exempts it
+		// from light dismiss.
+		popoverId: popover.id
 	}));
 
 	// Anchor the popover to the parent <nav> (the TopNav), not to the trigger —
@@ -179,90 +174,6 @@
 		}
 		return popover.attachTrigger(nav as HTMLElement);
 	});
-
-	$effect(() => () => clearTimeouts());
-
-	function clearTimeouts(): void {
-		if (showTimeout) {
-			clearTimeout(showTimeout);
-			showTimeout = null;
-		}
-		if (hideTimeout) {
-			clearTimeout(hideTimeout);
-			hideTimeout = null;
-		}
-	}
-
-	function scheduleShow(): void {
-		clearTimeouts();
-		showTimeout = setTimeout(() => {
-			hoverOpenedAt = Date.now();
-			popover.show({ skipAutoFocus: true });
-		}, delay);
-	}
-
-	function scheduleHide(): void {
-		clearTimeouts();
-		hideTimeout = setTimeout(() => {
-			popover.hide();
-		}, hideDelay);
-	}
-
-	function focusFirstPanelItem(): void {
-		panelElement
-			?.querySelector<HTMLElement>(
-				'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
-			)
-			?.focus();
-	}
-
-	function handleTriggerMouseEnter(): void {
-		clearTimeouts();
-		if (!popover.isOpen) {
-			scheduleShow();
-		}
-	}
-
-	function handlePanelMouseEnter(): void {
-		clearTimeouts();
-	}
-
-	function handleMouseLeave(): void {
-		if (!sticky) {
-			scheduleHide();
-		}
-	}
-
-	function handleClick(event: MouseEvent): void {
-		// Cancel the native invoker toggle so this guard is the single source of
-		// truth for trigger activation. `popovertarget` still establishes the
-		// invoker relationship used by native light dismiss and stacking.
-		event.preventDefault();
-		clearTimeouts();
-
-		if (event.detail === 0) {
-			// Keyboard activation: pin, and move focus into the panel.
-			sticky = true;
-			hoverOpenedAt = 0;
-			if (popover.isOpen) {
-				focusFirstPanelItem();
-			} else {
-				popover.show();
-			}
-		} else if (!popover.isOpen) {
-			sticky = true;
-			popover.show({ skipAutoFocus: true });
-		} else if (Date.now() - hoverOpenedAt < CLICK_GUARD_MS) {
-			// A click that naturally follows a hover-open confirms the open state
-			// instead of toggling the panel shut. From here it behaves like any
-			// other click-open and stays pinned until explicit dismissal.
-			sticky = true;
-			hoverOpenedAt = 0;
-		} else {
-			popover.hide();
-			triggerButton?.focus();
-		}
-	}
 
 	const theme = themeProps('top-nav-mega-menu');
 	const drawerTheme = themeProps('top-nav-mega-menu', { mode: 'drawer' });
@@ -323,12 +234,10 @@
 	<button
 		{...rest}
 		bind:this={triggerButton}
+		{@attach menuHover.attachTrigger}
 		type="button"
 		{...popover.triggerProps}
-		popovertarget={popover.id}
-		onclick={handleClick}
-		onmouseenter={handleTriggerMouseEnter}
-		onmouseleave={handleMouseLeave}
+		{...menuHover.triggerProps}
 		{...theme}
 		class={cx(theme.class, triggerAttrs.class, className)}
 		style={mergeStyle(triggerAttrs.style, styleProp as string | undefined)}
@@ -355,11 +264,12 @@
 			which is what 0.1.9 corrected.
 		-->
 		<div
-			bind:this={panelElement}
+			{@attach menuHover.attachMenu}
 			role="group"
 			aria-label={label}
-			onmouseenter={handlePanelMouseEnter}
-			onmouseleave={handleMouseLeave}
+			onmouseenter={menuHover.contentProps.onmouseenter}
+			onmouseleave={menuHover.contentProps.onmouseleave}
+			onkeydown={menuHover.contentProps.onkeydown}
 			class={panelContainerAttrs.class}
 			style={panelContainerAttrs.style}
 		>

--- a/packages/core/src/lib/components/top-nav/top-nav-menu.stylex.ts
+++ b/packages/core/src/lib/components/top-nav/top-nav-menu.stylex.ts
@@ -250,7 +250,7 @@ export function topNavMenuDrawerSectionAttrs(): SvelteStyleAttrs {
 
 /** The drawer-mode disclosure header — a nav item that also justifies apart. */
 export function topNavMenuDrawerHeaderAttrs(): SvelteStyleAttrs {
-	return sx(navItemStyles.item, drawerStyles.header);
+	return focusOutlineProps.focusVisible(navItemStyles.item, drawerStyles.header);
 }
 
 /** The drawer header's chevron, rotated while expanded. Also an `Icon` `xstyle` (#4838). */
@@ -270,7 +270,7 @@ export function topNavMenuDrawerItemsInnerAttrs(): SvelteStyleAttrs {
 
 /** A drawer-mode row — the shared nav item plus this menu's indent. */
 export function topNavMenuDrawerItemAttrs(): SvelteStyleAttrs {
-	return sx(navItemStyles.item, drawerStyles.item);
+	return focusOutlineProps.focusVisible(navItemStyles.item, drawerStyles.item);
 }
 
 /** The 20px icon slot on a drawer row. */

--- a/packages/core/src/lib/components/top-nav/top-nav-menu.svelte
+++ b/packages/core/src/lib/components/top-nav/top-nav-menu.svelte
@@ -131,7 +131,10 @@
 		isOpen: popover.isOpen,
 		isEnabled: true,
 		showDelay: delay,
-		hideDelay
+		hideDelay,
+		// Trigger sits outside an auto popover; the invoker relationship exempts
+		// it from light dismiss.
+		popoverId: popover.id
 	}));
 
 	// The desktop popup is a composite menu widget per the APG menu pattern: a
@@ -142,7 +145,8 @@
 	const list = useListFocus(() => ({
 		itemSelector: '[role="menuitem"]',
 		hasRovingTabIndex: true,
-		onEscape: popover.hide
+		// Not popover.hide: Escape must also restore focus to the trigger.
+		onEscape: menuHover.close
 	}));
 
 	// Upstream reads `listRef.current` for the typeahead's item list, which is the
@@ -264,8 +268,10 @@
 	<button
 		{...rest}
 		{@attach popover.attachTrigger}
+		{@attach menuHover.attachTrigger}
 		type="button"
 		{...popover.triggerProps}
+		popovertarget={menuHover.triggerProps.popovertarget}
 		onclick={menuHover.triggerProps.onclick}
 		onmouseenter={menuHover.triggerProps.onmouseenter}
 		onmouseleave={menuHover.triggerProps.onmouseleave}

--- a/packages/core/src/lib/components/top-nav/top-nav.svelte
+++ b/packages/core/src/lib/components/top-nav/top-nav.svelte
@@ -142,12 +142,12 @@
 		Mobile bar mode — heading + endContent + toggle, nav items hidden.
 	-->
 	<nav
-		{...rest}
 		role="navigation"
 		aria-label={label}
 		{...mobileBarTheme}
 		class={cx(mobileBarTheme.class, mobileBarAttrs.class, className)}
 		style={mergeStyle(mobileBarAttrs.style, styleProp as string | undefined)}
+		{...rest}
 	>
 		{#if heading}
 			<div class={headingSlotAttrs.class} style={headingSlotAttrs.style}>{@render heading()}</div>
@@ -187,12 +187,12 @@
 {:else}
 	<!-- Default mode — the full top bar -->
 	<nav
-		{...rest}
 		role="navigation"
 		aria-label={label}
 		{...theme}
 		class={cx(theme.class, rootAttrs.class, className)}
 		style={mergeStyle(rootAttrs.style, styleProp as string | undefined)}
+		{...rest}
 	>
 		<div class={leftSectionAttrs.class} style={leftSectionAttrs.style}>
 			{#if heading}

--- a/packages/core/src/lib/components/tree-list/TreeList.doc.mjs
+++ b/packages/core/src/lib/components/tree-list/TreeList.doc.mjs
@@ -56,6 +56,13 @@ export default {
 				description:
 					'Vertical gap between adjacent rows. Default `2px` (var(--spacing-0-5)) gives a subtle separation; set it on the `tree-list` target to widen or close the gap. The connector guides span the gap automatically (the line stays continuous) and do not overhang the last row, so no guide-height tuning is needed.',
 				default: 'var(--spacing-0-5)'
+			},
+			{
+				name: '--_tree-indent',
+				description:
+					'Distance one row is indented, computed per row from --tree-list-indent and the row depth. Set --tree-list-indent to retune indentation; this is the resolved value.',
+				default: '0px',
+				private: true
 			}
 		]
 	},

--- a/packages/core/src/lib/components/tree-list/tree-list-item.svelte
+++ b/packages/core/src/lib/components/tree-list/tree-list-item.svelte
@@ -19,6 +19,12 @@
 		isDisabled?: boolean;
 		isSelected?: boolean;
 		hasChildren: boolean;
+		/**
+		 * Whether the tree has any expandable item at all. A leaf only reserves the
+		 * chevron column when some sibling can actually show a chevron — a wholly
+		 * flat tree sits flush against the edge.
+		 */
+		hasExpandableItems: boolean;
 		nestedLevel: number;
 		isLast: boolean;
 		ancestorsIsLast: ReadonlyArray<boolean>;
@@ -86,6 +92,7 @@
 		isDisabled = false,
 		isSelected = false,
 		hasChildren,
+		hasExpandableItems,
 		nestedLevel,
 		isLast,
 		ancestorsIsLast,
@@ -135,10 +142,11 @@
 	// with the lever. Published as the private `--_tree-indent` and consumed by
 	// `contentWrapper`'s stylesheet `margin-inline-start` (kept out of the inline
 	// style so the theme layer can override it — see upstream #4308).
+	const reservesChevronColumn = $derived(!hasChildren && hasExpandableItems);
 	const indentDistance = $derived(
-		hasChildren
-			? `calc(${nestedLevel} * var(--tree-list-indent))`
-			: `calc(${nestedLevel} * var(--tree-list-indent) + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`
+		reservesChevronColumn
+			? `calc(${nestedLevel} * var(--tree-list-indent) + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`
+			: `calc(${nestedLevel} * var(--tree-list-indent))`
 	);
 
 	const theme = $derived(

--- a/packages/core/src/lib/components/tree-list/tree-list.svelte
+++ b/packages/core/src/lib/components/tree-list/tree-list.svelte
@@ -154,6 +154,15 @@
 	// the hook's repair pass preserves that seeded `tabindex="0"`.
 	const initialTabbableId = $derived(findInitialTabbableId(items));
 
+	// Whether any *top-level* item can expand. Upstream computes it exactly this
+	// way — `items.some(...)` on the prop, outside `renderItems`, which shadows the
+	// name during recursion — so a tree whose only expandable item is nested deep
+	// does not reserve the column. Leaves consult it to decide whether to hold a
+	// chevron-width gutter open; a wholly flat tree holds none.
+	const hasExpandableItems = $derived(
+		items.some((item) => item.children != null && item.children.length > 0)
+	);
+
 	/**
 	 * Enter/Space activation: prefer the treeitem's own inner action (link or
 	 * button); return true when handled so the hook does not also toggle. Scoped
@@ -211,6 +220,7 @@
 			startContent={item.startContent}
 			endContent={item.endContent}
 			{hasChildren}
+			{hasExpandableItems}
 			onClick={item.onClick}
 			href={item.href}
 			target={item.target}

--- a/packages/core/src/lib/hooks/container-reveal.stylex.ts
+++ b/packages/core/src/lib/hooks/container-reveal.stylex.ts
@@ -2,9 +2,10 @@ import * as stylex from '@stylexjs/stylex';
 import { durationVars, easeVars } from '../styles/tokens.stylex.js';
 
 /**
- * The container style that publishes the reveal state, and the four content
- * style blocks (reveal / conceal, each with a layout-preserved variant) that
- * read it. Ported from Astryx's `hooks/containerReveal.stylex.ts`.
+ * The container style that publishes the reveal state, the suspended and
+ * hover-delay container variants, and the four content style blocks (reveal /
+ * conceal, each with a layout-preserved variant) that read it. Ported from
+ * Astryx's `hooks/containerReveal.stylex.ts`.
  *
  * HOW THE SCOPING WORKS: the container declares its own reveal state as
  * inherited custom properties on itself, and content reads them. Because a
@@ -28,8 +29,14 @@ import { durationVars, easeVars } from '../styles/tokens.stylex.js';
 
 const REST_DELAY = '0s, ' + durationVars['--duration-fast'];
 
+// The hover-intent gate: how long the pointer must dwell before the hover
+// branch takes effect. Declared on every container so a nested one never
+// inherits its ancestor's dwell.
+const HOVER_DELAY = 'var(--_hover-delay, 0s)';
+
 export const styles = stylex.create({
 	container: {
+		'--_hover-delay': '0s',
 		'--_reveal-opacity': {
 			default: 0,
 			':hover': { '@media (hover: hover)': 1 },
@@ -43,13 +50,21 @@ export const styles = stylex.create({
 			'@media (any-pointer: coarse)': 'static'
 		},
 		// The position flip is discrete, so it transitions with allow-discrete and
-		// a state-conditional delay: 0 on entry (flips into flow immediately, then
-		// fades in) and the fade duration on exit (stays in flow until the fade
-		// finishes, then snaps out) — without this the exit would snap out of flow
-		// at full opacity and flicker.
+		// a state-conditional delay: the dwell on entry (flips into flow when the
+		// gate opens, then fades in) and the fade duration on exit (stays in flow
+		// until the fade finishes, then snaps out) — without the exit half the
+		// content would snap out of flow at full opacity and flicker.
 		'--_reveal-delay': {
 			default: REST_DELAY,
-			':hover': { '@media (hover: hover)': '0s, 0s' },
+			':hover': { '@media (hover: hover)': HOVER_DELAY + ', ' + HOVER_DELAY },
+			':focus-within': '0s, 0s',
+			'@media (any-pointer: coarse)': '0s, 0s'
+		},
+		// Reduced motion drops the exit sequencing (there is no fade left to wait
+		// for) but keeps the dwell: an intent gate is timing, not motion.
+		'--_reveal-delay-reduced': {
+			default: '0s, 0s',
+			':hover': { '@media (hover: hover)': HOVER_DELAY + ', ' + HOVER_DELAY },
 			':focus-within': '0s, 0s',
 			'@media (any-pointer: coarse)': '0s, 0s'
 		},
@@ -59,8 +74,99 @@ export const styles = stylex.create({
 		'--_conceal-opacity': {
 			default: 1,
 			':hover': { '@media (hover: hover)': 0 }
+		},
+		// Single-value dwell for the opacity-only blocks, which have no discrete
+		// position to sequence.
+		'--_fade-delay': {
+			default: '0s',
+			':hover': { '@media (hover: hover)': HOVER_DELAY },
+			':focus-within': '0s',
+			'@media (any-pointer: coarse)': '0s'
 		}
 	},
+	// stateInactive is `container` with the hover branch pinned to its rest
+	// value, so the pointer stops driving the reveal while a caller holds the
+	// container inactive. Keyboard focus and coarse pointers keep their branches:
+	// an inactive container must never hide content from a keyboard or touch
+	// user. Every property repeats the full condition shape of `container` —
+	// StyleX replaces styles per property AND condition, so a plain `default`
+	// here would lose to the earlier block's `:hover` rule.
+	stateInactive: {
+		'--_reveal-opacity': {
+			default: 0,
+			':hover': { '@media (hover: hover)': 0 },
+			':focus-within': 1,
+			'@media (any-pointer: coarse)': 1
+		},
+		'--_reveal-position': {
+			default: 'absolute',
+			':hover': { '@media (hover: hover)': 'absolute' },
+			':focus-within': 'static',
+			'@media (any-pointer: coarse)': 'static'
+		},
+		'--_reveal-delay': {
+			default: REST_DELAY,
+			':hover': { '@media (hover: hover)': REST_DELAY },
+			':focus-within': '0s, 0s',
+			'@media (any-pointer: coarse)': '0s, 0s'
+		},
+		'--_reveal-delay-reduced': {
+			default: '0s, 0s',
+			':hover': { '@media (hover: hover)': '0s, 0s' },
+			':focus-within': '0s, 0s',
+			'@media (any-pointer: coarse)': '0s, 0s'
+		},
+		'--_conceal-opacity': {
+			default: 1,
+			':hover': { '@media (hover: hover)': 1 }
+		},
+		'--_fade-delay': {
+			default: '0s',
+			':hover': { '@media (hover: hover)': '0s' },
+			':focus-within': '0s',
+			'@media (any-pointer: coarse)': '0s'
+		}
+	},
+	// stateActive pins the other end: every branch reads as pointed-at, so
+	// revealed content stays in and inverted content stays out, with no dwell to
+	// wait through.
+	stateActive: {
+		'--_reveal-opacity': {
+			default: 1,
+			':hover': { '@media (hover: hover)': 1 },
+			':focus-within': 1,
+			'@media (any-pointer: coarse)': 1
+		},
+		'--_reveal-position': {
+			default: 'static',
+			':hover': { '@media (hover: hover)': 'static' },
+			':focus-within': 'static',
+			'@media (any-pointer: coarse)': 'static'
+		},
+		'--_reveal-delay': {
+			default: '0s, 0s',
+			':hover': { '@media (hover: hover)': '0s, 0s' },
+			':focus-within': '0s, 0s',
+			'@media (any-pointer: coarse)': '0s, 0s'
+		},
+		'--_reveal-delay-reduced': {
+			default: '0s, 0s',
+			':hover': { '@media (hover: hover)': '0s, 0s' },
+			':focus-within': '0s, 0s',
+			'@media (any-pointer: coarse)': '0s, 0s'
+		},
+		'--_conceal-opacity': {
+			default: 0,
+			':hover': { '@media (hover: hover)': 0 }
+		},
+		'--_fade-delay': {
+			default: '0s',
+			':hover': { '@media (hover: hover)': '0s' },
+			':focus-within': '0s',
+			'@media (any-pointer: coarse)': '0s'
+		}
+	},
+	hoverDelay: (delay: string) => ({ '--_hover-delay': delay }),
 	// The fallbacks make content spread outside a reveal container fail visible
 	// rather than invisible.
 	reveal: {
@@ -73,7 +179,7 @@ export const styles = stylex.create({
 		transitionBehavior: 'allow-discrete',
 		transitionDelay: {
 			default: 'var(--_reveal-delay, 0s, 0s)',
-			'@media (prefers-reduced-motion: reduce)': '0s, 0s'
+			'@media (prefers-reduced-motion: reduce)': 'var(--_reveal-delay-reduced, 0s, 0s)'
 		},
 		opacity: 'var(--_reveal-opacity, 1)',
 		position: 'var(--_reveal-position, static)'
@@ -85,6 +191,7 @@ export const styles = stylex.create({
 			'@media (prefers-reduced-motion: reduce)': '0s'
 		},
 		transitionTimingFunction: easeVars['--ease-standard'],
+		transitionDelay: 'var(--_fade-delay, 0s)',
 		opacity: 'var(--_reveal-opacity, 1)'
 	},
 	conceal: {
@@ -94,6 +201,7 @@ export const styles = stylex.create({
 			'@media (prefers-reduced-motion: reduce)': '0s'
 		},
 		transitionTimingFunction: easeVars['--ease-standard'],
+		transitionDelay: 'var(--_fade-delay, 0s)',
 		opacity: 'var(--_conceal-opacity, 1)'
 	},
 	concealLayoutPreserved: {
@@ -103,6 +211,29 @@ export const styles = stylex.create({
 			'@media (prefers-reduced-motion: reduce)': '0s'
 		},
 		transitionTimingFunction: easeVars['--ease-standard'],
+		transitionDelay: 'var(--_fade-delay, 0s)',
 		opacity: 'var(--_conceal-opacity, 1)'
+	},
+	// Per-element overrides. These read no container state at all — they are the
+	// caller saying what THIS element looks like, whatever the container is
+	// doing, so they are plain values rather than custom properties.
+	contentShown: {
+		opacity: 1,
+		position: 'static',
+		transitionDelay: '0s'
+	},
+	// Hidden yields to focus: a forced-hidden element is still mounted and still
+	// tabbable, so it has to reappear when focus lands inside it — otherwise a
+	// keyboard user tabs into something they cannot see.
+	contentHidden: {
+		opacity: { default: 0, ':focus-within': 1 },
+		position: { default: 'absolute', ':focus-within': 'static' },
+		transitionDelay: '0s'
+	},
+	// Layout-preserved content has no discrete position to flip, so its hidden
+	// variant is opacity alone.
+	contentHiddenLayoutPreserved: {
+		opacity: { default: 0, ':focus-within': 1 },
+		transitionDelay: '0s'
 	}
 });

--- a/packages/core/src/lib/hooks/index.ts
+++ b/packages/core/src/lib/hooks/index.ts
@@ -27,6 +27,7 @@ export {
 // (`POOL`, `POOL_SIZE`, `m0`…`m5`, `RevealSlot`), all equally internal.
 export {
 	useContainerReveal,
+	type ContainerRevealOptions,
 	type ContentRevealOptions,
 	type UseContainerRevealOptions,
 	type UseContainerRevealReturn
@@ -36,10 +37,12 @@ export { useDevWarning } from './use-dev-warning.svelte.js';
 
 export { useEntryAnimation, type EntryAnimationPreset } from './use-entry-animation.js';
 
-// `hasActiveFocusTrapEscape` and `isImeKeyEvent` are deliberately absent, as
-// they are from upstream's barrel: Dialog is their only consumer and imports
-// them from the module directly.
+// `hasActiveFocusTrapEscape` and `isImeKeyEvent` joined upstream's barrel at
+// 0.4.2 (#5023): they coordinate nested traps and skip IME composition keys, so
+// an overlay outside this package needs them too.
 export {
+	hasActiveFocusTrapEscape,
+	isImeKeyEvent,
 	useFocusTrap,
 	type UseFocusTrapOptions,
 	type UseFocusTrapReturn

--- a/packages/core/src/lib/hooks/use-container-reveal.svelte.ts
+++ b/packages/core/src/lib/hooks/use-container-reveal.svelte.ts
@@ -21,10 +21,21 @@ import { styles } from './container-reveal.stylex.js';
  * `isEnabled` takes effect **after mount** — it is read on every call rather
  * than deciding a one-time slot claim.
  *
+ * Two levers sit on top of the pointer, both still CSS-only. On the container:
+ * `hoverDelay` (dwell before the reveal starts — the Tooltip / HoverCard intent
+ * gate applied to a reveal) and `forceState` (pin the trigger state a caller
+ * owns: a motion gate, a scroll, an open menu). On a single piece of content:
+ * `forceVisibility`, which pins how THAT element looks. State belongs to the
+ * container because one container feeds children whose looks are opposite;
+ * appearance belongs to the element, where it is unambiguous. Neither lever can
+ * hide content from a keyboard user — see ACCESSIBILITY.
+ *
  * ACCESSIBILITY (WCAG 2.2 by construction):
  * - Revealed content is visually hidden at rest via position + opacity, so it
  *   stays in the accessibility tree and tab order — never `display: none`.
- * - Keyboard: revealed on `:focus-within`, so tabbing in shows it.
+ * - Keyboard: revealed on `:focus-within`, so tabbing in shows it — with no
+ *   dwell to wait through, and neither an inactive container nor a forced-hidden
+ *   element can keep it dark.
  * - Touch: always visible on coarse pointers; never gated behind hover.
  * - Concealed (inverted) content is a mouse-only visual swap: it ignores
  *   `:focus-within` (a keyboard user must never watch content vanish) and stays
@@ -42,6 +53,36 @@ export interface UseContainerRevealOptions {
 	isEnabled?: boolean;
 }
 
+export interface ContainerRevealOptions {
+	/**
+	 * Pin the container's trigger state instead of letting the pointer drive it.
+	 * `'active'` reads as pointed-at and `'inactive'` as at rest; omit it — the
+	 * default — to leave the container on hover and focus.
+	 *
+	 * State, not appearance: what each child then looks like is the child's own
+	 * business (revealed content fades in on `'active'`, inverted content fades
+	 * out). This is the lever for state a caller owns — a motion gate over a
+	 * list, a scroll in progress, a row whose menu is open and must stay lit.
+	 *
+	 * `'inactive'` never overrides keyboard focus or a coarse pointer: the
+	 * container still reveals on `:focus-within` and stays revealed on touch, so
+	 * it cannot hide content from a keyboard or touch user.
+	 */
+	forceState?: 'active' | 'inactive';
+	/**
+	 * Hover-intent gate, in milliseconds: how long the pointer must rest on the
+	 * container before the reveal starts. A pointer that passes through leaves
+	 * nothing painted behind it, which is what keeps a list of rows quiet while
+	 * the cursor sweeps across it.
+	 *
+	 * Mouse-only, like `Tooltip`'s and `HoverCard`'s `delay`: keyboard focus and
+	 * touch reveal immediately. It survives `prefers-reduced-motion` — an intent
+	 * gate is timing, not motion.
+	 * @default 0
+	 */
+	hoverDelay?: number;
+}
+
 export interface ContentRevealOptions {
 	/**
 	 * Conceal-on-hover instead of reveal-on-hover: content is visible at rest
@@ -56,11 +97,24 @@ export interface ContentRevealOptions {
 	 * @default false
 	 */
 	isLayoutPreserved?: boolean;
+	/**
+	 * Pin THIS element's appearance, whatever the container's state: `'shown'`
+	 * keeps it visible, `'hidden'` keeps it out. Omit it — the default — to
+	 * follow the container.
+	 *
+	 * Appearance, not state: it says how one element looks, so it is unambiguous
+	 * where the container's `forceState` cannot be (a container feeds revealed
+	 * and inverted children at once).
+	 *
+	 * `'hidden'` yields to focus — a forced-hidden element is still mounted and
+	 * tabbable, so it reappears when focus lands inside it.
+	 */
+	forceVisibility?: 'shown' | 'hidden';
 }
 
 export interface UseContainerRevealReturn {
 	/** Spread onto the container whose hover/focus-within drives the reveal. */
-	getContainerProps: () => { class?: string; style?: string };
+	getContainerProps: (options?: ContainerRevealOptions) => { class?: string; style?: string };
 	/** Spread onto each revealed / concealed child. */
 	getContentRevealProps: (options?: ContentRevealOptions) => { class?: string; style?: string };
 }
@@ -80,7 +134,7 @@ const EMPTY = Object.freeze({});
  * ```svelte
  * <script lang="ts">
  *   const reveal = useContainerReveal(() => ({ isEnabled: revealOn === 'hover' }));
- *   const container = $derived(reveal.getContainerProps());
+ *   const container = $derived(reveal.getContainerProps({ hoverDelay: 120 }));
  *   const actions = $derived(reveal.getContentRevealProps());
  * </script>
  *
@@ -94,17 +148,27 @@ export function useContainerReveal(
 	options: () => UseContainerRevealOptions = () => ({})
 ): UseContainerRevealReturn {
 	return {
-		getContainerProps: () => {
+		getContainerProps: (containerOptions: ContainerRevealOptions = {}) => {
 			if (options().isEnabled === false) {
 				return EMPTY;
 			}
-			return sx(styles.container);
+			const { forceState, hoverDelay = 0 } = containerOptions;
+			return sx(
+				styles.container,
+				hoverDelay > 0 && styles.hoverDelay(`${hoverDelay}ms`),
+				forceState === 'inactive' && styles.stateInactive,
+				forceState === 'active' && styles.stateActive
+			);
 		},
 		getContentRevealProps: (contentOptions: ContentRevealOptions = {}) => {
 			if (options().isEnabled === false) {
 				return EMPTY;
 			}
-			const { isRevealInverted = false, isLayoutPreserved = false } = contentOptions;
+			const {
+				isRevealInverted = false,
+				isLayoutPreserved = false,
+				forceVisibility
+			} = contentOptions;
 			const style = isRevealInverted
 				? isLayoutPreserved
 					? styles.concealLayoutPreserved
@@ -112,7 +176,12 @@ export function useContainerReveal(
 				: isLayoutPreserved
 					? styles.revealLayoutPreserved
 					: styles.reveal;
-			return sx(style);
+			return sx(
+				style,
+				forceVisibility === 'shown' && styles.contentShown,
+				forceVisibility === 'hidden' &&
+					(isLayoutPreserved ? styles.contentHiddenLayoutPreserved : styles.contentHidden)
+			);
 		}
 	};
 }

--- a/packages/core/src/lib/hooks/use-dev-warning.svelte.ts
+++ b/packages/core/src/lib/hooks/use-dev-warning.svelte.ts
@@ -15,8 +15,14 @@ import { devWarn } from '../utils/dev-warning.js';
  * list that varies, and the hook's contract includes re-checking it — upstream
  * warns when the condition flips false → true after mount. A plain boolean read
  * once could not do that, so it comes in as a getter and the `$effect` tracks
- * it. `component` and `message` stay plain strings, as `useMediaQuery`'s
- * `serverDefault` does beside its getter.
+ * it. `component` stays a plain string.
+ *
+ * **`message` also takes a getter**, which upstream gets for free: its `message`
+ * is an ordinary argument re-evaluated on every render and listed in the
+ * effect's dependency array, so an interpolated message always reports current
+ * values. A string captured once at init cannot — `Timestamp` interpolates the
+ * value that failed to parse, and a captured string would report the mount-time
+ * one instead. That is why `Timestamp` used to expand this hook inline.
  *
  * **The latch is a plain `let`.** Upstream's `useRef(false)` exists to hold a
  * value across renders without causing one; a closure variable in a hook that
@@ -44,14 +50,14 @@ import { devWarn } from '../utils/dev-warning.js';
  */
 export function useDevWarning(
 	component: string,
-	message: string,
+	message: string | (() => string),
 	condition: () => boolean = () => true
 ): void {
 	let hasWarned = false;
 	$effect(() => {
 		if (condition() && !hasWarned) {
 			hasWarned = true;
-			devWarn(component, message);
+			devWarn(component, typeof message === 'function' ? message() : message);
 		}
 	});
 }

--- a/packages/core/src/lib/hooks/use-focus-trap.svelte.ts
+++ b/packages/core/src/lib/hooks/use-focus-trap.svelte.ts
@@ -313,12 +313,21 @@ export function useFocusTrap(options: () => UseFocusTrapOptions): UseFocusTrapRe
 				lastFocus = target as Element;
 			} else if (isKeyboardNavigation) {
 				// Focus escaped via keyboard - redirect it back
-				focusFirstDescendant(container);
+				const focusedFirst = focusFirstDescendant(container);
 
 				// If we're back at the same element (Shift+Tab from first element),
 				// try focusing the last element instead
-				if (lastFocus === document.activeElement) {
+				if (focusedFirst && lastFocus === document.activeElement) {
 					focusLastDescendant(container);
+				} else if (
+					!focusedFirst &&
+					lastFocus instanceof HTMLElement &&
+					container.contains(lastFocus)
+				) {
+					// A modal surface may intentionally have no tabbable controls and
+					// place initial focus on a tabindex={-1} heading or panel. Preserve
+					// that programmatic focus target instead of letting Tab escape.
+					attemptFocus(lastFocus);
 				}
 
 				lastFocus = document.activeElement;
@@ -387,6 +396,15 @@ export function useFocusTrap(options: () => UseFocusTrapOptions): UseFocusTrapRe
 
 				const focusable = getFocusableElements(container);
 				if (focusable.length === 0) {
+					// There is nowhere to advance to. Keep focus on the current
+					// programmatic target (for example a dialog panel with tabindex=-1)
+					// rather than allowing the browser to move into background content.
+					event.preventDefault();
+					const active = document.activeElement;
+					if (active instanceof HTMLElement && container.contains(active)) {
+						lastFocus = active;
+					}
+					isKeyboardNavigation = false;
 					return;
 				}
 

--- a/packages/core/src/lib/hooks/useContainerReveal.doc.mjs
+++ b/packages/core/src/lib/hooks/useContainerReveal.doc.mjs
@@ -37,14 +37,15 @@ export default {
 	returns: [
 		{
 			name: 'getContainerProps',
-			type: '() => { class?: string; style?: string; }',
-			description: 'Spread onto the container whose hover/focus-within drives the reveal.'
+			type: '(options?: ContainerRevealOptions) => { class?: string; style?: string; }',
+			description:
+				'Spread onto the container whose hover/focus-within drives the reveal. Accepts hoverDelay (ms the pointer must dwell before the reveal starts — a hover-intent gate like Tooltip\'s and HoverCard\'s delay, so a cursor sweeping across a list leaves nothing painted behind it) and forceState ("active" | "inactive") to pin the trigger state when a caller owns it — a motion gate, a scroll, a row whose menu is open. "inactive" still yields to keyboard focus and coarse pointers.'
 		},
 		{
 			name: 'getContentRevealProps',
 			type: '(options?: ContentRevealOptions) => { class?: string; style?: string; }',
 			description:
-				'Spread onto each revealed (or concealed) child. Accepts isRevealInverted to conceal-on-hover instead of reveal-on-hover, and isLayoutPreserved to reserve the layout box while hidden (opacity-only) and avoid layout shift.'
+				'Spread onto each revealed / concealed child. Accepts isRevealInverted to conceal-on-hover instead of reveal-on-hover, isLayoutPreserved to reserve the layout box while hidden (opacity-only) and avoid layout shift, and forceVisibility ("shown" | "hidden") to pin this one element\'s appearance whatever the container is doing. "hidden" yields to focus.'
 		}
 	],
 	usage: {
@@ -70,6 +71,21 @@ export default {
 				guidance: true,
 				description:
 					'Pass isLayoutPreserved for absolutely-positioned or overlay content to reserve its box and avoid layout shift when it appears.'
+			},
+			{
+				guidance: true,
+				description:
+					'Set a hoverDelay (100-250ms) on rows in a long list, so a cursor travelling across the list does not light up every row it passes; keyboard and touch still reveal immediately.'
+			},
+			{
+				guidance: true,
+				description:
+					'Reach for forceState when something other than the pointer owns the interaction (a drag, a scroll or motion gate, an open row menu), and forceVisibility when just one element should ignore the container.'
+			},
+			{
+				guidance: false,
+				description:
+					"Reach past the API into the hook's private custom properties (--_reveal-opacity and friends) to suppress a reveal; use forceState / forceVisibility, which survive a rename."
 			},
 			{
 				guidance: false,

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,3 +1,28 @@
+/**
+ * The published API surface, mirroring upstream's per-component `index.ts`
+ * barrels.
+ *
+ * **The rule for Svelte-only names.** This port has types upstream has no
+ * counterpart for, because a Svelte hook returns a live *object* where React
+ * returns a plain value destructured at the call site. Such a name is published
+ * when it appears on an already-published signature — a consumer who cannot
+ * write the type down cannot type their own variable, and that is a hole in the
+ * surface rather than a smaller surface. It stays module-public otherwise.
+ *
+ * That is the argument the `BaseTablePlugins` / `TableContextProvider` and
+ * `TableFilterFieldRef` notes below already make case by case; it is stated here
+ * because the batch-5 sweep found the family growing by roughly one per hook
+ * ported, and publishing some while withholding others was the one option that
+ * could not be defended. The current members are `LinkifySegment`,
+ * `MediaQueryState`, `ImageModeState`, `ScrollOverflow`, `OutlineFromDOMState`,
+ * `OutlineFromMarkdownState`, `StreamingTextState` and `BaseTablePlugins`.
+ *
+ * The converse still holds and is not weakened by this: a name that is
+ * module-private *upstream* stays module-public here (`focusableSelector`,
+ * `resolveLayerPortalTarget`, `THUMB_SIZE`), and a props interface upstream
+ * inlines is not given a published alias.
+ */
+
 export { default as AlertDialog } from './components/alert-dialog/alert-dialog.svelte';
 export { default as AppShell } from './components/app-shell/app-shell.svelte';
 export {
@@ -345,6 +370,7 @@ export type { DropdownMenuCheckboxItemProps as BreadcrumbMenuCheckboxItemProps }
 export type { DropdownMenuRadioGroupProps as BreadcrumbMenuRadioGroupProps } from './components/dropdown-menu/dropdown-menu-radio-group.svelte';
 export type { DropdownMenuRadioItemProps as BreadcrumbMenuRadioItemProps } from './components/dropdown-menu/dropdown-menu-radio-item.svelte';
 export type { DropdownMenuSubMenuProps as BreadcrumbMenuSubMenuProps } from './components/dropdown-menu/dropdown-menu-sub-menu.svelte';
+export type { DropdownMenuDividerProps as BreadcrumbMenuDividerProps } from './components/dropdown-menu/dropdown-menu-divider.svelte';
 export type {
 	DropdownMenuOption as BreadcrumbMenuOption,
 	DropdownMenuItemData as BreadcrumbMenuItemData,
@@ -527,6 +553,7 @@ export type { DropdownMenuCheckboxItemProps as ContextMenuCheckboxItemProps } fr
 export type { DropdownMenuRadioGroupProps as ContextMenuRadioGroupProps } from './components/dropdown-menu/dropdown-menu-radio-group.svelte';
 export type { DropdownMenuRadioItemProps as ContextMenuRadioItemProps } from './components/dropdown-menu/dropdown-menu-radio-item.svelte';
 export type { DropdownMenuSubMenuProps as ContextMenuSubMenuProps } from './components/dropdown-menu/dropdown-menu-sub-menu.svelte';
+export type { DropdownMenuDividerProps as ContextMenuDividerProps } from './components/dropdown-menu/dropdown-menu-divider.svelte';
 export type {
 	ContextMenuProps,
 	ContextMenuItemData,
@@ -795,6 +822,8 @@ export type { SideNavItemProps } from './components/side-nav/side-nav-item.svelt
 export type { SideNavSectionProps } from './components/side-nav/side-nav-section.svelte';
 export type {
 	SideNavCollapseState,
+	SideNavCollapsibleConfig,
+	SideNavControlledCollapsible,
 	SideNavImperativeCollapseHandle
 } from './components/side-nav/side-nav-collapse-context.svelte.js';
 export type { SideNavRenderMode } from './components/side-nav/side-nav-render-context.svelte.js';
@@ -1212,7 +1241,11 @@ export {
 	inputStatusHoverShadowStyles,
 	inputWrapperStyles
 } from './components/field/input-styles.stylex.js';
+// Upstream's `FormLayout/index.ts` publishes the `FormLayoutContext` object
+// itself, as it does `SizeContext` and `RadioListContext`; the setter and reader
+// are this port's wrappers around it, not a substitute for it.
 export {
+	FormLayoutContext,
 	setFormLayoutContext,
 	useFormLayout,
 	type FormLayoutDirection
@@ -1495,6 +1528,20 @@ export {
 	type ButtonGroupOrientation,
 	type ElementSize
 } from './internal/contexts.svelte.js';
+// Upstream's `SizeProvider` (`SizeContext.Provider`). `setSizeContext` is not
+// the counterpart — it cascades to a component's whole subtree, where this
+// scopes to part of one, which is the case upstream needs a provider for.
+export { default as SizeProvider } from './internal/size-scope.svelte';
+export type { SizeScopeProps as SizeProviderProps } from './internal/size-scope.svelte';
+// Upstream publishes `useTruncation` and its two types from `Text/index.ts`.
+// `attach` stands in for upstream's `ref` — an attachment is the Svelte
+// lifecycle a ref callback maps to — and the options are a getter, so reading
+// `maxLines` registers the dependency upstream spells as a dependency list.
+export {
+	useTruncation,
+	type UseTruncationOptions,
+	type UseTruncationReturn
+} from './internal/truncation.svelte.js';
 
 export {
 	InteractiveRoleContext,

--- a/packages/core/src/lib/internal/size-scope.svelte
+++ b/packages/core/src/lib/internal/size-scope.svelte
@@ -1,0 +1,38 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+	import type { ElementSize } from './contexts.svelte.js';
+
+	export interface SizeScopeProps {
+		/** The size to cascade to the wrapped subtree. */
+		value: ElementSize;
+		children?: Snippet;
+	}
+</script>
+
+<script lang="ts">
+	import { setSizeContext } from './contexts.svelte.js';
+
+	/**
+	 * Internal — publishes `SizeContext` to a subtree. Upstream's `SizeProvider`.
+	 *
+	 * React scopes a context to part of a tree by wrapping that part in a
+	 * provider element. Svelte sets context at *component* init, so scoping needs
+	 * a component boundary: this is that boundary and nothing more, rendering no
+	 * element of its own. `setSizeContext` remains the right call for a component
+	 * that cascades a size to the whole of its own subtree, as `Toolbar` does;
+	 * this exists for the case upstream needs a provider for — cascading to one
+	 * *part* of a component's output, as `SideNav` does to its icon rows.
+	 *
+	 * Published as `SizeProvider`, which is upstream's name for it. An earlier note
+	 * here argued the opposite — that `setSizeContext` was already the counterpart,
+	 * so exporting this would invent surface. That was wrong, and the paragraph
+	 * above says why: `setSizeContext` cascades to a component's *whole* subtree,
+	 * where `SizeProvider` scopes to *part* of one. They are different
+	 * capabilities, and only this one can express upstream's.
+	 */
+	let { value, children }: SizeScopeProps = $props();
+
+	setSizeContext(() => value);
+</script>
+
+{#if children}{@render children()}{/if}

--- a/packages/core/src/lib/internal/truncation.svelte.ts
+++ b/packages/core/src/lib/internal/truncation.svelte.ts
@@ -15,7 +15,15 @@ import { observeResize, unobserveResize } from './shared-resize-observer.js';
  * This only ever runs in the browser: attachments do not execute during SSR, so
  * the server renders the untruncated markup and the first client pass measures.
  */
-export interface Truncation {
+/**
+ * Upstream's `UseTruncationOptions`. A getter rather than a plain object: reading
+ * `maxLines` inside the attachment is what registers the dependency, which is
+ * upstream's `useCallback` dependency list expressed as reactivity.
+ */
+export type UseTruncationOptions = () => number;
+
+/** Upstream's `UseTruncationReturn`, with `ref` replaced by `attach`. */
+export interface UseTruncationReturn {
 	/** Whether the content currently overflows its clamp. */
 	readonly isTruncated: boolean;
 	/** The element's full text, for the tooltip or `title` fallback. */
@@ -24,7 +32,7 @@ export interface Truncation {
 	readonly attach: Attachment<HTMLElement>;
 }
 
-export function createTruncation(maxLines: () => number): Truncation {
+export function useTruncation(maxLines: UseTruncationOptions): UseTruncationReturn {
 	let isTruncated = $state(false);
 	let fullText = $state('');
 

--- a/packages/core/src/lib/internal/use-menu-hover.svelte.ts
+++ b/packages/core/src/lib/internal/use-menu-hover.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from 'svelte';
 import type { Attachment } from 'svelte/attachments';
 import { useListFocus } from '../hooks/use-list-focus.svelte.js';
 import { useMediaQuery } from '../hooks/use-media-query.svelte.js';
@@ -5,15 +6,31 @@ import { useMediaQuery } from '../hooks/use-media-query.svelte.js';
 /**
  * Ported from Astryx's `hooks/useMenuHover.ts`.
  *
- * Hover as a progressive enhancement over ordinary popover behaviour, shared by
- * `SideNavHeading`, `TopNavHeading` and `TopNavMenu`:
+ * Hover as a progressive enhancement over standard popover behaviour, shared by
+ * `SideNavHeading`, `SideNavItem`, `TopNavHeading`, `TopNavMenu`,
+ * `TopNavMegaMenu` and `DropdownMenuSubMenu`: click toggles, Escape and
+ * outside-click close, arrows navigate; on top of that, mouseenter opens after a
+ * delay and mouseleave closes one that hover opened.
  *
- * 1. Click toggles; Escape, outside-click and arrow-key navigation come from the
- *    popover and `useListFocus` underneath.
- * 2. `mouseenter` activates *hover mode* and opens after `showDelay`; while in
- *    hover mode `mouseleave` closes after `hideDelay`. Any close resets hover
- *    mode, and closing by click additionally swallows the next `mouseenter` so
- *    the menu does not immediately reopen under a stationary pointer.
+ * Three upstream behaviours are not obvious and are load-bearing:
+ *
+ * 1. **Hover→click guard (#3121).** A hover-opened menu is already open under
+ *    the cursor when the pointer arrives, so the click that naturally follows
+ *    would toggle it shut. Within `clickGuardMs` a click instead *confirms* it:
+ *    the menu pins and behaves like a click-open from then on.
+ * 2. **Focus moves synchronously.** `show()` calls `showPopover()` in the same
+ *    tick and the layer's children are always mounted, so items are focusable
+ *    the moment `show()` returns — a `requestAnimationFrame` here lands after
+ *    paint and races anything else moving focus. Hover-opens are the exception:
+ *    the pointer is driving, so focus stays on the trigger. The hook always
+ *    passes `skipAutoFocus` and owns focus itself, because the popover's
+ *    auto-focus targets the first *tabbable* node while a menu wants its first
+ *    item — under roving tabindex those are different elements.
+ * 3. **Native light dismiss.** A `popover="auto"` is dismissed by the browser on
+ *    pointer interaction outside the panel, and a trigger outside the panel
+ *    counts — before our click handler runs. `popoverId` makes the trigger the
+ *    panel's invoker, which exempts it. jsdom implements neither light dismiss
+ *    nor invokers, so that wiring is only verifiable in a browser.
  *
  * Only `mouseenter`/`mouseleave`, never `mouseover` — the difference matters,
  * because `mouseover` fires again for every descendant.
@@ -24,65 +41,95 @@ import { useMediaQuery } from '../hooks/use-media-query.svelte.js';
  *
  * Four translations:
  *
- * - **Options come in as a getter**, read at event time. Upstream's six
- *   `useCallback` dependency lists exist only to keep those closures current; a
- *   getter is current by construction.
- * - **The five refs are plain `let`s.** `showTimer`, `hideTimer`, `hoverMode`,
- *   `skipNextEnter` and `prevIsOpen` are all values that must survive a render
- *   without causing one — which is what a non-reactive binding already is here.
- * - **A sixth ref is dropped outright, along with its public setter.** Upstream
- *   returns `setTriggerEl`, which writes `triggerElRef` — and nothing in the hook
- *   ever reads it, so the three consumers that merge it into their trigger refs
- *   achieve nothing. Dropped rather than transcribed, as `SideNavHeading`'s and
- *   `TopNavHeading`'s equally dead `rootRef` is. The return type is therefore one
- *   member short of upstream's, deliberately.
- * - **`listRef` becomes `attachMenu`**, `useListFocus`'s attachment.
- * - **The `isEnabled` bail returns no-ops but the *same* menu attachment and
- *   `focusFirst`.** Upstream does this too (it calls `useListFocus`
- *   unconditionally and swaps only the handlers), which is what lets
- *   `SideNavHeading` call the hook with `isEnabled: !!menu` at the top level and
- *   still hand a working `attachMenu` to a menu that appears later.
+ * - **Options come in as a getter**, read at event time. Upstream's `useCallback`
+ *   dependency lists exist only to keep those closures current; a getter is
+ *   current by construction.
+ * - **The refs are plain `let`s.** `showTimer`, `hideTimer`, `hoverMode`,
+ *   `closedAt`, `hoverOpenedAt` and `triggerEl` are all values that must survive
+ *   a render without causing one — which is what a non-reactive binding already
+ *   is here.
+ * - **`listRef` becomes `attachMenu` and `setTriggerEl` becomes `attachTrigger`**,
+ *   because Svelte has no ref objects. `attachMenu` wraps `useListFocus`'s own
+ *   attachment so this hook can also read the container: `focusMenu` focuses it
+ *   when the menu is empty, and `close` has to know whether focus was inside it
+ *   before hiding.
+ * - **The `isEnabled` bail returns no-ops but the *same* menu attachment,
+ *   `focusFirst`, `focusMenu`, `confirmHoverOpen` and `close`.** Upstream does
+ *   this too (it calls `useListFocus` unconditionally and swaps only the
+ *   handlers), which is what lets `SideNavHeading` call the hook with
+ *   `isEnabled: !!menu` at the top level and still hand a working `attachMenu` to
+ *   a menu that appears later.
  *
- * The one place upstream's shape could not survive verbatim is the
- * close-resets-hover-mode rule. React writes it as a during-render comparison
- * against `prevIsOpenRef`; Svelte has no render pass to hang that on, so it is
- * folded into the same getter reads the handlers already do — `syncHoverMode()`
- * runs at the top of every handler, and `hoverMode` is *read* only in
- * `handleMouseLeave`, so for any sequence where the open state changes through
- * this hook's own handlers the two reach the same state. The reset is idempotent
- * and `prevIsOpen` is reassigned on every call, so it can neither be
- * double-consumed nor fire twice for one transition.
- *
- * The gap it leaves is narrow and reachable exactly once: upstream resets on
- * *every* `true → false` transition because it re-renders on every one, whereas
- * this misses a close if a **reopen lands between two handler calls**. That needs
- * both edges to happen outside a handler — `handleMouseEnter` arms `showTimer`
- * while the layer is already open, the browser light-dismisses it inside that
- * window, and the pending timer reopens it. `hoverMode` is then `true` here and
- * `false` upstream, so the next `mouseleave` schedules a hide here and is ignored
- * upstream. Left as-is: the window is at most `showDelay` wide and closing on
- * mouseleave is the better of the two outcomes. Same "a one-shot flag assumes
- * exactly one intervening event" family as `useHoverCard`'s `isEscapeDismissing`,
- * which port/todo.md already records.
+ * The close observer is the one place React's shape could not be transcribed.
+ * Upstream catches every close — whatever caused it — in a layout effect keyed on
+ * `isOpen`, and **it must be a real observer here too**: `closedAt` is a
+ * *timestamp*, so stamping it lazily at the top of the next handler (which is
+ * what this hook did while the flag was a one-shot boolean) would record the time
+ * of the re-hover rather than the time of the close, and suppress a deliberate
+ * re-hover that arrived long after the window should have expired. `$effect` is
+ * the analogue that lands after the DOM update and before the browser hit-tests
+ * the vanished panel and fires the mouseenter `REOPEN_SUPPRESS_MS` exists to
+ * swallow. `isOpen` is narrowed through a `$derived` for the same reason
+ * `useListFocus`'s `hasRovingTabIndex` is — a derived notifies only when its
+ * *value* changes, which is what a dependency list means.
  */
+
+const DEFAULT_CLICK_GUARD_MS = 500;
+
+/**
+ * How long after a close a mouseenter on the trigger is ignored.
+ *
+ * A panel positioned over its own trigger puts that trigger back under a
+ * stationary pointer when it closes, and the browser fires a fresh mouseenter —
+ * which reopened the menu the user had just dismissed. Time-bounded rather than
+ * a one-shot flag, so a deliberate re-hover seconds later still opens; a real
+ * mouseleave clears it early.
+ */
+const REOPEN_SUPPRESS_MS = 300;
 
 export interface UseMenuHoverOptions {
 	show: (options?: { skipAutoFocus?: boolean }) => void;
 	hide: () => void;
 	isOpen: boolean;
 	isEnabled: boolean;
-	/** @default 150 */
+	/** Delay before a hover opens the menu (ms). @default 150 */
 	showDelay?: number;
-	/** @default 200 */
+	/** Delay before leaving the trigger or menu closes it (ms). @default 200 */
 	hideDelay?: number;
+	/**
+	 * Window after a hover-open in which a click confirms the menu instead of
+	 * closing it. 0 opts out, making every click toggle. @default 500
+	 */
+	clickGuardMs?: number;
+	/**
+	 * Selector for the menu's focusable items, forwarded to `useListFocus`. A
+	 * panel of links (a mega menu) needs an override; `role="menuitem"` rows do
+	 * not. @default '[role="menuitem"]'
+	 */
+	itemSelector?: string;
+	/**
+	 * The popup's DOM id (`usePopover().id`). Supply it when the popup is a
+	 * native `popover="auto"` and the trigger sits outside it; omit it for
+	 * `popover="manual"` popups and triggers inside the panel.
+	 */
+	popoverId?: string;
+	/**
+	 * Whether the hook moves focus on a click or keyboard open. False for
+	 * consumers that wire the pointer half only and leave focus to the popover's
+	 * own trap — a panel that is a dialog rather than a menu (`SideNavItem`'s
+	 * collapsed flyout) has no items for the hook to focus. @default true
+	 */
+	ownsFocus?: boolean;
 }
 
 export interface UseMenuHoverReturn {
 	/** Handlers for the trigger element. */
 	readonly triggerProps: {
-		onclick: () => void;
+		onclick: (event?: MouseEvent) => void;
 		onmouseenter: () => void;
 		onmouseleave: () => void;
+		/** Present only when `popoverId` is supplied. */
+		popovertarget?: string;
 	};
 	/** Handlers for the popover content element. */
 	readonly contentProps: {
@@ -92,20 +139,45 @@ export interface UseMenuHoverReturn {
 	};
 	/** Attach to the `role="menu"` container. Upstream's `menuRef`. */
 	readonly attachMenu: Attachment<HTMLElement>;
-	/** Focus the first enabled menu item. */
+	/** Attach to the trigger element. Upstream's `setTriggerEl`. */
+	readonly attachTrigger: Attachment<HTMLElement>;
+	/** Focus the first enabled item. Returns false when there was none. */
 	focusFirst: () => boolean;
+	/**
+	 * Focus the first enabled item, falling back to the menu container when the
+	 * menu is empty or still loading.
+	 */
+	focusMenu: () => void;
+	/**
+	 * For consumers with their own click handler: call this in the open branch.
+	 * Returns `true` when the click was the one following a hover-open — the menu
+	 * is now pinned and the click must NOT be treated as a dismissal.
+	 */
+	confirmHoverOpen: () => boolean;
+	/**
+	 * Close, restoring focus to the trigger. For dismiss affordances rendered
+	 * inside the popup, which are close buttons rather than the trigger and so
+	 * must not carry its toggle and keyboard-activation semantics.
+	 */
+	close: () => void;
 }
 
 export function useMenuHover(options: () => UseMenuHoverOptions): UseMenuHoverReturn {
 	const hasHover = useMediaQuery(() => '(hover: hover)');
 
+	// The one option read reactively: the close observer below is keyed on it.
+	const isOpen = $derived(options().isOpen);
+
 	let showTimer: ReturnType<typeof setTimeout> | null = null;
 	let hideTimer: ReturnType<typeof setTimeout> | null = null;
-	// Whether the menu was opened/interacted via hover (enables mouseleave-to-close)
+	let triggerEl: HTMLElement | null = null;
+	let menuEl: HTMLElement | null = null;
+	/** Menu was hover-opened, so mouseleave may close it. */
 	let hoverMode = false;
-	// One-shot: skip the next mouseenter after click-to-close
-	let skipNextEnter = false;
-	let prevIsOpen = options().isOpen;
+	let closedAt = 0;
+	/** When the current open began as a hover-open; 0 once confirmed or closed. */
+	let hoverOpenedAt = 0;
+	let prevIsOpen = untrack(() => isOpen);
 
 	function clearTimeouts(): void {
 		if (showTimer) {
@@ -118,65 +190,163 @@ export function useMenuHover(options: () => UseMenuHoverOptions): UseMenuHoverRe
 		}
 	}
 
-	// Upstream's during-render `if (prevIsOpenRef.current && !isOpen)`. Any close,
-	// for any reason, leaves hover mode — so a menu dismissed by Escape does not
-	// close a second time when the pointer eventually leaves.
-	function syncHoverMode(): void {
-		const isOpen = options().isOpen;
-		if (prevIsOpen && !isOpen) {
-			hoverMode = false;
-		}
-		prevIsOpen = isOpen;
-	}
+	// Catches every close, whatever caused it — a menu dismissed by Escape or by
+	// light dismiss must leave hover mode exactly as a click-close does.
+	$effect(() => {
+		const open = isOpen;
+		untrack(() => {
+			const wasOpen = prevIsOpen;
+			prevIsOpen = open;
+			if (wasOpen && !open) {
+				hoverMode = false;
+				hoverOpenedAt = 0;
+				closedAt = Date.now();
+			}
+		});
+	});
 
 	const list = useListFocus(() => ({
+		itemSelector: options().itemSelector,
 		onEscape: () => {
 			clearTimeouts();
-			options().hide();
+			hideAndRestoreFocus();
 		}
 	}));
 
 	$effect(() => () => clearTimeouts());
 
-	// Click: always toggle.
-	function handleClick(): void {
-		syncHoverMode();
-		clearTimeouts();
-		if (options().isOpen) {
-			skipNextEnter = true;
-			options().hide();
-		} else {
-			skipNextEnter = false;
-			options().show();
-			requestAnimationFrame(() => list.focusFirst());
+	const attachMenu: Attachment<HTMLElement> = (element) => {
+		menuEl = element;
+		const cleanupList = untrack(() => list.attachList(element));
+		return () => {
+			cleanupList?.();
+			menuEl = null;
+		};
+	};
+
+	const attachTrigger: Attachment<HTMLElement> = (element) => {
+		triggerEl = element;
+		return () => {
+			triggerEl = null;
+		};
+	};
+
+	function hideAndRestoreFocus(): void {
+		// Read before hiding: closing the layer moves focus itself.
+		const menuHadFocus = menuEl?.contains(document.activeElement) ?? false;
+		options().hide();
+		if (menuHadFocus) {
+			triggerEl?.focus();
 		}
 	}
 
-	// Hover: mouseenter activates hover mode and opens.
+	function focusMenu(): void {
+		// An empty or still-loading menu has no focusable item; focus the container
+		// so keyboard ownership still transfers off the trigger's list.
+		if (!list.focusFirst()) {
+			menuEl?.focus();
+		}
+	}
+
+	function openAndFocus(): void {
+		if (!(options().ownsFocus ?? true)) {
+			options().show();
+			return;
+		}
+		options().show({ skipAutoFocus: true });
+		focusMenu();
+	}
+
+	function confirmHoverOpen(): boolean {
+		const clickGuardMs = options().clickGuardMs ?? DEFAULT_CLICK_GUARD_MS;
+		const isConfirming =
+			clickGuardMs > 0 && hoverOpenedAt > 0 && Date.now() - hoverOpenedAt < clickGuardMs;
+		if (!isConfirming) {
+			return false;
+		}
+		hoverMode = false;
+		hoverOpenedAt = 0;
+		return true;
+	}
+
+	function handleClick(event?: MouseEvent): void {
+		const { popoverId, ownsFocus = true } = options();
+
+		// Cancel the invoker's default toggle so this handler stays the single
+		// source of truth; popovertarget still exempts the trigger from dismissal.
+		if (popoverId) {
+			event?.preventDefault();
+		}
+		clearTimeouts();
+
+		// Enter/Space arrive as a click with detail 0, and always open. A keyboard
+		// user reaches the trigger of an open menu only because a hover-open left
+		// focus behind; closing there would strand them outside a visible menu.
+		const isKeyboardActivation = event != null && event.detail === 0;
+		if (isKeyboardActivation) {
+			closedAt = 0;
+			hoverMode = false;
+			hoverOpenedAt = 0;
+			if (options().isOpen) {
+				if (ownsFocus) {
+					focusMenu();
+				}
+			} else {
+				openAndFocus();
+			}
+			return;
+		}
+
+		if (!options().isOpen) {
+			closedAt = 0;
+			hoverMode = false;
+			hoverOpenedAt = 0;
+			openAndFocus();
+			return;
+		}
+
+		if (confirmHoverOpen()) {
+			if (ownsFocus) {
+				focusMenu();
+			}
+			return;
+		}
+
+		hideAndRestoreFocus();
+	}
+
 	function handleMouseEnter(): void {
-		syncHoverMode();
 		if (!hasHover.matches) {
 			return;
 		}
-		if (skipNextEnter) {
-			skipNextEnter = false;
+		if (closedAt > 0 && Date.now() - closedAt < REOPEN_SUPPRESS_MS) {
+			return;
+		}
+		// Re-entering an open menu's trigger must not un-pin it or re-arm the
+		// guard, which would make the next deliberate click another "confirm" and
+		// leave the menu undismissable.
+		if (options().isOpen) {
+			clearTimeouts();
 			return;
 		}
 		hoverMode = true;
 		clearTimeouts();
+		const openByHover = () => {
+			hoverOpenedAt = Date.now();
+			options().show({ skipAutoFocus: true });
+		};
 		const showDelay = options().showDelay ?? 150;
 		if (showDelay > 0) {
-			showTimer = setTimeout(() => {
-				options().show({ skipAutoFocus: true });
-			}, showDelay);
+			showTimer = setTimeout(openByHover, showDelay);
 		} else {
-			options().show({ skipAutoFocus: true });
+			openByHover();
 		}
 	}
 
-	// Hover: mouseleave only closes if in hover mode.
 	function handleMouseLeave(): void {
-		syncHoverMode();
+		// A real leave ends the stationary-pointer case the suppression window
+		// exists for, so the next enter is deliberate whenever it arrives.
+		closedAt = 0;
 		if (!hoverMode) {
 			return;
 		}
@@ -186,24 +356,12 @@ export function useMenuHover(options: () => UseMenuHoverOptions): UseMenuHoverRe
 		}, options().hideDelay ?? 200);
 	}
 
-	// Content: mouseenter cancels a pending hide.
 	function handleContentMouseEnter(): void {
-		syncHoverMode();
 		clearTimeouts();
 	}
 
 	function noop(): void {}
 
-	const enabledTriggerProps = {
-		onclick: handleClick,
-		onmouseenter: handleMouseEnter,
-		onmouseleave: handleMouseLeave
-	};
-	const disabledTriggerProps = {
-		onclick: noop,
-		onmouseenter: noop,
-		onmouseleave: noop
-	};
 	const enabledContentProps = {
 		onmouseenter: handleContentMouseEnter,
 		onmouseleave: handleMouseLeave,
@@ -214,17 +372,37 @@ export function useMenuHover(options: () => UseMenuHoverOptions): UseMenuHoverRe
 		onmouseleave: noop,
 		onkeydown: noop
 	};
+	const disabledTriggerProps = {
+		onclick: noop,
+		onmouseenter: noop,
+		onmouseleave: noop
+	};
 
 	return {
 		get triggerProps() {
-			return options().isEnabled ? enabledTriggerProps : disabledTriggerProps;
+			if (!options().isEnabled) {
+				return disabledTriggerProps;
+			}
+			const { popoverId } = options();
+			return {
+				onclick: handleClick,
+				onmouseenter: handleMouseEnter,
+				onmouseleave: handleMouseLeave,
+				...(popoverId ? { popovertarget: popoverId } : null)
+			};
 		},
 		get contentProps() {
 			return options().isEnabled ? enabledContentProps : disabledContentProps;
 		},
 		get attachMenu() {
-			return list.attachList;
+			return attachMenu;
 		},
-		focusFirst: () => list.focusFirst()
+		get attachTrigger() {
+			return options().isEnabled ? attachTrigger : () => {};
+		},
+		focusFirst: () => list.focusFirst(),
+		focusMenu,
+		confirmHoverOpen,
+		close: hideAndRestoreFocus
 	};
 }

--- a/packages/core/src/lib/locales/en.json
+++ b/packages/core/src/lib/locales/en.json
@@ -419,6 +419,66 @@
     "defaultMessage": "Next",
     "description": "Screen-reader-only label on the right-arrow button in a Lightbox (navigates to next media item). Pairs with `lightbox.previous`."
   },
+  "@astryx.listInput.emptyTitle": {
+    "defaultMessage": "No {itemName}s yet",
+    "description": "EmptyState title shown inside a lab ListInput when its collection has no records. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\"); the source appends a literal \"s\" to pluralize it, which only works for regular English plurals. If your language cannot pluralize an interpolated noun this way, rephrase around `{itemName}` instead (e.g. \"No {itemName} added yet\")."
+  },
+  "@astryx.listInput.emptyDescription": {
+    "defaultMessage": "Add a {itemName} to get started.",
+    "description": "EmptyState supporting text shown inside a lab ListInput when its collection has no records. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\")."
+  },
+  "@astryx.listInput.addItem": {
+    "defaultMessage": "Add {itemName}",
+    "description": "Accessible label on the button that appends a new record to a lab ListInput. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\")."
+  },
+  "@astryx.listInput.removeItem": {
+    "defaultMessage": "Remove {itemName} {position, number}",
+    "description": "Accessible label and tooltip on the button that deletes one record from a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is its 1-based row number (e.g. \"Remove guest 2\")."
+  },
+  "@astryx.listInput.reorderItem": {
+    "defaultMessage": "Reorder {itemName} {position, number}",
+    "description": "Accessible label on the drag-handle button that reorders one record in a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is its 1-based row number (e.g. \"Reorder guest 2\")."
+  },
+  "@astryx.listInput.fieldLabelWithPosition": {
+    "defaultMessage": "{header}, {itemName} {position, number} of {total, number}",
+    "description": "Accessible name for a field inside a lab ListInput row after the first row, disambiguating repeated column labels. `{header}` is the column's own label (e.g. \"Name\"); `{itemName}` is the consumer's singular noun for one record; `{position}`/`{total}` are the row's 1-based index and the total row count (e.g. \"Name, guest 2 of 3\")."
+  },
+  "@astryx.listInput.reorderInstructions": {
+    "defaultMessage": "Use Arrow Up or Arrow Down to move this item one position. Press Space or Enter to pick it up for extended keyboard reordering.",
+    "description": "Visually-hidden instructions describing how to use a lab ListInput row's keyboard reorder handle, referenced via aria-describedby from every reorder button."
+  },
+  "@astryx.listInput.announceAdded": {
+    "defaultMessage": "Added {itemName} {position, number}.",
+    "description": "Screen-reader-only live announcement after a new record is appended to a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is the new record's 1-based row number."
+  },
+  "@astryx.listInput.announceRemoved": {
+    "defaultMessage": "Removed {itemName} {position, number}.",
+    "description": "Screen-reader-only live announcement after a record is deleted from a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is the removed record's former 1-based row number."
+  },
+  "@astryx.listInput.announceGrabbed": {
+    "defaultMessage": "{itemName} {position, number} grabbed. Use arrow keys to move, Space or Enter to drop, and Escape to cancel.",
+    "description": "Screen-reader-only live announcement when a lab ListInput record's keyboard reorder handle enters extended \"lift\" mode. `{itemName}` is the consumer's singular noun for one record; `{position}` is its 1-based row number."
+  },
+  "@astryx.listInput.announceMovedToPosition": {
+    "defaultMessage": "{itemName} moved to position {position, number} of {total, number}.",
+    "description": "Screen-reader-only live announcement each time a lab ListInput record's reorder position changes (arrow-key step, keyboard lift-mode preview, or pointer drag). `{itemName}` is the consumer's singular noun for one record; `{position}`/`{total}` are the record's new 1-based position and the total row count."
+  },
+  "@astryx.listInput.announceReorderCancelled": {
+    "defaultMessage": "Reordering cancelled.",
+    "description": "Screen-reader-only live announcement when a lab ListInput reorder in progress is cancelled (Escape key, blur, or the collection becoming disabled/loading mid-drag)."
+  },
+  "@astryx.listInput.announceReturnedToPosition": {
+    "defaultMessage": "{itemName} returned to position {position, number}.",
+    "description": "Screen-reader-only live announcement when a lab ListInput reorder is committed without the record's position actually changing. `{itemName}` is the consumer's singular noun for one record; `{position}` is its unchanged 1-based row number."
+  },
+  "@astryx.listInput.announceDropped": {
+    "defaultMessage": "{itemName} dropped at position {position, number} of {total, number}.",
+    "description": "Screen-reader-only live announcement when a lab ListInput reorder is committed with the record's position actually changing. `{itemName}` is the consumer's singular noun for one record; `{position}`/`{total}` are its new 1-based position and the total row count."
+  },
+  "@astryx.listInput.announceAlreadyAtBoundary": {
+    "defaultMessage": "This {itemName} is already {boundary, select, first {first} last {last} other {}}.",
+    "description": "Screen-reader-only live announcement when an arrow-key reorder attempt has no effect because the record is already at that end of the list. `{itemName}` is the consumer's singular noun for one record; `{boundary}` is always exactly \"first\" or \"last\"."
+  },
   "@astryx.markdown.taskList": {
     "defaultMessage": "Task list",
     "description": "Screen-reader-only accessible name for a GitHub-flavored Markdown task list (rendered from `- [ ] item` / `- [x] done` syntax)."
@@ -642,6 +702,14 @@
   "@astryx.dateInput.invalidDate": {
     "defaultMessage": "Invalid date",
     "description": "Screen-reader-only live-region alert in DateInput / DateTimeInput when the typed date cannot be parsed. The field silently reverts on blur, so this is the only rejection feedback a screen-reader user gets."
+  },
+  "@astryx.dateTimeInput.timeHint12h": {
+    "defaultMessage": "e.g., 2:30 PM",
+    "description": "Placeholder hint shown in the DateTimeInput time field when focused and empty with 12-hour format. Gives an example of expected input format."
+  },
+  "@astryx.dateTimeInput.timeHint24h": {
+    "defaultMessage": "e.g., 14:30",
+    "description": "Placeholder hint shown in the DateTimeInput time field when focused and empty with 24-hour format. Gives an example of expected input format."
   },
   "@astryx.dateTimeInput.timeSuffix": {
     "defaultMessage": "{label} time",
@@ -935,6 +1003,10 @@
     "defaultMessage": "Collapse {label}",
     "description": "Screen-reader-only label on the same chevron when the group is expanded. Example: `Collapse Settings`. Pairs with `sideNavItem.expand`."
   },
+  "@astryx.sideNavItem.submenuLabel": {
+    "defaultMessage": "{label} submenu",
+    "description": "Accessible name for the flyout dialog that opens from a collapsed (icon-only) SideNav item to show its sub-items. {label} is the parent item's label. Example: `Settings submenu`."
+  },
   "@astryx.tableFiltering.filterByColumn": {
     "defaultMessage": "Filter {header}",
     "description": "Triple-use string on per-column filter controls: visible label, placeholder, AND aria label. `{header}` is the column header — example: `Filter Name`. Keep short."
@@ -1050,5 +1122,17 @@
   "@astryx.token.remove": {
     "defaultMessage": "Remove {label}",
     "description": "Screen-reader-only label on the \"×\" on an individual Token/chip. Example: `Remove John Smith`, `Remove Active`. Imperative verb."
+  },
+  "@astryx.commandPalette.footer.navigate": {
+    "defaultMessage": "Navigate",
+    "description": "Keyboard hint in the CommandPalette footer, paired with up/down arrow key icons. Tells users arrow keys move between items."
+  },
+  "@astryx.commandPalette.footer.select": {
+    "defaultMessage": "Select",
+    "description": "Keyboard hint in the CommandPalette footer, paired with the Enter key icon. Tells users Enter activates the highlighted item."
+  },
+  "@astryx.commandPalette.footer.close": {
+    "defaultMessage": "Close",
+    "description": "Keyboard hint in the CommandPalette footer, paired with the Escape key icon. Tells users Escape dismisses the palette."
   }
 }

--- a/packages/core/src/lib/styles/tokens.stylex.ts
+++ b/packages/core/src/lib/styles/tokens.stylex.ts
@@ -15,6 +15,10 @@
  *
  * This file must keep the `.stylex.ts` extension — `defineVars` is only valid in
  * a StyleX-compiled module.
+ *
+ * SYNC: adding or removing a token FAMILY (a whole `*Defaults` group) also
+ * means updating:
+ * - /packages/cli/assets/theme.template.ts (its inventory of what exists)
  */
 
 import * as stylex from '@stylexjs/stylex';

--- a/packages/core/src/lib/theme/define-theme.ts
+++ b/packages/core/src/lib/theme/define-theme.ts
@@ -73,6 +73,13 @@ export type StyleOverrides = Record<string, TokenValue | TokenMap>;
 /** Component overrides, keyed by style key (see parseStyleKey). */
 export type ComponentOverrides = Record<string, Record<string, StyleOverrides>>;
 
+/**
+ * SYNC: `ThemeConfig` is the theme surface. Adding, removing, or renaming a
+ * field means updating:
+ * - /packages/cli/assets/theme.template.ts (documents every field; the drift
+ *   guard is packages/cli/scripts/check-theme-template.test.mjs)
+ * - /packages/cli/assets/docs/theme.doc.mjs (`astryx-svelte docs theme`)
+ */
 export interface ThemeConfig {
 	name: string;
 	typography?: TypographyConfig;

--- a/packages/core/src/lib/theme/derived-var-registry.ts
+++ b/packages/core/src/lib/theme/derived-var-registry.ts
@@ -64,6 +64,10 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
 		{ property: 'borderRadius', vars: ['--_dialog-radius'] },
 		{ property: 'padding', expand: 'container' }
 	],
+	'context-menu': [
+		{ property: 'borderRadius', vars: ['--_dropdown-menu-radius'] },
+		{ property: 'padding', vars: ['--_dropdown-menu-padding'] }
+	],
 	'dropdown-menu': [
 		{ property: 'borderRadius', vars: ['--_dropdown-menu-radius'] },
 		{ property: 'padding', vars: ['--_dropdown-menu-padding'] }

--- a/packages/core/src/lib/theme/expand-color-scale.ts
+++ b/packages/core/src/lib/theme/expand-color-scale.ts
@@ -26,6 +26,9 @@
  * expander currently ships as a published utility with no in-repo caller. The
  * five upstream cases covering that integration are named as dropped in the test
  * file rather than silently missing.
+ *
+ * SYNC: When modified, update:
+ * - /packages/cli/assets/theme.template.ts (the annotated field reference)
  */
 
 import { contrastRatio } from './contrast.js';

--- a/packages/core/src/lib/theme/expand-motion-scale.ts
+++ b/packages/core/src/lib/theme/expand-motion-scale.ts
@@ -8,6 +8,9 @@
  *
  * A "snappy" theme lowers the bases, a "cinematic" one raises them, and the
  * proportional relationships hold automatically.
+ *
+ * SYNC: When modified, update:
+ * - /packages/cli/assets/theme.template.ts (the annotated field reference)
  */
 
 export interface MotionScaleConfig {

--- a/packages/core/src/lib/theme/expand-radius-scale.ts
+++ b/packages/core/src/lib/theme/expand-radius-scale.ts
@@ -11,6 +11,9 @@
  * every named radius token explicitly, so the only declaration the expander
  * actually contributes there is `--radius-chat`, which is exactly what the
  * theme oracle reported missing.
+ *
+ * SYNC: When modified, update:
+ * - /packages/cli/assets/theme.template.ts (the annotated field reference)
  */
 
 /** Radius scale configuration. */

--- a/packages/core/src/lib/theme/expand-type-scale.ts
+++ b/packages/core/src/lib/theme/expand-type-scale.ts
@@ -18,16 +18,46 @@
  * the gap was invisible until something rendered `display-3`. It also meant a
  * theme with a *different* `scale` got upstream's leadings rather than its own,
  * which is the more serious half.
+ *
+ * SYNC: When modified, update:
+ * - /packages/cli/assets/theme.template.ts (the annotated field reference)
  */
 
-export type TypeWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+/**
+ * Named font weight — maps to `var(--font-weight-*)` at the token layer. Raw CSS
+ * values (e.g. `'800'`) are accepted as an escape hatch, matching upstream's
+ * `FontWeight`; `(string & {})` keeps the four names in editor completion while
+ * still admitting any string.
+ */
+export type TypeWeight = 'normal' | 'medium' | 'semibold' | 'bold' | (string & {});
+
+/**
+ * Upstream's `resolveFontWeight`: a named weight becomes a token reference so a
+ * theme that also retunes `--font-weight-*` stays coherent; anything else is a
+ * raw CSS value and passes through untouched.
+ */
+function resolveWeight(weight: TypeWeight): string {
+	const named: Record<string, string> = {
+		normal: 'var(--font-weight-normal)',
+		medium: 'var(--font-weight-medium)',
+		semibold: 'var(--font-weight-semibold)',
+		bold: 'var(--font-weight-bold)'
+	};
+	return named[weight] ?? weight;
+}
 
 export interface TypeRole {
 	/** Primary family name, e.g. 'Figtree'. */
 	family?: string;
 	/** Comma-separated fallback stack appended after `family`. */
 	fallbacks?: string;
-	/** Per-level weight overrides, keyed by heading level. */
+	/**
+	 * Default weight for the whole role. On `heading` it fills every level
+	 * `weights` does not name; on `body` and `code` it sets that text role's
+	 * weight directly. Upstream's `FontRole.weight`.
+	 */
+	weight?: TypeWeight;
+	/** Per-level weight overrides, keyed by heading level. Beats `weight`. */
 	weights?: Record<number, TypeWeight>;
 }
 
@@ -165,14 +195,38 @@ export function expandTypeScale(config: TypographyConfig): TypeScaleTokens {
 	// so a theme that also retunes --font-weight-* stays coherent.
 	const headingWeights = new Map<number, string>();
 	for (const [level, weight] of Object.entries(config.heading?.weights ?? {})) {
-		headingWeights.set(Number(level), `var(--font-weight-${weight})`);
+		headingWeights.set(Number(level), resolveWeight(weight));
+	}
+
+	// The role-level default fills every level `weights` did not name, which is
+	// upstream's `defaultHeadingWeight` loop. `weights` wins where both are set.
+	const defaultHeadingWeight = config.heading?.weight
+		? resolveWeight(config.heading.weight)
+		: undefined;
+
+	// `body` and `code` set their own text role's weight; there is no `large`,
+	// `label` or `supporting` role to carry one, exactly as upstream has none.
+	const textWeights = new Map<string, string>();
+	if (config.body?.weight) {
+		textWeights.set('body', resolveWeight(config.body.weight));
+	}
+	if (config.code?.weight) {
+		textWeights.set('code', resolveWeight(config.code.weight));
 	}
 
 	if (!config.scale) {
 		// Without a scale there are no sizes to derive leadings from, so only the
 		// explicit weight overrides are expressible.
+		if (defaultHeadingWeight) {
+			for (const [level] of HEADING_STEPS) {
+				tokens[`--text-heading-${level}-weight`] = defaultHeadingWeight;
+			}
+		}
 		for (const [level, weight] of headingWeights) {
 			tokens[`--text-heading-${level}-weight`] = weight;
+		}
+		for (const [type, weight] of textWeights) {
+			tokens[`--text-${type}-weight`] = weight;
 		}
 		return tokens;
 	}
@@ -190,13 +244,14 @@ export function expandTypeScale(config: TypographyConfig): TypeScaleTokens {
 	// scale moves both together; leadings are the computed constants above.
 	for (const [level, step] of HEADING_STEPS) {
 		tokens[`--text-heading-${level}-size`] = `var(${SIZE_TOKEN_BY_STEP.get(step)})`;
-		tokens[`--text-heading-${level}-weight`] = headingWeights.get(level) ?? DEFAULT_HEADING_WEIGHT;
+		tokens[`--text-heading-${level}-weight`] =
+			headingWeights.get(level) ?? defaultHeadingWeight ?? DEFAULT_HEADING_WEIGHT;
 		tokens[`--text-heading-${level}-leading`] = String(computeLeading(sizeAt(step)));
 	}
 
 	for (const [type, step] of TEXT_STEPS) {
 		tokens[`--text-${type}-size`] = `var(${SIZE_TOKEN_BY_STEP.get(step)})`;
-		tokens[`--text-${type}-weight`] = DEFAULT_TEXT_WEIGHTS[type];
+		tokens[`--text-${type}-weight`] = textWeights.get(type) ?? DEFAULT_TEXT_WEIGHTS[type];
 		tokens[`--text-${type}-leading`] = String(computeLeading(sizeAt(step)));
 	}
 

--- a/packages/core/src/lib/theme/tokens.ts
+++ b/packages/core/src/lib/theme/tokens.ts
@@ -1,9 +1,11 @@
 import type { DefinedTheme, TokenValue } from './define-theme.js';
 import { formatColor, parseColor } from '../utils/color.js';
 import {
+	borderDefaults,
 	colorDefaults,
 	durationDefaults,
 	easeDefaults,
+	focusDefaults,
 	fontWeightDefaults,
 	radiusDefaults,
 	shadowDefaults,
@@ -27,16 +29,22 @@ import {
  * import path. See the note at that file's head.
  *
  * Upstream also folds in its `domainTokens/` (data-viz) group, which this port
- * does not ship — and **omits `borderDefaults`**, which it does ship and does
- * publish a `BorderVarName` type for. That looks like an upstream bug, so it is
- * recorded in port/todo.md rather than corrected here: including the group would put
- * a `--border-width` key in `tokenVars` and in every `useTheme().tokens` that
- * upstream's does not have.
+ * does not ship.
+ *
+ * It **used to omit `borderDefaults`** — which it ships and publishes a
+ * `BorderVarName` type for — and this port recorded that as an upstream bug
+ * rather than correcting it, since including the group would have put a
+ * `--border-width` key in `tokenVars` and in every `useTheme().tokens` that
+ * upstream's did not have. Upstream 0.4.2 folded it in (#5026), so the group is
+ * here now and the debt retires with it. `focusDefaults` was simply missing on
+ * this side, and lands in the same pass.
  */
 export const tokenDefaults: Record<string, string> = {
 	...colorDefaults,
 	...spacingDefaults,
 	...sizeDefaults,
+	...borderDefaults,
+	...focusDefaults,
 	...radiusDefaults,
 	...shadowDefaults,
 	...durationDefaults,

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -115,3 +115,31 @@ export { isFocusDetached } from './focus-return.js';
 // it stays module-public and barrel-absent here, on the same standing as
 // `rtlMirrorAttrs` and `__resetDevWarnings`. An extra published symbol is a
 // defect under the parity rule.
+
+// -----------------------------------------------------------------------------
+// Upstream's `utils/` directory, reunited with its subpath
+// -----------------------------------------------------------------------------
+//
+// These ten all live in upstream's `utils/index.ts` and were reachable here only
+// from the package root (or, for `parseStyleKey`, from `./theme`), so
+// `import {themeProps} from '@astryx-svelte/core/utils'` failed where upstream's
+// succeeds. Placement, not absence — recorded in `port/debts.md` as the
+// consumer-visible half of the "two homes for one upstream dir" item.
+//
+// The *files* stay where they are: `internal/types.ts`,
+// `internal/theme-props.ts`, `internal/shared-resize-observer.ts` and
+// `theme/parse-style-key.ts` are imported by name across the tree, and moving
+// them is a whole-tree import churn with no consumer-visible effect. The root
+// re-exports stay too, because they have shipped since 0.3.1 and dropping one
+// would break a consumer to tidy a barrel. This adds the subpath upstream has.
+export type { SizeValue } from '../internal/types.js';
+export { parseStyleKey } from '../theme/parse-style-key.js';
+export {
+	themeProps,
+	themeDataAttributes,
+	type ClassProps,
+	type ClassValue,
+	type ThemeProps,
+	type ThemeDataAttributes
+} from '../internal/theme-props.js';
+export { observeResize, unobserveResize } from '../internal/shared-resize-observer.js';

--- a/packages/core/src/tests/avatar.svelte.test.ts
+++ b/packages/core/src/tests/avatar.svelte.test.ts
@@ -552,4 +552,60 @@ describe('Avatar — interactivity (Button trichotomy)', () => {
 		await tick();
 		expect(warn).not.toHaveBeenCalled();
 	});
+
+	// -- 0.4.2: the box moves to the theme target, and a blank name is no name --
+
+	it('puts the avatar box on the element that carries the theme target', async () => {
+		// T7: `.astryx-avatar` documents a `size` visual prop, so the width and
+		// height that prop selects on must live on the targeted element — a theme
+		// rule that resizes the target has to resize the whole avatar, not leave a
+		// fixed-size circle inside a grown box.
+		const screen = await render(Avatar, {
+			props: { name: 'Ada Lovelace', size: 'lg', 'data-testid': 'a' }
+		});
+		const root = screen.container.querySelector('[data-testid="a"]') as HTMLElement;
+		expect(root.className).toContain('astryx-avatar');
+		expect(root.getAttribute('style') ?? '').toContain('48px');
+
+		const content = root.firstElementChild as HTMLElement;
+		expect(content.getAttribute('style') ?? '').not.toContain('48px');
+	});
+
+	it('keeps the box on the root for an interactive avatar too', async () => {
+		const screen = await render(Avatar, { props: { name: 'Ada', size: 'lg', href: '/ada' } });
+		const link = screen.getByRole('link', { name: 'Ada' }).element();
+		expect(link.getAttribute('style') ?? '').toContain('48px');
+	});
+
+	describe('a whitespace-only name carries no identity', () => {
+		it('falls through to the default icon instead of an empty plate', async () => {
+			const screen = await render(Avatar, { props: { name: '   ', 'data-testid': 'a' } });
+			const el = screen.container.querySelector('[data-testid="a"]') as HTMLElement;
+			expect(el.querySelector('svg')).not.toBeNull();
+			expect(el.textContent?.trim()).toBe('');
+		});
+
+		it('is decorative rather than a role="img" with a blank name', async () => {
+			const screen = await render(Avatar, { props: { name: '   ', 'data-testid': 'a' } });
+			const el = screen.container.querySelector('[data-testid="a"]') as HTMLElement;
+			expect(el).toHaveAttribute('aria-hidden', 'true');
+			expect(el).not.toHaveAttribute('aria-label');
+		});
+
+		it('keeps a meaningful alt as the accessible name and still shows the icon', async () => {
+			const screen = await render(Avatar, {
+				props: { name: '   ', alt: 'Profile photo', 'data-testid': 'a' }
+			});
+			const el = screen.getByRole('img', { name: 'Profile photo' }).element();
+			expect(el).toBe(screen.container.querySelector('[data-testid="a"]'));
+			expect(el.querySelector('svg')).not.toBeNull();
+		});
+
+		it('treats a whitespace-only alt the same way', async () => {
+			const screen = await render(Avatar, {
+				props: { alt: '  ', name: 'Ada Lovelace', 'data-testid': 'a' }
+			});
+			await expect.element(screen.getByRole('img', { name: 'Ada Lovelace' })).toBeInTheDocument();
+		});
+	});
 });

--- a/packages/core/src/tests/button-group.svelte.test.ts
+++ b/packages/core/src/tests/button-group.svelte.test.ts
@@ -17,14 +17,15 @@ import ButtonGroupHarness from './fixtures/button-group-harness.svelte';
  * arrived with 0.1.9's `elevation` prop; both are ported now and both passed on
  * the first run.)
  *
- * **Dropped: the two `rounds a trailing DropdownMenu trigger, whose popover
- * follows it (%s)` cases.** `DropdownMenu` is not ported. Its only role in that
- * case is to be a member that renders its own `[popover]` sibling after its
- * trigger, and a stub reproducing that shape would be a `<Button>` with a
- * hand-placed popover next to it — which is character for character the
- * `rounds a tooltip'd trailing Button` pair two cases above, asserted against a
- * fixture we wrote rather than against the port. Recorded in port/todo.md; the cases
- * come back with `DropdownMenu`.
+ * **The two `rounds a trailing DropdownMenu trigger, whose popover follows it
+ * (%s)` cases are back.** They were dropped when `DropdownMenu` was unported,
+ * with the note "the cases come back with `DropdownMenu`" — it has been ported
+ * since, so they do. This matters more than the count: the dropped case is the
+ * only one exercising a trailing member that emits **marker + popover** together,
+ * and the marker is exactly what `IS_LAST_ITEM` changed to skip at 0.4.2
+ * (`:not(:has(~ *:not([popover]):not(template)))`). The tooltip'd-`Button`
+ * stand-in happens to have the same shape today; a `DropdownMenu`-specific
+ * sibling order would slip past it.
  *
  * **Restated: `rounds only the last member (first/middle/last)`.** Its last
  * member is a `DropdownMenu`; a `Button` with a `tooltip` stands in, because
@@ -73,7 +74,7 @@ type CompiledRule = {
 	property: string;
 	/** CSS value, e.g. `var(--radius-element)`. */
 	value: string;
-	/** The full compiled selector, e.g. `.xajhecq:not(:has(~ *:not([popover])))`. */
+	/** The full compiled selector, e.g. `.x1rmb4wm:not(:has(~ *:not([popover]):not(template)))`. */
 	selector: string;
 };
 
@@ -302,15 +303,16 @@ describe('ButtonGroup', () => {
 	// ===========================================================================
 	// Trailing radius (issue #2508)
 	//
-	// The trailing end cap cannot be keyed off `:last-child`: members render an
-	// invisible layer AFTER their button (tooltip'd Button, DropdownMenu), and
-	// useLayer renders it inline rather than portaling it, so the layer steals the
-	// slot. See IS_LAST_ITEM in button.stylex.ts.
+	// The trailing end cap cannot be keyed off `:last-child`: members render
+	// invisible layer infrastructure AFTER their button (tooltip'd Button,
+	// DropdownMenu), and useLayer renders a marker plus the layer inline when the
+	// host is safe, so they steal the slot. See IS_LAST_ITEM in
+	// button.stylex.ts.
 	// ===========================================================================
 	describe('trailing radius (#2508)', () => {
 		/** The group members, in DOM order (excludes invisible layer siblings). */
 		const items = (group: HTMLElement): Element[] =>
-			Array.from(group.querySelectorAll(':scope > *:not([popover])'));
+			Array.from(group.querySelectorAll(':scope > *:not([popover]):not(template)'));
 
 		/** A rounded (non-zero) corner is exactly this value in the compiled CSS. */
 		const ROUNDED = 'var(--radius-element)';
@@ -375,11 +377,12 @@ describe('ButtonGroup', () => {
 				for (const selector of selectors) {
 					// `:last-child` is the bug: an inline layer element steals the slot.
 					expect(selector).not.toContain(':last-child');
-					// `[popover]` must survive compilation *verbatim*. StyleX only
-					// statically evaluates a selector key from a same-file const; a
-					// `defineConsts` import compiles to a mangled selector like
+					// `[popover]` and `template` must survive compilation *verbatim*.
+					// StyleX only statically evaluates a selector key from a same-file
+					// const; a `defineConsts` import compiles to a mangled selector like
 					// `[x13pbwiz]` that matches nothing in the DOM.
 					expect(selector).toContain('[popover]');
+					expect(selector).toContain('template');
 				}
 			}
 		);
@@ -439,11 +442,37 @@ describe('ButtonGroup', () => {
 			}
 		);
 
-		// Upstream's `rounds a trailing DropdownMenu trigger, whose popover follows
-		// it (%s)` — two cases — is dropped here. See the file header: DropdownMenu
-		// is not ported, and the only thing the case needs from it is a trigger
-		// followed by its own `[popover]` sibling, which is the pair of cases
-		// immediately above.
+		it.each(['horizontal', 'vertical'] as const)(
+			'rounds a trailing DropdownMenu trigger, whose popover follows it (%s)',
+			async (orientation) => {
+				const screen = await render(ButtonGroupHarness, {
+					props: {
+						label: 'Approve action',
+						orientation,
+						members: [
+							{ label: 'Allow once', variant: 'primary' as const },
+							{
+								kind: 'dropdown-menu' as const,
+								label: 'Allow options',
+								variant: 'primary' as const,
+								items: ['Always allow']
+							}
+						]
+					}
+				});
+
+				const group = groupIn(screen.container);
+				const allow = screen.getByRole('button', { name: 'Allow once' }).element();
+				const trigger = screen.getByRole('button', { name: 'Allow options' }).element();
+
+				// The popover surface is an inline sibling after the trigger.
+				expect(trigger).not.toBe(group.lastElementChild);
+				expect(items(group).at(-1)).toBe(trigger);
+
+				expect(hasRoundedTrailingCorners(trigger, orientation)).toBe(true);
+				expect(hasRoundedTrailingCorners(allow, orientation)).toBe(false);
+			}
+		);
 
 		it('rounds a trailing link (<a>) member with a tooltip', async () => {
 			const screen = await render(ButtonGroupHarness, {

--- a/packages/core/src/tests/chat-message.svelte.test.ts
+++ b/packages/core/src/tests/chat-message.svelte.test.ts
@@ -5,6 +5,7 @@ import ChatMessageMetadata from '$lib/components/chat/chat-message-metadata.svel
 import ChatSystemMessage from '$lib/components/chat/chat-system-message.svelte';
 import ChatListProbe from './fixtures/chat-list-probe.svelte';
 import ChatMessageProbe from './fixtures/chat-message-probe.svelte';
+import ChatGhostProbe from './fixtures/chat-ghost-bubble-probe.svelte';
 import SlotProbe from './fixtures/slot-probe.svelte';
 
 /**
@@ -147,6 +148,86 @@ describe('ChatMessageBubble', () => {
 			props: { sender: 'assistant', text: 'Hi', bubbleRest: { 'data-testid': 'my-bubble' } }
 		});
 		expect(screen.container.querySelector('[data-testid="my-bubble"]')).not.toBeNull();
+	});
+
+	// -- 0.4.2: ghost alignment and the width cap (#2574) ----------------------
+
+	/**
+	 * Upstream's `sharedClasses`. StyleX emits one atomic class per declaration,
+	 * so two elements share a class exactly when they share a declaration — which
+	 * is how "these two line up" is asserted without measuring geometry.
+	 */
+	function sharedClasses(a: Element, b: Element): string[] {
+		const bClasses = new Set(Array.from(b.classList));
+		return Array.from(a.classList).filter((c) => bClasses.has(c));
+	}
+
+	function nameSlotIn(container: HTMLElement): Element {
+		const el = container.querySelector('[data-chat-name]');
+		if (!el) {
+			throw new Error('expected a bubble name slot');
+		}
+		return el;
+	}
+
+	it('ghost variant aligns custom content with the bubble text column (#2574)', async () => {
+		// Repro from the issue: a raw child renders flush with the message edge —
+		// it carries none of the inset the bubble's name slot gets.
+		const screen = await render(ChatGhostProbe, {
+			props: { name: 'Navi', hasRawChild: true, ghostTestId: 'ghost' }
+		});
+		const nameSlot = nameSlotIn(screen.container);
+		const raw = screen.container.querySelector('[data-testid="raw"]')!;
+		const ghost = screen.container.querySelector('[data-testid="ghost"]')!;
+
+		// Unwrapped custom content: no shared inset — the misalignment case.
+		expect(sharedClasses(raw, nameSlot)).toEqual([]);
+		// Ghost-wrapped content: shares the bubble slot's paddingInline
+		// declaration, so its text column matches the filled bubble exactly.
+		expect(sharedClasses(ghost, nameSlot).length).toBeGreaterThan(0);
+	});
+
+	it('ghost inset tracks message density', async () => {
+		async function insetAtDensity(density: 'balanced' | 'spacious') {
+			const screen = await render(ChatGhostProbe, {
+				props: { density, name: 'Navi', ghostTestId: `ghost-${density}` }
+			});
+			return sharedClasses(
+				screen.container.querySelector(`[data-testid="ghost-${density}"]`)!,
+				nameSlotIn(screen.container)
+			);
+		}
+
+		const balancedInset = await insetAtDensity('balanced');
+		const spaciousInset = await insetAtDensity('spacious');
+
+		// Both densities align with their own bubble's slot padding...
+		expect(balancedInset.length).toBeGreaterThan(0);
+		expect(spaciousInset.length).toBeGreaterThan(0);
+		// ...and spacious uses a wider inset than balanced.
+		expect(spaciousInset).not.toEqual(balancedInset);
+	});
+
+	it('width prop replaces the default width cap', async () => {
+		const screen = await render(ChatGhostProbe, {
+			props: { cappedTestId: 'capped', ghostTestId: 'full', ghostWidth: '100%' }
+		});
+		const capped = screen.container.querySelector('[data-testid="capped"]') as HTMLElement;
+		const full = screen.container.querySelector('[data-testid="full"]') as HTMLElement;
+
+		// Default bubbles keep the cap; a width bubble replaces it with none.
+		expect(getComputedStyle(capped).maxWidth).toMatch(/^max\(80%,\s*280px\)$/);
+		expect(getComputedStyle(full).maxWidth).toBe('none');
+		// The dynamic width value is set on the element (string passes through).
+		expect(full.getAttribute('style')).toContain('100%');
+	});
+
+	it('numeric width is treated as pixels', async () => {
+		const screen = await render(ChatGhostProbe, {
+			props: { cappedTestId: 'fixed', cappedWidth: 420 }
+		});
+		const fixed = screen.container.querySelector('[data-testid="fixed"]')!;
+		expect(fixed.getAttribute('style')).toContain('420px');
 	});
 });
 

--- a/packages/core/src/tests/container-reveal.svelte.test.ts
+++ b/packages/core/src/tests/container-reveal.svelte.test.ts
@@ -4,7 +4,10 @@ import Probe from './fixtures/container-reveal-probe.svelte';
 import ManyProbe from './fixtures/container-reveal-many-probe.svelte';
 
 /**
- * Upstream's `hooks/useContainerReveal.test.tsx`, ported case for case — all 6.
+ * Upstream's `hooks/useContainerReveal.test.tsx`, ported case for case — all 11
+ * at v0.4.2. The last five arrived with #5084's hover-intent delay and forced
+ * states, which is this port's 0.4.2 tracking batch; they are grouped at the
+ * bottom under their own banner.
  *
  * `renderHook` becomes the probe fixture and `result.current` its instance
  * export. `className` becomes `class` throughout: the hook returns Svelte
@@ -90,6 +93,66 @@ describe('useContainerReveal', () => {
 		const clipped = reveal.getContentRevealProps().class;
 		const preserved = reveal.getContentRevealProps({ isLayoutPreserved: true }).class;
 		expect(clipped).not.toBe(preserved);
+	});
+
+	// -- 0.4.2: the hover-intent delay and the forced states (#5084) -----------
+
+	it('forceState pins each end of the container to its own style block', async () => {
+		const screen = await render(Probe);
+		const { reveal } = screen.component;
+		const auto = reveal.getContainerProps().class;
+		const inactive = reveal.getContainerProps({ forceState: 'inactive' }).class;
+		const active = reveal.getContainerProps({ forceState: 'active' }).class;
+		expect(new Set([auto, inactive, active]).size).toBe(3);
+	});
+
+	it('forceVisibility pins one element, independent of its reveal mode', async () => {
+		const screen = await render(Probe);
+		const { reveal } = screen.component;
+		const auto = reveal.getContentRevealProps().class;
+		const shown = reveal.getContentRevealProps({ forceVisibility: 'shown' }).class;
+		const hidden = reveal.getContentRevealProps({ forceVisibility: 'hidden' }).class;
+		expect(new Set([auto, shown, hidden]).size).toBe(3);
+
+		// The layout-preserved variant has no position to flip, so hidden maps to
+		// its own opacity-only block.
+		expect(
+			reveal.getContentRevealProps({ forceVisibility: 'hidden', isLayoutPreserved: true }).class
+		).not.toBe(hidden);
+	});
+
+	it('hoverDelay publishes the dwell as an inline custom property', async () => {
+		const screen = await render(Probe);
+		const { reveal } = screen.component;
+		// Upstream reads `Object.values(style)` because its `style` is an object;
+		// ours is the serialised `style` attribute string, so the same claim — the
+		// dwell reaches the element as an inline custom property — is a substring
+		// check. `toContain` on a string is the assertion `toContain` on an array
+		// of values was standing in for.
+		expect(reveal.getContainerProps({ hoverDelay: 120 }).style).toContain('120ms');
+		expect(reveal.getContainerProps({ hoverDelay: 0 }).style).toBe(
+			reveal.getContainerProps().style
+		);
+	});
+
+	it('hoverDelay and forceState compose on one container', async () => {
+		const screen = await render(Probe);
+		const { reveal } = screen.component;
+		const props = reveal.getContainerProps({ hoverDelay: 120, forceState: 'inactive' });
+		expect(props.style).toContain('120ms');
+		expect(props.class).not.toBe(reveal.getContainerProps({ hoverDelay: 120 }).class);
+	});
+
+	it('ignores container options while disabled', async () => {
+		const screen = await render(Probe, { props: { options: () => ({ isEnabled: false }) } });
+		const { reveal } = screen.component;
+		// Upstream asserts `toEqual({})`. The Svelte return carries the two
+		// attribute keys whatever the state, so the equivalent claim is that both
+		// are empty — which is what `is inert when disabled` above already asserts
+		// for the no-argument call, restated here with the options supplied.
+		const props = reveal.getContainerProps({ hoverDelay: 120, forceState: 'inactive' });
+		expect(props.class).toBeFalsy();
+		expect(props.style).toBeFalsy();
 	});
 
 	it('mounts a large flat list without a dev warning', async () => {

--- a/packages/core/src/tests/dropdown-menu-sub-menu.svelte.test.ts
+++ b/packages/core/src/tests/dropdown-menu-sub-menu.svelte.test.ts
@@ -496,6 +496,84 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
 	});
 });
 
+/**
+ * Upstream's `describe('DropdownMenuSubMenu hover/click guard')`, new at 0.4.2
+ * with the #3121 `useMenuHover` consolidation — the submenu gained the guard it
+ * never had. All three cases.
+ *
+ * Timing translation is `menu-hover.svelte.test.ts`'s: upstream drives fake
+ * timers and `act()`, these wait out real ones. The hover is dispatched
+ * synthetically for the same reason the other menu suites do it — a real pointer
+ * press hit-tests into a flyout that deliberately overlaps its own trigger.
+ */
+describe('DropdownMenuSubMenu hover/click guard', () => {
+	/** The hook's `DEFAULT_CLICK_GUARD_MS`. */
+	const CLICK_GUARD_MS = 500;
+
+	async function openTrigger() {
+		const screen = await render(SubMenu, { props: { scenario: 'move' } });
+		(screen.getByRole('button', { name: /Actions/ }).element() as HTMLElement).click();
+		const trigger = item(screen.container, 'Move to');
+		return { screen, trigger };
+	}
+
+	function hover(el: HTMLElement): void {
+		el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+	}
+
+	it('keeps the flyout open when a hover-open is immediately clicked', async () => {
+		const { screen, trigger } = await openTrigger();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		trigger.click();
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			expect(document.activeElement).toBe(item(screen.container, 'Folder A'));
+		});
+	});
+
+	it('closes on a click that lands well after the hover-open', async () => {
+		const { trigger } = await openTrigger();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+		// Past the guard: a deliberate dismissal, not a follow-on.
+		await new Promise((resolve) => setTimeout(resolve, CLICK_GUARD_MS + 100));
+
+		trigger.click();
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'false');
+		});
+	});
+
+	it('moves focus into the flyout synchronously on a click-open', async () => {
+		const { screen, trigger } = await openTrigger();
+
+		trigger.click();
+
+		// No waitFor and no flush: focus must already be inside the flyout when the
+		// click handler returns, which is what "synchronously" means and what a
+		// deferred (rAF) focus would fail.
+		//
+		// Scoped to the flyout rather than read through `item(container, …)`: the
+		// flyout renders *inline*, inside the trigger row's own subtree, so the
+		// trigger's `textContent` contains "Folder A" too and the container-wide
+		// lookup can return the trigger itself.
+		const flyout = flyoutFor(screen.container, trigger);
+		const firstItem = Array.from(flyout.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+			(row) => row.textContent?.trim().includes('Folder A')
+		);
+		expect(firstItem).toBeDefined();
+		expect(document.activeElement).toBe(firstItem);
+	});
+});
+
 describe('DropdownMenuSubMenu theming slots', () => {
 	it('exposes a themeable slot on the submenu indicator icon', async () => {
 		const screen = await render(SubMenu, { props: { scenario: 'move' } });

--- a/packages/core/src/tests/fixtures/button-group-harness.svelte
+++ b/packages/core/src/tests/fixtures/button-group-harness.svelte
@@ -13,7 +13,8 @@
 	 */
 	export interface GroupMember {
 		/** @default 'button' */
-		kind?: 'button' | 'icon-button' | 'raw' | 'tooltip-wrapped' | 'hover-card-wrapped';
+		kind?:
+			'button' | 'icon-button' | 'raw' | 'tooltip-wrapped' | 'hover-card-wrapped' | 'dropdown-menu';
 		label: string;
 		variant?: ButtonVariant;
 		href?: string;
@@ -24,6 +25,8 @@
 		iconTestId?: string;
 		/** Content of a wrapping `<Tooltip>` / `<HoverCard>`. */
 		content?: string;
+		/** Item labels for a `dropdown-menu` member. */
+		items?: string[];
 	}
 
 	export interface ButtonGroupHarnessProps extends Omit<ButtonGroupProps, 'children'> {
@@ -34,6 +37,7 @@
 <script lang="ts">
 	import Button from '$lib/components/button/button.svelte';
 	import ButtonGroup from '$lib/components/button-group/button-group.svelte';
+	import DropdownMenu from '$lib/components/dropdown-menu/dropdown-menu.svelte';
 	import HoverCard from '$lib/components/hover-card/hover-card.svelte';
 	import IconButton from '$lib/components/icon-button/icon-button.svelte';
 	import Tooltip from '$lib/components/tooltip/tooltip.svelte';
@@ -56,6 +60,11 @@
 			<Tooltip content={member.content ?? ''}>
 				<Button label={member.label} variant={member.variant} />
 			</Tooltip>
+		{:else if member.kind === 'dropdown-menu'}
+			<DropdownMenu
+				button={{ label: member.label, variant: member.variant }}
+				items={(member.items ?? []).map((label) => ({ label }))}
+			/>
 		{:else if member.kind === 'hover-card-wrapped'}
 			{#snippet cardContent()}{member.content ?? ''}{/snippet}
 			<HoverCard content={cardContent}>

--- a/packages/core/src/tests/fixtures/button-size-reference.svelte
+++ b/packages/core/src/tests/fixtures/button-size-reference.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import Button from '$lib/components/button/button.svelte';
+
+	/**
+	 * Two icon-only `Button`s — one at the size under test, one at `md` — so a
+	 * case can compute the atomic classes that size compiles to *and `md` does
+	 * not*.
+	 *
+	 * Upstream renders this pair inline inside `sizeOnlyClasses` and unmounts it;
+	 * a Svelte case renders a fixture instead, and the render is scoped to its own
+	 * container so there is nothing to unmount.
+	 */
+	interface Props {
+		size: 'sm' | 'lg';
+	}
+
+	const { size }: Props = $props();
+</script>
+
+{#snippet icon()}<span></span>{/snippet}
+
+<Button label="sized reference" {size} isIconOnly {icon} data-testid="sized-ref" />
+<Button label="md reference" size="md" isIconOnly {icon} data-testid="md-ref" />

--- a/packages/core/src/tests/fixtures/chat-ghost-bubble-probe.svelte
+++ b/packages/core/src/tests/fixtures/chat-ghost-bubble-probe.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import type { ChatDensity } from '$lib/components/chat/chat-context.svelte.js';
+	import type { SizeValue } from '$lib/internal/types.js';
+	import ChatMessage from '$lib/components/chat/chat-message.svelte';
+	import ChatMessageBubble from '$lib/components/chat/chat-message-bubble.svelte';
+
+	/**
+	 * The `ghost` / `width` compositions upstream's `ChatMessageBubble.test.tsx`
+	 * writes inline, added at 0.4.2 with #2574.
+	 *
+	 * Separate from `chat-message-probe.svelte` because these cases need *several*
+	 * bubbles in one message — a named one to take the inset from, optionally a
+	 * raw child, and the ghost under test — where that probe renders at most one.
+	 */
+	interface Props {
+		density?: ChatDensity;
+		/** Render a named bubble, whose name slot is the alignment reference. */
+		name?: string;
+		/** Render a raw, unwrapped child — the misalignment repro from the issue. */
+		hasRawChild?: boolean;
+		/** Render a `variant="ghost"` bubble carrying this `data-testid`. */
+		ghostTestId?: string;
+		/** `width` for the ghost bubble. */
+		ghostWidth?: SizeValue;
+		/** Render a default (capped) bubble carrying this `data-testid`. */
+		cappedTestId?: string;
+		/** `width` for the capped bubble, so a non-ghost width can be checked too. */
+		cappedWidth?: SizeValue;
+	}
+
+	const {
+		density,
+		name,
+		hasRawChild = false,
+		ghostTestId,
+		ghostWidth,
+		cappedTestId,
+		cappedWidth
+	}: Props = $props();
+</script>
+
+<ChatMessage sender="assistant" {density}>
+	{#if name}
+		<ChatMessageBubble {name}>Hello</ChatMessageBubble>
+	{/if}
+	{#if hasRawChild}
+		<div data-testid="raw">Artifact card</div>
+	{/if}
+	{#if cappedTestId}
+		<ChatMessageBubble data-testid={cappedTestId} width={cappedWidth}>Text</ChatMessageBubble>
+	{/if}
+	{#if ghostTestId}
+		<ChatMessageBubble variant="ghost" data-testid={ghostTestId} width={ghostWidth}>
+			Artifact card
+		</ChatMessageBubble>
+	{/if}
+</ChatMessage>

--- a/packages/core/src/tests/fixtures/focus-trap-fixture.svelte
+++ b/packages/core/src/tests/fixtures/focus-trap-fixture.svelte
@@ -10,7 +10,13 @@
 	const {
 		content
 	}: {
-		content: 'contenteditable' | 'inert' | 'anchor' | 'aria-hidden' | 'aria-hidden-last';
+		content:
+			| 'contenteditable'
+			| 'inert'
+			| 'anchor'
+			| 'aria-hidden'
+			| 'aria-hidden-last'
+			| 'programmatic-only';
 	} = $props();
 
 	const trap = useFocusTrap(() => ({ isActive: true }));
@@ -37,6 +43,12 @@
 			<div aria-hidden="true">
 				<button type="button" data-testid="aria-hidden-btn">Hidden from AT</button>
 			</div>
+		{:else if content === 'programmatic-only'}
+			<!--
+				Nothing tabbable, only a programmatic focus target — upstream's
+				`tabIndex={-1}` read-only dialog body, new at 0.4.2 with #5023.
+			-->
+			<div tabindex="-1" data-testid="programmatic-target">Read-only dialog content</div>
 		{:else}
 			<a href="#link" data-testid="anchor">Link</a>
 		{/if}

--- a/packages/core/src/tests/fixtures/hover-card-in-link.svelte
+++ b/packages/core/src/tests/fixtures/hover-card-in-link.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import HoverCard from '$lib/components/hover-card/hover-card.svelte';
+
+	/**
+	 * Upstream's wrapping-link tree, verbatim:
+	 * `<a href="#profile"><HoverCard content={<span><a href="#inner">Inner
+	 * link</a></span>}>Trigger</HoverCard></a>`.
+	 *
+	 * The point is the `<a>`: an interactive ancestor captures the layer's own
+	 * interactions, so the container has to be hosted outside it (#5039).
+	 */
+	interface Props {
+		/** Hover-open delay, in ms. */
+		delay?: number;
+	}
+
+	const { delay }: Props = $props();
+</script>
+
+{#snippet content()}<span><a href="#inner">Inner link</a></span>{/snippet}
+
+<!--
+	`children` as a *prop*, not component content: Svelte wraps content in a
+	snippet whatever it holds, so this is the only form that reaches `HoverCard`'s
+	text branch — which is what upstream's bare `Trigger` string is. Recorded with
+	the identical constraint in `hover-card-fixture.svelte`.
+-->
+<a href="#profile"><HoverCard {content} {delay} children="Trigger" /></a>

--- a/packages/core/src/tests/fixtures/hover-card-nested-theme.svelte
+++ b/packages/core/src/tests/fixtures/hover-card-nested-theme.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import HoverCard from '$lib/components/hover-card/hover-card.svelte';
+	import Button from '$lib/components/button/button.svelte';
+	import Theme from '$lib/theme/theme.svelte';
+	import { defineTheme } from '$lib/theme/define-theme.js';
+
+	/**
+	 * Upstream's nested-theme tree, verbatim. The point is that the corrective
+	 * portal must stop at the *inner* theme scope: a layer hoisted past it renders
+	 * under a theme its trigger was never written under.
+	 *
+	 * Needs a fixture rather than an inline tree for the reason
+	 * `icon-nested-theme.svelte` records — `render()` takes one component.
+	 */
+	interface Props {
+		/** Hover-open delay, in ms. */
+		delay?: number;
+	}
+
+	const { delay }: Props = $props();
+
+	const outerTheme = defineTheme({ name: 'hovercard-outer-test' });
+	const innerTheme = defineTheme({
+		name: 'hovercard-inner-test',
+		components: {
+			hovercard: { base: { borderWidth: '7px' } },
+			button: { base: { fontWeight: '700' } }
+		}
+	});
+</script>
+
+{#snippet content()}<Button label="View profile" />{/snippet}
+
+<Theme theme={outerTheme}>
+	<Theme theme={innerTheme}>
+		<!--
+			`children` as a prop is the only form that reaches the text branch — the
+			identical constraint `hover-card-in-link.svelte` records.
+		-->
+		<p><HoverCard {content} {delay} children="Trigger" /></p>
+	</Theme>
+</Theme>

--- a/packages/core/src/tests/fixtures/hover-card-paragraph.svelte
+++ b/packages/core/src/tests/fixtures/hover-card-paragraph.svelte
@@ -7,17 +7,23 @@
 	 * <a href="#trigger">Trigger</a></HoverCard> after</p>`.
 	 *
 	 * Kept separate from `hover-card-fixture.svelte` because the `<p>` is the
-	 * point of these cases — the layer must stay phrasing content so the HTML
-	 * parser does not reparent it out of the paragraph.
+	 * point of these cases — a paragraph is an unsafe host, so the layer has to
+	 * be corrected out of it rather than reparented by the HTML parser.
 	 */
 	interface Props {
 		/** Text rendered inside the card. */
 		contentText?: string;
+		/** Hover-open delay, in ms. */
+		delay?: number;
+		/** Hover-close delay, in ms. */
+		hideDelay?: number;
 	}
 
-	const { contentText = 'Card content' }: Props = $props();
+	const { contentText = 'Card content', delay, hideDelay }: Props = $props();
 </script>
 
 {#snippet content()}<span>{contentText}</span>{/snippet}
 
-<p>Before <HoverCard {content}><a href="#trigger">Trigger</a></HoverCard> after</p>
+<p>
+	Before <HoverCard {content} {delay} {hideDelay}><a href="#trigger">Trigger</a></HoverCard> after
+</p>

--- a/packages/core/src/tests/fixtures/hover-card-safe-host.svelte
+++ b/packages/core/src/tests/fixtures/hover-card-safe-host.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import HoverCard from '$lib/components/hover-card/hover-card.svelte';
+
+	/**
+	 * Upstream's safe-host tree: a card whose parent needs no correction, followed
+	 * by another control. The following button is the assertion's anchor — the
+	 * container must mount at the layer's own position, immediately before it.
+	 */
+	interface Props {
+		/** Hover-open delay, in ms. */
+		delay?: number;
+	}
+
+	const { delay }: Props = $props();
+</script>
+
+{#snippet content()}<div>Block card content</div>{/snippet}
+
+<HoverCard {content} {delay}><button type="button">Trigger</button></HoverCard>
+<button type="button">Following control</button>

--- a/packages/core/src/tests/fixtures/layer-context-harness.svelte
+++ b/packages/core/src/tests/fixtures/layer-context-harness.svelte
@@ -17,6 +17,7 @@
 		positioning,
 		placement,
 		alignment,
+		offset,
 		layerStyle,
 		triggerStyle,
 		triggerDir
@@ -24,6 +25,8 @@
 		positioning?: 'anchor' | 'custom';
 		placement?: LayerPlacement;
 		alignment?: LayerAlignment;
+		/** Gap between the layer and its anchor, on the placement's own axis. */
+		offset?: number | string;
 		layerStyle?: string;
 		triggerStyle?: string;
 		triggerDir?: 'ltr' | 'rtl';
@@ -42,6 +45,6 @@
 >
 	trigger
 </button>
-<Layer {layer} {positioning} {placement} {alignment} style={layerStyle}>
+<Layer {layer} {positioning} {placement} {alignment} {offset} style={layerStyle}>
 	<span>content</span>
 </Layer>

--- a/packages/core/src/tests/fixtures/layer-hosting-harness.svelte
+++ b/packages/core/src/tests/fixtures/layer-hosting-harness.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import Layer from '$lib/components/layer/layer.svelte';
+	import { useLayer } from '$lib/components/layer/use-layer.svelte.js';
+
+	/**
+	 * Upstream's `ContextHostingHarness`. A `lazyMount` context layer inside a
+	 * host whose safety the test chooses: `unsafe` wraps the contents in a `<p>`,
+	 * which is a host the layer has to be corrected out of.
+	 *
+	 * The trailing "Following control" button is load-bearing — the safe-host case
+	 * asserts the layer lands immediately before it, which is what "inline at the
+	 * render position" means in DOM terms.
+	 */
+	interface Props {
+		/** Wrap the contents in a `<p>`, making the layer's parent unsafe. */
+		unsafe?: boolean;
+		/** Value for a `--test-layer-color` custom property set on the host. */
+		themeColor?: string;
+		/** Writing direction set on the host. */
+		direction?: 'ltr' | 'rtl';
+		/** Writing mode set on the host. */
+		writingMode?: 'horizontal-tb' | 'vertical-rl';
+	}
+
+	const { unsafe = false, themeColor, direction, writingMode }: Props = $props();
+
+	const id = $props.id();
+	const layer = useLayer(() => ({ mode: 'context', lazyMount: true, id }));
+
+	const hostStyle = $derived(
+		[
+			themeColor ? `--test-layer-color: ${themeColor}` : '',
+			direction ? `direction: ${direction}` : '',
+			writingMode ? `writing-mode: ${writingMode}` : ''
+		]
+			.filter(Boolean)
+			.join('; ')
+	);
+</script>
+
+{#snippet contents()}
+	<button type="button" {@attach layer.attachTrigger} onclick={() => layer.show()}>Trigger</button>
+	<Layer {layer}>
+		<button type="button">Layer action</button>
+	</Layer>
+	<button type="button">Following control</button>
+{/snippet}
+
+<div data-testid="host" style={hostStyle}>
+	{#if unsafe}
+		<p>{@render contents()}</p>
+	{:else}
+		{@render contents()}
+	{/if}
+</div>

--- a/packages/core/src/tests/fixtures/layer-relocating-harness.svelte
+++ b/packages/core/src/tests/fixtures/layer-relocating-harness.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import Layer from '$lib/components/layer/layer.svelte';
+	import { useLayer } from '$lib/components/layer/use-layer.svelte.js';
+
+	/**
+	 * Upstream's `RelocatingContextHostingHarness` and
+	 * `RelocatingOpenContextHostingHarness` in one fixture — they differ only in
+	 * `lazyMount`, whether a trigger is rendered, and the safe branch's testid.
+	 *
+	 * The point of both is that the *render call itself* moves between an unsafe
+	 * and a safe position while the hook stays mounted, so the marker's parent —
+	 * and therefore the resolved portal target — has to be recomputed rather than
+	 * reused from the previous position.
+	 */
+	interface Props {
+		/** Render the layer inside a `<p>` (unsafe) rather than a `<section>`. */
+		unsafe: boolean;
+		/** Defer mounting until `show()`, and render a trigger to drive it. */
+		lazyMount?: boolean;
+		/** Forwarded to the hook so a test can count opens. */
+		onShow?: () => void;
+	}
+
+	const { unsafe, lazyMount = false, onShow }: Props = $props();
+
+	const id = $props.id();
+	const layer = useLayer(() => ({ mode: 'context', lazyMount, id, onShow }));
+
+	/** Exposed so a case can assert the hook's logical state, not just the DOM. */
+	export const hook = layer;
+</script>
+
+{#snippet renderedLayer()}
+	<Layer {layer}>
+		{#if lazyMount}
+			<button type="button">Layer action</button>
+		{:else}
+			<span>Layer content</span>
+		{/if}
+	</Layer>
+{/snippet}
+
+{#if lazyMount}
+	<button type="button" {@attach layer.attachTrigger} onclick={() => layer.show()}>Trigger</button>
+{/if}
+
+{#if unsafe}
+	<div data-testid="unsafe-host">
+		<p>{@render renderedLayer()}</p>
+	</div>
+{:else}
+	<section data-testid={lazyMount ? 'safe-host' : 'render-position'}>
+		{@render renderedLayer()}
+	</section>
+{/if}

--- a/packages/core/src/tests/fixtures/side-nav-collapse-button-scope.svelte
+++ b/packages/core/src/tests/fixtures/side-nav-collapse-button-scope.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import SideNavCollapseButton from '$lib/components/side-nav/side-nav-collapse-button.svelte';
+	import SideNavCollapseScope from '$lib/components/side-nav/side-nav-collapse-scope.svelte';
+
+	/**
+	 * Upstream's `renderExpanded(<SideNavCollapseButton … />)` — the button on its
+	 * own inside a `SideNavCollapseContext`, with no `SideNav` around it.
+	 *
+	 * `side-nav-collapse-handle-fixture` is the *imperative* wiring (a button
+	 * outside a real sidebar, joined by a handle); this is the context-only shape
+	 * the size and chevron cases need, where there is no sidebar at all.
+	 */
+	interface Props {
+		isCollapsed?: boolean;
+		/** Props spread onto the button — `size`, `data-testid`. */
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		buttonProps?: Record<string, any>;
+	}
+
+	const { isCollapsed = false, buttonProps = {} }: Props = $props();
+
+	const state = $derived({ isCollapsed, toggle: () => {}, isCollapsible: true });
+</script>
+
+<SideNavCollapseScope {state}>
+	<SideNavCollapseButton {...buttonProps} />
+</SideNavCollapseScope>

--- a/packages/core/src/tests/fixtures/side-nav-fixture.svelte
+++ b/packages/core/src/tests/fixtures/side-nav-fixture.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <script lang="ts">
+	import Button from '$lib/components/button/button.svelte';
 	import SideNav, { type SideNavProps } from '$lib/components/side-nav/side-nav.svelte';
 
 	/**
@@ -26,6 +27,8 @@
 		topContent?: SideNavSlotSpec;
 		footer?: SideNavSlotSpec;
 		footerIcons?: SideNavSlotSpec;
+		/** Renders a real `Button` in the `footerIcons` slot, for the size cascade. */
+		footerIconButton?: { testid: string; size?: 'sm' | 'md' | 'lg' };
 		/** The scrollable `children`. */
 		content?: SideNavSlotSpec;
 	}
@@ -36,6 +39,7 @@
 		topContent,
 		footer,
 		footerIcons,
+		footerIconButton,
 		content = { text: 'Content' }
 	}: Props = $props();
 </script>
@@ -44,8 +48,25 @@
 {#snippet topContentSlot()}<span data-testid={topContent?.testid}>{topContent?.text}</span
 	>{/snippet}
 {#snippet footerSlot()}<span data-testid={footer?.testid}>{footer?.text}</span>{/snippet}
-{#snippet footerIconsSlot()}<span data-testid={footerIcons?.testid}>{footerIcons?.text}</span
-	>{/snippet}
+{#snippet footerIconsSlot()}
+	{#if footerIconButton}
+		<!--
+			A real `Button`, because the size-cascade cases are about what `useSize`
+			resolves for a footer icon that did not size itself — a bare <span> reads
+			no context and would make them vacuous.
+		-->
+		<Button
+			label="Help"
+			size={footerIconButton.size}
+			isIconOnly
+			icon={buttonIcon}
+			data-testid={footerIconButton.testid}
+		/>
+	{:else}
+		<span data-testid={footerIcons?.testid}>{footerIcons?.text}</span>
+	{/if}
+{/snippet}
+{#snippet buttonIcon()}<span></span>{/snippet}
 {#snippet contentSlot()}<span data-testid={content.testid}>{content.text}</span>{/snippet}
 
 <SideNav
@@ -53,6 +74,6 @@
 	header={header ? headerSlot : undefined}
 	topContent={topContent ? topContentSlot : undefined}
 	footer={footer ? footerSlot : undefined}
-	footerIcons={footerIcons ? footerIconsSlot : undefined}
+	footerIcons={footerIcons || footerIconButton ? footerIconsSlot : undefined}
 	children={contentSlot}
 />

--- a/packages/core/src/tests/fixtures/side-nav-heading-fixture.svelte
+++ b/packages/core/src/tests/fixtures/side-nav-heading-fixture.svelte
@@ -29,6 +29,8 @@
 		 * precedence over `menu` when both are given, which no case does.
 		 */
 		menuItems?: string[];
+		/** Gives each `menuItems` entry `tabindex="-1"`, so focus can land on it. */
+		menuItemsFocusable?: boolean;
 		/** Fills `headerEndContent` with `<span data-testid={testid}>{text}</span>`. */
 		headerEndContent?: { text: string; testid?: string };
 		/** Publishes a collapsed `SideNavCollapseContext` around the heading. */
@@ -43,6 +45,7 @@
 		icon,
 		menu,
 		menuItems,
+		menuItemsFocusable = false,
 		headerEndContent,
 		collapsed = false,
 		provider
@@ -55,7 +58,14 @@
 {#snippet menuSlot()}<div>{menu}</div>{/snippet}
 {#snippet menuItemsSlot()}
 	{#each menuItems ?? [] as label (label)}
-		<div role="menuitem">{label}</div>
+		<!--
+			`tabindex` mirrors upstream, which uses two different `menuItems`
+			fragments: bare `<div role="menuitem">` for the popover-semantics cases
+			and `tabIndex={-1}` for the hover-guard ones, where focus has to land on
+			an item. A `<div>` with no tabindex is not focusable, so without it the
+			focus assertions would be vacuous.
+		-->
+		<div role="menuitem" tabindex={menuItemsFocusable ? -1 : undefined}>{label}</div>
 	{/each}
 {/snippet}
 {#snippet endSlot()}<span data-testid={headerEndContent?.testid}>{headerEndContent?.text}</span

--- a/packages/core/src/tests/fixtures/top-nav-heading-fixture.svelte
+++ b/packages/core/src/tests/fixtures/top-nav-heading-fixture.svelte
@@ -15,9 +15,16 @@
 		logo?: { img?: boolean; text?: string; testid?: string };
 		/** `menu` slot: a single `<a>` with this href and text. */
 		menu?: { href: string; text: string };
+		/**
+		 * `menu` slot as `role="menuitem"` rows — upstream's `menuItems` fragment
+		 * for the hover/click-guard block. `tabindex="-1"` matches real menu items,
+		 * because a bare `role="menuitem"` div is not focusable and the focus
+		 * assertions would be vacuous without it. Takes precedence over `menu`.
+		 */
+		menuItems?: string[];
 	}
 
-	const { props = {}, logo, menu }: Props = $props();
+	const { props = {}, logo, menu, menuItems }: Props = $props();
 </script>
 
 {#snippet logoSlot()}
@@ -35,4 +42,14 @@
 	{#if menu}<a href={menu.href}>{menu.text}</a>{/if}
 {/snippet}
 
-<TopNavHeading {...props} logo={logo ? logoSlot : undefined} menu={menu ? menuSlot : undefined} />
+{#snippet menuItemsSlot()}
+	{#each menuItems ?? [] as label (label)}
+		<div role="menuitem" tabindex="-1">{label}</div>
+	{/each}
+{/snippet}
+
+<TopNavHeading
+	{...props}
+	logo={logo ? logoSlot : undefined}
+	menu={menuItems ? menuItemsSlot : menu ? menuSlot : undefined}
+/>

--- a/packages/core/src/tests/focus-trap.svelte.test.ts
+++ b/packages/core/src/tests/focus-trap.svelte.test.ts
@@ -247,3 +247,29 @@ describe('useFocusTrap focus restoration', () => {
 		await expect.element(prev).toHaveFocus();
 	});
 });
+
+/**
+ * Upstream's `keeps a programmatic focus target when the trap has no tabbable
+ * controls`, added at 0.4.2 with #5023: a modal surface whose body is read-only
+ * must not let Tab escape to the page behind it.
+ *
+ * `fireEvent.keyDown(...) === false` carries over as the return of
+ * `dispatchEvent`, which is what Testing Library returns: `false` means the
+ * event **was** cancelled. So upstream's assertion is that the trap swallows
+ * Tab even with nothing tabbable to move to — which is the whole point, since
+ * letting it through is how focus escapes to the page behind the modal.
+ */
+describe('useFocusTrap with no tabbable controls', () => {
+	it('keeps a programmatic focus target when the trap has no tabbable controls', async () => {
+		const screen = await render(Trap, { props: { content: 'programmatic-only' } });
+		const target = screen.getByTestId('programmatic-target').element() as HTMLElement;
+		target.focus();
+
+		const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+		const notCancelled = target.dispatchEvent(event);
+
+		expect(notCancelled).toBe(false);
+		await expect.element(screen.getByTestId('programmatic-target')).toHaveFocus();
+		await expect.element(screen.getByTestId('outside')).not.toHaveFocus();
+	});
+});

--- a/packages/core/src/tests/hover-card.svelte.test.ts
+++ b/packages/core/src/tests/hover-card.svelte.test.ts
@@ -2,12 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import HoverCard from './fixtures/hover-card-fixture.svelte';
 import HoverCardParagraph from './fixtures/hover-card-paragraph.svelte';
+import HoverCardInLink from './fixtures/hover-card-in-link.svelte';
+import HoverCardSafeHost from './fixtures/hover-card-safe-host.svelte';
+import HoverCardNestedTheme from './fixtures/hover-card-nested-theme.svelte';
 import { TIMER_BUDGET } from './timer-budget.js';
 import { whenWired } from './trigger-wiring.js';
 
 /**
- * Ported from Astryx's `HoverCard/HoverCard.test.tsx`. Twenty of its
- * twenty-four cases live here.
+ * Ported from Astryx's `HoverCard/HoverCard.test.tsx` at v0.4.2, which declares
+ * twenty-eight cases. Twenty-four of them live here.
  *
  * Three of the remaining four are server-side and live in `hover-card.test.ts`,
  * which runs in the node project against `svelte/server` — the repo rule that
@@ -61,12 +64,34 @@ function layerIn(container: HTMLElement): HTMLElement {
 }
 
 /**
+ * The layer, or null. `HoverCard` opts into `lazyMount` as of upstream 0.4.2, so
+ * a *closed* card has no container at all — only the inert marker — and the
+ * cases that assert its absence need a lookup that does not throw.
+ */
+function maybeLayerIn(container: HTMLElement): HTMLElement | null {
+	const el = container.querySelector('[popover]');
+	return el instanceof HTMLElement ? el : null;
+}
+
+/** Open the card and wait for its container to mount. */
+async function open(container: HTMLElement, selector?: string): Promise<HTMLElement> {
+	mouse(await triggerIn(container, selector), 'mouseenter');
+	await vi.waitFor(() => {
+		expect(maybeLayerIn(container)).not.toBeNull();
+	});
+	return layerIn(container);
+}
+
+/**
  * Async because it waits for the trigger to be *wired*, not merely present —
  * see `trigger-wiring.ts`. Every interaction below goes through here so the
  * precondition cannot be forgotten at a call site.
  */
-async function triggerIn(container: HTMLElement): Promise<HTMLElement> {
-	const el = container.querySelector('button, a, span[tabindex]');
+async function triggerIn(container: HTMLElement, selector?: string): Promise<HTMLElement> {
+	// `selector` narrows for the trees that wrap the card in another interactive
+	// element — in `hover-card-in-link.svelte` the outer `<a>` would win the
+	// default query, and hovering it opens nothing.
+	const el = container.querySelector(selector ?? 'button, a, span[tabindex]');
 	if (!(el instanceof HTMLElement)) {
 		throw new Error('expected a trigger');
 	}
@@ -90,19 +115,29 @@ describe('HoverCard', () => {
 	});
 
 	it('exposes the floating layer as role="group" when no label is provided', async () => {
-		const screen = await render(HoverCard);
+		const screen = await render(HoverCard, { props: { delay: 0 } });
 		// A group may validly be unnamed; an unnamed dialog may not. Without a
 		// label the layer must not claim the dialog role.
 		// `getByRole(…, {hidden: true})` → a container query; see the header.
-		expect(screen.container.querySelector('[role="group"]')).toHaveTextContent('Card content');
+		// Nothing is mounted until the card opens (`lazyMount`, upstream 0.4.2).
+		expect(screen.container.querySelector('[role="group"]')).toBeNull();
 		expect(screen.container.querySelector('[role="dialog"]')).toBeNull();
+
+		await open(screen.container);
+
+		expect(screen.container.querySelector('[role="group"]')).toHaveTextContent('Card content');
 	});
 
 	it('exposes the floating layer as a named dialog when label is provided', async () => {
-		const screen = await render(HoverCard, { props: { label: 'Profile preview' } });
-		// The layer is hidden while closed, so assert the accessible name via the
-		// aria-label attribute on the role-carrying element — accname computation
-		// returns '' for hidden elements.
+		const screen = await render(HoverCard, {
+			props: { label: 'Profile preview', delay: 0 }
+		});
+		expect(screen.container.querySelector('[role="dialog"]')).toBeNull();
+
+		await open(screen.container);
+
+		// Assert the accessible name via the aria-label attribute on the
+		// role-carrying element — accname computation returns '' for a hidden one.
 		const dialog = screen.container.querySelector('[role="dialog"]')!;
 		expect(dialog).toHaveAttribute('aria-label', 'Profile preview');
 		expect(dialog).toHaveTextContent('Card content');
@@ -119,29 +154,108 @@ describe('HoverCard', () => {
 		expect(paragraph?.querySelector('div')).toBeNull();
 	});
 
-	it('renders the floating layer with inline-safe markup (no block elements in a paragraph)', async () => {
-		// HoverCard renders its floating layer inline (no portal), so the layer
-		// must be phrasing content to stay valid — and stay put on hydration —
-		// inside a <p>. Assert the layer popover element is a <span> and that the
-		// paragraph contains no <div> descendants at all.
-		const screen = await render(HoverCardParagraph);
+	it('portals block content before showing and restores the marker after hiding', async () => {
+		// Restated at upstream 0.4.2 (#5039), which inverted the fact this case
+		// asserts. It used to be "the layer is a <span> and stays inside the <p>",
+		// because the layer rendered inline and had to be phrasing content. A
+		// paragraph is now an *unsafe* host: the layer mounts as a <div> outside
+		// it, and only the inert <template> marker is left at the render position.
+		const screen = await render(HoverCardParagraph, { props: { delay: 0, hideDelay: 0 } });
 
 		const paragraph = screen.container.querySelector('p');
-		const layer = layerIn(screen.container);
-
-		expect(layer).not.toBeNull();
-		expect(layer.tagName).toBe('SPAN');
-		// The whole layer subtree lives inside the paragraph with no block boxes.
-		expect(paragraph?.contains(layer)).toBe(true);
+		expect(maybeLayerIn(screen.container)).toBeNull();
+		expect(paragraph?.querySelector('template')).not.toBeNull();
 		expect(paragraph?.querySelector('div')).toBeNull();
+
+		const layer = await open(screen.container);
+
+		expect(layer.tagName).toBe('DIV');
+		expect(paragraph?.contains(layer)).toBe(false);
+		expect(layer).toHaveTextContent('Card content');
+
+		mouse(await triggerIn(screen.container), 'mouseleave');
+
+		await vi.waitFor(() => {
+			expect(maybeLayerIn(screen.container)).toBeNull();
+			expect(paragraph?.querySelector('template')).not.toBeNull();
+		});
 	});
 
-	it('does not show content initially', async () => {
+	it('hosts the floating layer outside a wrapping link', async () => {
+		// Interactive ancestors capture the layer's own interactions: a card left
+		// inside an <a> puts its links and buttons inside that link, so clicking
+		// one navigates.
+		const screen = await render(HoverCardInLink, { props: { delay: 0 } });
+
+		const link = screen.container.querySelector('a[href="#profile"]')!;
+		expect(maybeLayerIn(screen.container)).toBeNull();
+
+		const layer = await open(screen.container, 'span[tabindex]');
+
+		expect(link.contains(layer)).toBe(false);
+	});
+
+	it('keeps a safe layer inline at its render position', async () => {
+		const screen = await render(HoverCardSafeHost, { props: { delay: 0 } });
+
+		const layer = await open(screen.container);
+		const following = screen.getByRole('button', { name: 'Following control' }).element();
+
+		// The marker's parent is safe, so nothing moves: the container mounts where
+		// the layer was written, immediately before the next control.
+		expect(layer.nextElementSibling).toBe(following);
+	});
+
+	it('does not render content initially', async () => {
 		const screen = await render(HoverCard);
-		// Content is in DOM (popover not open but element exists)
-		const content = layerIn(screen.container);
-		expect(content).toBeInTheDocument();
-		expect(content).toHaveTextContent('Card content');
+		// `lazyMount`: only the inert marker exists until the card is asked to open.
+		expect(maybeLayerIn(screen.container)).toBeNull();
+		expect(screen.container.querySelector('template')).not.toBeNull();
+	});
+
+	it('keeps a paragraph portal inside the nearest nested theme scope', async () => {
+		const screen = await render(HoverCardNestedTheme, { props: { delay: 0 } });
+
+		const layer = await open(screen.container);
+		const innerThemeScope = screen.container.querySelector(
+			'[data-astryx-theme="hovercard-inner-test"]'
+		);
+
+		expect(innerThemeScope).not.toBeNull();
+		expect(layer.querySelector('button')).not.toBeNull();
+		expect(layer.parentElement).toBe(innerThemeScope);
+		expect(innerThemeScope?.contains(layer)).toBe(true);
+		expect(screen.container.querySelector('p')?.contains(layer)).toBe(false);
+	});
+
+	/**
+	 * Counterpart to upstream's `does not freeze computed CSS variables on a
+	 * paragraph portal`. Upstream stubs `window.getComputedStyle` to answer with a
+	 * fixed map of custom properties, because jsdom resolves none — so its version
+	 * can only check that nothing was written *onto* the element.
+	 *
+	 * A real browser resolves them, so the stronger half is available and is the
+	 * one that matters: a property set on the corrective host *after* the layer
+	 * moved there still reaches it. A snapshot taken at portal time would not
+	 * update, and an absent-inline-property check alone cannot tell the two apart.
+	 */
+	it('does not freeze computed CSS variables on a paragraph portal', async () => {
+		const screen = await render(HoverCardParagraph, { props: { delay: 0 } });
+
+		const layer = await open(screen.container);
+		expect(screen.container.querySelector('p')?.contains(layer)).toBe(false);
+
+		// Nothing about the theme is snapshotted onto the element…
+		const inline = Array.from({ length: layer.style.length }, (_, i) => layer.style.item(i));
+		expect(inline.some((property) => property.startsWith('--'))).toBe(false);
+
+		// …so a custom property set on the corrective host still reaches it live.
+		const host = layer.parentElement as HTMLElement;
+		host.style.setProperty('--test-hovercard-color', 'rgb(1, 2, 3)');
+		expect(getComputedStyle(layer).getPropertyValue('--test-hovercard-color').trim()).toBe(
+			'rgb(1, 2, 3)'
+		);
+		host.style.removeProperty('--test-hovercard-color');
 	});
 
 	/**
@@ -156,9 +270,10 @@ describe('HoverCard', () => {
 	 * — and it holds under any theme rather than only the default one.
 	 */
 	it('applies the theme body font to the floating layer', async () => {
-		const screen = await render(HoverCard);
+		// The card has to be open for the container to exist at all (`lazyMount`).
+		const screen = await render(HoverCard, { props: { delay: 0 } });
 
-		const layer = layerIn(screen.container);
+		const layer = await open(screen.container);
 		const bodyFont = getComputedStyle(document.documentElement)
 			.getPropertyValue('--font-family-body')
 			.trim();

--- a/packages/core/src/tests/hover-card.test.ts
+++ b/packages/core/src/tests/hover-card.test.ts
@@ -7,7 +7,7 @@ import HoverCardParagraph from './fixtures/hover-card-paragraph.svelte';
  * The server-side cases from Astryx's `HoverCard/HoverCard.test.tsx`
  * `SSR / hydration` block. They assert on `renderToString` output, so they
  * belong in the node project against `svelte/server` — the same placement
- * `metadata-list.test.ts` uses. The suite's other twenty cases are in
+ * `metadata-list.test.ts` uses. The suite's other cases are in
  * `hover-card.svelte.test.ts`, which also carries the block's full accounting.
  *
  * The first two here are ported verbatim. The third is a restatement of
@@ -18,51 +18,51 @@ import HoverCardParagraph from './fixtures/hover-card-paragraph.svelte';
  * whole string rather than looking for one attribute in it. Upstream's fourth
  * case, `server markup matches the first client render`, is dropped for the same
  * reason, and is recorded in port/todo.md.
+ *
+ * **All three were restated at upstream 0.4.2 (#5039)**, which inverted what
+ * they assert. The layer used to render inline on both server and client as
+ * phrasing markup (`<span popover>`); a context layer now emits *only* an inert
+ * `<template>` marker on the server, and resolves its real position — inline or
+ * corrected out of an unsafe ancestor — on the client. The hydration-mismatch
+ * guarantee (#3107) the block exists for is unchanged and, if anything,
+ * stronger: a marker is valid in every position, so there is nothing for the
+ * parser to reparent.
  */
 describe('HoverCard — SSR', () => {
-	// Regression coverage for the hydration mismatch (#3107). The floating
-	// layer used to be portaled into document.body behind a
-	// `typeof document !== 'undefined'` gate: the server rendered nothing while
-	// the first client render emitted the portal, so the two trees disagreed.
-	//
-	// The layer is now rendered inline as inline-safe phrasing markup (a
-	// `<span popover>`), identically on the server and the client, so there is
-	// nothing for hydration to mismatch.
-
-	it('renders the floating layer in server markup (no document gate)', () => {
+	it('renders only the inert marker in server markup', () => {
 		const { body } = render(HoverCard);
 
-		// The popover element is present in the server output...
-		expect(body).toContain('popover="manual"');
-		expect(body).toContain('Card content');
-		// ...and it is a <span> (inline-safe), not a <div>.
-		expect(body).toMatch(/<span[^>]*popover="manual"/);
+		// No container, and no consumer content, until the client resolves where
+		// the layer may live.
+		expect(body).not.toContain('popover=');
+		expect(body).not.toContain('Card content');
+		expect(body).toContain('<template');
 	});
 
-	it('keeps the floating layer inline-safe in server markup inside a paragraph', () => {
+	it('emits only a valid marker inside a paragraph', () => {
 		const { body } = render(HoverCardParagraph);
 
-		// No <div> is emitted inside the paragraph — the layer and its wrappers
-		// are all phrasing content, so the server string is valid <p> markup that
-		// the browser parser will not reparent (which would itself desync
-		// hydration).
+		// `<template>` is inert script-supporting content, so the parser has no
+		// block layer and no consumer content to reparent out of the `<p>` — which
+		// would itself desync hydration.
 		expect(body).not.toContain('<div');
-		expect(body).toMatch(/<span[^>]*popover="manual"/);
+		expect(body).not.toContain('popover=');
+		expect(body).toContain('<template');
 	});
 
 	it('keeps a default-open hover card closed in server markup', () => {
 		// isDefaultOpen must not leak the open state into SSR markup — the open
 		// call happens in an effect after hydration, so the server output is the
-		// same closed markup the first client render produces. Upstream reads that
-		// as `expect(serverHTML).toContain('popover="manual"')`, which the closed
-		// markup satisfies too; the whole-string diff below is the claim itself.
-		// Both renders start their own `$props.id()` counter, so the ids agree.
+		// same closed markup the first client render produces. The whole-string
+		// diff is the claim itself. Both renders start their own `$props.id()`
+		// counter, so the ids agree.
 		const { body } = render(HoverCard, { props: { contentText: 'Default open' } });
 		const openBody = render(HoverCard, {
 			props: { contentText: 'Default open', isDefaultOpen: true }
 		}).body;
 
-		expect(openBody).toContain('popover="manual"');
+		expect(openBody).toContain('<template');
+		expect(openBody).not.toContain('popover=');
 		expect(openBody).toBe(body);
 	});
 });

--- a/packages/core/src/tests/layer-host.svelte.test.ts
+++ b/packages/core/src/tests/layer-host.svelte.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveLayerPortalTarget } from '$lib/components/layer/layer-host.js';
+
+/**
+ * Ported case-for-case from Astryx's `Layer/layerHost.test.ts` (19 cases; the
+ * two `it.each` tables contribute 11 and 4).
+ *
+ * **Upstream's file is a `.test.ts`; this one is `.svelte.test.ts`.** The suite
+ * builds real DOM subtrees and reads `parentElement`, and this port's `.test.ts`
+ * project runs in a bare **node** environment with no `document` — so the same
+ * cases have to run in the client (real Chromium) project. Nothing about the
+ * cases changes; only which project executes them.
+ */
+
+function mount(html: string): HTMLElement {
+	const root = document.createElement('div');
+	root.id = 'root';
+	root.innerHTML = html;
+	document.body.appendChild(root);
+	return root;
+}
+
+afterEach(() => {
+	document.getElementById('root')?.remove();
+});
+
+describe('resolveLayerPortalTarget', () => {
+	it('returns null without an inline parent', () => {
+		expect(resolveLayerPortalTarget(null)).toBeNull();
+	});
+
+	it('returns null when the intended inline position is already safe', () => {
+		const root = mount('<div id="host"><template id="marker"></template></div>');
+		const target = resolveLayerPortalTarget(root.querySelector('#host'));
+
+		expect(target).toBeNull();
+	});
+
+	it.each([
+		['paragraph', '<p><template></template></p>'],
+		['heading', '<h2><template></template></h2>'],
+		['link', '<a href="#x"><template></template></a>'],
+		['button', '<button><template></template></button>'],
+		['label', '<label><template></template></label>'],
+		['data', '<data><template></template></data>'],
+		['definition', '<dfn><template></template></dfn>'],
+		['meter', '<meter><template></template></meter>'],
+		['output', '<output><template></template></output>'],
+		['progress', '<progress><template></template></progress>'],
+		['nested inline formatting', '<p><em><b><template id="marker"></template></b></em></p>']
+	])('walks out of a %s', (_name, markup) => {
+		const root = mount(`<div id="host">${markup}</div>`);
+		const marker = root.querySelector('template');
+		const target = resolveLayerPortalTarget(marker?.parentElement ?? null);
+
+		expect(target).toBe(root.querySelector('#host'));
+	});
+
+	it('walks past a safe wrapper nested inside an unsafe ancestor', () => {
+		const root = mount(
+			'<div id="host"><a href="#x"><div id="inline"><template></template></div></a></div>'
+		);
+		const target = resolveLayerPortalTarget(root.querySelector('#inline'));
+
+		expect(target).toBe(root.querySelector('#host'));
+	});
+
+	it.each([
+		['table row', '<table><tbody><tr><template></template></tr></tbody></table>'],
+		['list', '<ul><template></template></ul>'],
+		['select', '<select><template></template></select>'],
+		['heading group', '<hgroup><template></template></hgroup>']
+	])('walks out of a structural %s', (_name, markup) => {
+		const root = mount(`<div id="host">${markup}</div>`);
+		const marker = root.querySelector('template');
+		const target = resolveLayerPortalTarget(marker?.parentElement ?? null);
+
+		expect(target).toBe(root.querySelector('#host'));
+	});
+
+	it('stops at the nearest safe ancestor rather than the body', () => {
+		const root = mount(
+			'<section id="outer"><li id="host"><p><span id="t">t</span></p></li></section>'
+		);
+		const marker = root.querySelector('#t');
+		const target = resolveLayerPortalTarget(marker?.parentElement ?? null);
+
+		// The nearest safe ancestor keeps the layer inside the trigger's theme
+		// scope and next to it in the tab order.
+		expect(target).toBe(root.querySelector('#host'));
+		expect(target).not.toBe(document.body);
+	});
+});

--- a/packages/core/src/tests/layer.svelte.test.ts
+++ b/packages/core/src/tests/layer.svelte.test.ts
@@ -7,9 +7,19 @@ import {
 } from '$lib/components/layer/use-layer.svelte.js';
 import ContextHarness from './fixtures/layer-context-harness.svelte';
 import FixedHarness from './fixtures/layer-fixed-harness.svelte';
+import HostingHarness from './fixtures/layer-hosting-harness.svelte';
+import RelocatingHarness from './fixtures/layer-relocating-harness.svelte';
 
 /**
- * Ported from Astryx's `Layer/useLayer.test.tsx`, all twenty-nine cases.
+ * Ported from Astryx's `Layer/useLayer.test.tsx` at v0.4.2 — **all thirty-two of
+ * its cases**, plus one beyond-upstream case documented at its own site.
+ *
+ * The header twice stated a count that was true of no upstream tag: first "all
+ * twenty-nine cases", which was 0.4.1-minus-`describe('offset')` and named none
+ * of the five it was short, then a corrected twenty-seven while those five were
+ * still missing. They are ported now — `offset` had been implemented since
+ * before 0.4.0 with nothing asserting it — as is the nine-case
+ * `describe('context hosting')` block 0.4.2 added.
  *
  * `getPositionTryFallbacks` is pure and its five cases transcribe. The rendered
  * ones needed two mechanical changes:
@@ -381,6 +391,83 @@ describe('useLayer context positioning', () => {
 		});
 	});
 
+	/**
+	 * Upstream's `describe('offset')`, all five cases. They had never been ported,
+	 * while `offset` itself has been implemented since before 0.4.0 — the header
+	 * said "all twenty-nine cases" and these were the five it was short.
+	 *
+	 * **Counterpart, and stronger.** Upstream reads StyleX's *debug-mode* variable
+	 * names (`--x-marginBlockStart`) off the inline style, because jsdom resolves
+	 * neither the `var()` indirection nor logical margin properties — so the
+	 * declaration is all it can check. Chromium resolves both, so these read the
+	 * computed logical margins instead: that is the fact the declaration stands in
+	 * for, and it also catches a value the engine rejected, which upstream's form
+	 * cannot.
+	 */
+	describe('offset', () => {
+		async function openAndGetOffsets(props: Record<string, unknown>) {
+			const layer = await openContext(props);
+			const computed = getComputedStyle(layer);
+			return {
+				blockStart: computed.marginBlockStart,
+				blockEnd: computed.marginBlockEnd,
+				inlineStart: computed.marginInlineStart,
+				inlineEnd: computed.marginInlineEnd
+			};
+		}
+
+		const NONE = { blockStart: '0px', blockEnd: '0px', inlineStart: '0px', inlineEnd: '0px' };
+
+		it('is flush by default', async () => {
+			expect(await openAndGetOffsets({ placement: 'below' })).toEqual(NONE);
+		});
+
+		// Both edges of the axis, so the gap survives a position-try-fallbacks flip
+		// to the opposite side (#4803).
+		it('clears both block edges for a block placement', async () => {
+			expect(await openAndGetOffsets({ placement: 'above', offset: 8 })).toEqual({
+				...NONE,
+				blockStart: '8px',
+				blockEnd: '8px'
+			});
+		});
+
+		it('clears both inline edges for an inline placement', async () => {
+			expect(await openAndGetOffsets({ placement: 'end', offset: 8 })).toEqual({
+				...NONE,
+				inlineStart: '8px',
+				inlineEnd: '8px'
+			});
+		});
+
+		it('takes a CSS length string', async () => {
+			// Resolved rather than literal: upstream asserts the declaration text
+			// `var(--spacing-1)` survives, which is all jsdom can see. Here the
+			// engine resolves it, so the assertion is that it resolves to the same
+			// length `--spacing-1` holds on the page — and that it is not zero, or
+			// the case would pass against an offset that never applied.
+			const spacing1 = getComputedStyle(document.documentElement)
+				.getPropertyValue('--spacing-1')
+				.trim();
+			expect(spacing1).not.toBe('');
+
+			const offsets = await openAndGetOffsets({
+				placement: 'below',
+				offset: 'var(--spacing-1)'
+			});
+			expect(offsets.blockStart).toBe(offsets.blockEnd);
+			expect(offsets.blockStart).not.toBe('0px');
+			expect(offsets.inlineStart).toBe('0px');
+			expect(offsets.inlineEnd).toBe('0px');
+		});
+
+		it('is ignored under custom positioning, which owns its own insets', async () => {
+			expect(
+				await openAndGetOffsets({ placement: 'below', offset: 8, positioning: 'custom' })
+			).toEqual(NONE);
+		});
+	});
+
 	it('fixed mode emits no anchor-positioning styles', async () => {
 		const screen = await render(FixedHarness, { props: { x: 10, y: 20 } });
 		await screen.getByRole('button', { name: 'opener' }).click();
@@ -388,5 +475,204 @@ describe('useLayer context positioning', () => {
 		const style = styleOf(screen.container.querySelector('[popover]'));
 		expect(style).not.toContain('position-area');
 		expect(style).not.toContain('position-anchor');
+	});
+});
+
+/**
+ * Upstream's `describe('context hosting')`, added at 0.4.2 with #5039. Nine
+ * cases; all nine are here.
+ *
+ * Four of them are **counterparts rather than transcriptions**, and each says so
+ * at its own site. Upstream mocks `window.getComputedStyle` wholesale because
+ * jsdom computes no styles at all, so its assertions are about what the port
+ * *wrote down*. These run in a real Chromium, which computes all of it, so the
+ * same claims are checked against live computed values — strictly stronger, and
+ * in the custom-property cases it is the only form that can distinguish "the
+ * layer inherits from the corrective host" from "the layer got a snapshot of
+ * the host's values", which is the entire point of #5039's
+ * `readPortalWritingContext`.
+ *
+ * `rerender` has no counterpart either: these use a reactive prop on the fixture
+ * and let the `$state` write flush, which is the substitute the other suites
+ * already use.
+ */
+describe('useLayer context hosting', () => {
+	const nativeShowPopover = HTMLElement.prototype.showPopover;
+
+	afterEach(() => {
+		HTMLElement.prototype.showPopover = nativeShowPopover;
+	});
+
+	it('keeps closed content mounted by default for existing consumers', async () => {
+		const screen = await render(ContextHarness);
+
+		expect(screen.container.querySelector('template')).not.toBeNull();
+		expect(screen.container.querySelector('[popover]')).not.toBeNull();
+		expect(screen.container.textContent).toContain('content');
+	});
+
+	it('renders only an inert marker until show is requested', async () => {
+		const screen = await render(HostingHarness);
+
+		const sentinel = screen.container.querySelector('template');
+		expect(sentinel).not.toBeNull();
+		expect(sentinel?.hasAttribute('id')).toBe(false);
+		expect(screen.container.querySelector('[popover]')).toBeNull();
+		expect(screen.container.textContent).not.toContain('Layer action');
+	});
+
+	it('keeps the final layer inline when the JSX position is safe', async () => {
+		const screen = await render(HostingHarness);
+		await screen.getByRole('button', { name: 'Trigger' }).click();
+
+		const layer = await vi.waitFor(() => popoverIn(screen.container));
+		const following = screen.getByRole('button', { name: 'Following control' }).element();
+		expect(layer.parentElement).toBe(screen.container.firstElementChild);
+		expect(layer.nextElementSibling).toBe(following);
+		expect(screen.container.querySelector('template')).not.toBeNull();
+	});
+
+	it('portals out of an unsafe parent and preserves its logical writing context', async () => {
+		const showSpy = vi.fn(HTMLElement.prototype.showPopover);
+		HTMLElement.prototype.showPopover = showSpy;
+
+		const screen = await render(HostingHarness, {
+			props: { unsafe: true, direction: 'rtl', writingMode: 'vertical-rl' }
+		});
+		const trigger = screen.getByRole('button', { name: 'Trigger' }).element();
+		await screen.getByRole('button', { name: 'Trigger' }).click();
+
+		const layer = await vi.waitFor(() => popoverIn(screen.container));
+		const host = screen.container.querySelector('[data-testid="host"]');
+		expect(layer.parentElement).toBe(host);
+		expect(screen.container.querySelector('p')?.contains(layer)).toBe(false);
+		// Counterpart: upstream mocks `getComputedStyle` to answer rtl/vertical-rl
+		// and then asserts `toHaveStyle`. Here the host really carries them, so the
+		// carried context is read off the layer's own computed style.
+		expect(getComputedStyle(layer).direction).toBe('rtl');
+		expect(getComputedStyle(layer).writingMode).toBe('vertical-rl');
+		expect(showSpy).toHaveBeenCalledWith({ source: trigger });
+	});
+
+	it('inherits custom properties from the corrective host without freezing an inline snapshot', async () => {
+		const screen = await render(HostingHarness, {
+			props: { unsafe: true, themeColor: 'rgb(1, 2, 3)' }
+		});
+		await screen.getByRole('button', { name: 'Trigger' }).click();
+
+		const layer = await vi.waitFor(() => popoverIn(screen.container));
+		const host = screen.container.querySelector('[data-testid="host"]') as HTMLElement;
+		expect(layer.parentElement).toBe(host);
+		// Nothing is snapshotted onto the layer…
+		expect(layer.style.getPropertyValue('--test-layer-color')).toBe('');
+		expect(host.style.getPropertyValue('--test-layer-color')).toBe('rgb(1, 2, 3)');
+		// …so the value reaches it by inheritance, live. Upstream cannot check this
+		// half at all — jsdom resolves no custom properties — and it is the half
+		// that fails if the port ever starts copying them onto the element.
+		expect(getComputedStyle(layer).getPropertyValue('--test-layer-color').trim()).toBe(
+			'rgb(1, 2, 3)'
+		);
+
+		await screen.rerender({ unsafe: true, themeColor: 'rgb(4, 5, 6)' });
+
+		await vi.waitFor(() => {
+			expect(
+				getComputedStyle(popoverIn(screen.container)).getPropertyValue('--test-layer-color').trim()
+			).toBe('rgb(4, 5, 6)');
+		});
+		expect(popoverIn(screen.container).style.getPropertyValue('--test-layer-color')).toBe('');
+	});
+
+	it('keeps a shared writing context inheriting live from the corrective host', async () => {
+		const screen = await render(HostingHarness, {
+			props: { unsafe: true, direction: 'rtl', writingMode: 'vertical-rl' }
+		});
+		await screen.getByRole('button', { name: 'Trigger' }).click();
+
+		await vi.waitFor(() => {
+			expect(getComputedStyle(popoverIn(screen.container)).direction).toBe('rtl');
+		});
+
+		await screen.rerender({ unsafe: true, direction: 'ltr', writingMode: 'horizontal-tb' });
+
+		await vi.waitFor(() => {
+			expect(getComputedStyle(popoverIn(screen.container)).direction).toBe('ltr');
+		});
+		expect(getComputedStyle(popoverIn(screen.container)).writingMode).toBe('horizontal-tb');
+	});
+
+	it('re-resolves the host when a persistent render call moves', async () => {
+		const screen = await render(RelocatingHarness, { props: { unsafe: true } });
+
+		const host = screen.container.querySelector('[data-testid="unsafe-host"]');
+		expect(popoverIn(screen.container).parentElement).toBe(host);
+		expect(screen.container.querySelector('p')?.contains(popoverIn(screen.container))).toBe(false);
+
+		await screen.rerender({ unsafe: false });
+
+		await vi.waitFor(() => {
+			const section = screen.container.querySelector('section');
+			expect(popoverIn(screen.container).parentElement).toBe(section);
+			expect(section?.querySelector('template')).not.toBeNull();
+		});
+	});
+
+	it('reopens an open lazy layer after its render call moves', async () => {
+		const onShow = vi.fn();
+		const native = nativeShowPopover;
+		const showSpy = vi.fn(function (this: HTMLElement, options?: unknown) {
+			if (!this.isConnected) {
+				throw new Error('showPopover called on a detached layer');
+			}
+			this.dataset.open = 'true';
+			return (native as (this: HTMLElement, o?: unknown) => void).call(this, options);
+		});
+		HTMLElement.prototype.showPopover = showSpy as typeof HTMLElement.prototype.showPopover;
+
+		const screen = await render(RelocatingHarness, {
+			props: { unsafe: true, lazyMount: true, onShow }
+		});
+		await screen.getByRole('button', { name: 'Trigger' }).click();
+
+		await vi.waitFor(() => {
+			expect(popoverIn(screen.container).getAttribute('data-open')).toBe('true');
+		});
+
+		await screen.rerender({ unsafe: false, lazyMount: true, onShow });
+
+		await vi.waitFor(() => {
+			const layer = popoverIn(screen.container);
+			expect(layer.parentElement).toBe(screen.container.querySelector('[data-testid="safe-host"]'));
+			expect(layer.getAttribute('data-open')).toBe('true');
+		});
+		expect(onShow).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * Beyond upstream, and the reason it earns its place is the bug it was
+	 * written for: `attachSentinel` read the `isOpen` `$state` directly, so
+	 * opening a lazy layer re-ran the attachment, re-resolved `contextMount` to a
+	 * new-but-equal object, and `{@attach intoPortal(...)}` — keyed on that
+	 * object's identity — tore itself down and re-appended the node. Removing a
+	 * *showing* popover evicts it from the top layer without firing `toggle`, and
+	 * nothing re-shows it, so every corrected-out `HoverCard` rendered hidden.
+	 *
+	 * Upstream cannot express this case: React re-renders an equal `contextMount`
+	 * into the same `createPortal` container and moves no DOM, and jsdom has no
+	 * top layer to be evicted from. The whole hazard is Svelte-specific, which is
+	 * the bar `CLAUDE.md` sets for coverage beyond upstream.
+	 *
+	 * Mutation-checked: reverting either half of the fix (the `untrack` in
+	 * `attachSentinel`, or `requestContextMount`'s equality bail-out) fails this.
+	 */
+	it('leaves a corrected-out layer actually showing, not merely mounted', async () => {
+		const screen = await render(HostingHarness, { props: { unsafe: true } });
+		await screen.getByRole('button', { name: 'Trigger' }).click();
+
+		const layer = await vi.waitFor(() => popoverIn(screen.container));
+		await vi.waitFor(() => {
+			expect(layer.matches(':popover-open')).toBe(true);
+		});
+		expect(getComputedStyle(layer).display).not.toBe('none');
 	});
 });

--- a/packages/core/src/tests/menu-hover.svelte.test.ts
+++ b/packages/core/src/tests/menu-hover.svelte.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
+import TopNavMenuFixture, { type TopNavMenuItemSpec } from './fixtures/top-nav-menu-fixture.svelte';
+
+/**
+ * Ported from Astryx's `hooks/useMenuHover.test.tsx`, new at v0.4.2 with #3121 —
+ * all 21 of its `it` cases across five describes. Nothing dropped, nothing added.
+ *
+ * **Exercised through `TopNavMenu`, a real consumer, not a synthetic harness.**
+ * That is upstream's own choice and its stated reason ("so the hook cannot drift
+ * from how consumers wire it"), and it carries over unchanged: the hook is
+ * `internal/use-menu-hover.svelte.ts` here and has five adopters, so a harness
+ * that wired it by hand would be testing the harness.
+ *
+ * Two translations, both applied throughout:
+ *
+ * **Real timers, real waits.** Upstream drives everything with
+ * `vi.useFakeTimers({shouldAdvanceTime: true})` + `act(() => advanceTimersByTime(n))`,
+ * because jsdom has no clock of its own and React needs the flush. These run in a
+ * real Chromium against real `setTimeout`s, so the delays are simply waited out.
+ * `showDelay` is passed as a small explicit value (`SHOW_DELAY`) to keep that
+ * cheap; the two guard windows cannot be — `clickGuardMs` (500ms) and
+ * `REOPEN_SUPPRESS_MS` (300ms) are the hook's own constants, and a case about
+ * crossing one has to actually cross it. `act()` has no counterpart: a `$state`
+ * write flushes on its own.
+ *
+ * **`aria-expanded` is read off the trigger** on both sides, and it is the
+ * popover's own attribute rather than anything the hook writes — which is why it
+ * is the right observable for "is the menu open" in either framework.
+ *
+ * The `mockPointerlessDevice` helper is upstream's, restated against the
+ * `createMockMatchMedia` shape `app-shell.svelte.test.ts` already established
+ * here, because `useMediaQuery` subscribes with `addEventListener` where
+ * upstream's inline object only needs to answer `matches`.
+ */
+
+/** Long enough to observe the not-yet-open state, short enough to wait out. */
+const SHOW_DELAY = 60;
+/** The hook's `DEFAULT_CLICK_GUARD_MS`; a case that outlasts it must really wait. */
+const CLICK_GUARD_MS = 500;
+/** The hook's `REOPEN_SUPPRESS_MS`. */
+const REOPEN_SUPPRESS_MS = 300;
+
+const items: TopNavMenuItemSpec[] = [
+	{ title: 'Analytics', description: 'Track user behavior', href: '/analytics' },
+	{ title: 'Messaging', description: 'Real-time comms', href: '/messaging' }
+];
+
+async function renderMenu(delay = SHOW_DELAY): Promise<{
+	trigger: HTMLElement;
+	container: HTMLElement;
+}> {
+	const screen = await render(TopNavMenuFixture, {
+		props: { props: { label: 'Products', delay }, items }
+	});
+	return {
+		trigger: screen.getByRole('button', { name: 'Products' }).element() as HTMLElement,
+		container: screen.container
+	};
+}
+
+function firstMenuItem(container: HTMLElement): HTMLElement | null {
+	return container.querySelector<HTMLElement>('[role="menuitem"]');
+}
+
+function menuItems(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+}
+
+function expanded(trigger: HTMLElement): string | null {
+	return trigger.getAttribute('aria-expanded');
+}
+
+function hover(el: HTMLElement): void {
+	el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+}
+
+function unhover(el: HTMLElement): void {
+	el.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+}
+
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Upstream's `mockPointerlessDevice`: a touchscreen, so `(hover: hover)` is false. */
+function mockPointerlessDevice(): void {
+	const mql = {
+		matches: false,
+		media: '',
+		onchange: null,
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		dispatchEvent: vi.fn()
+	};
+	vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mql));
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('useMenuHover — hover/click guard', () => {
+	it('opens on hover after the show delay', async () => {
+		const { trigger } = await renderMenu();
+
+		hover(trigger);
+		expect(expanded(trigger)).toBe('false');
+
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+	});
+
+	it('keeps the menu open when a hover-open is immediately clicked', async () => {
+		const { trigger } = await renderMenu();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('true');
+	});
+
+	it('pins a confirmed menu so leaving the trigger no longer closes it', async () => {
+		const { trigger } = await renderMenu();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+		await userEvent.click(trigger);
+
+		unhover(trigger);
+		await wait(400);
+		expect(expanded(trigger)).toBe('true');
+	});
+
+	it('closes on a click that lands well after the hover-open', async () => {
+		const { trigger } = await renderMenu();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+		// Past the guard: a deliberate dismissal, not a follow-on.
+		await wait(CLICK_GUARD_MS + 100);
+
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('false');
+	});
+
+	it('closes a transient (hover-opened) menu when the pointer leaves', async () => {
+		const { trigger } = await renderMenu();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+		unhover(trigger);
+
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('false');
+		});
+	});
+
+	it('re-entering the trigger of an open menu does not re-arm the guard', async () => {
+		const { trigger } = await renderMenu();
+
+		// Click-open pins the menu.
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('true');
+
+		// Re-entering must not un-pin it, nor make the next click a "confirm".
+		unhover(trigger);
+		hover(trigger);
+		await wait(SHOW_DELAY + 40);
+		expect(expanded(trigger)).toBe('true');
+
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('false');
+	});
+
+	it('stays closed when the panel vanishing puts the trigger back under the pointer', async () => {
+		const { trigger } = await renderMenu();
+
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('true');
+
+		// Without suppression, the mouseenter fired when the panel stops covering
+		// the trigger reopens the menu — which made Escape look inert.
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('false');
+		hover(trigger);
+		await wait(SHOW_DELAY + 40);
+		expect(expanded(trigger)).toBe('false');
+	});
+
+	it('reopens on a deliberate re-hover once the suppression window passes', async () => {
+		const { trigger } = await renderMenu();
+
+		await userEvent.click(trigger);
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('false');
+
+		unhover(trigger);
+		await wait(REOPEN_SUPPRESS_MS + 100);
+		hover(trigger);
+
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+	});
+
+	it('toggles cleanly for click-only interaction', async () => {
+		const { trigger } = await renderMenu();
+
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('true');
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('false');
+	});
+});
+
+describe('useMenuHover — focus management', () => {
+	it('leaves focus on the trigger for a hover-open', async () => {
+		const { trigger, container } = await renderMenu();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+
+		expect(firstMenuItem(container)).not.toBe(document.activeElement);
+	});
+
+	it('moves focus to the first item on a click-open, synchronously', async () => {
+		const { trigger, container } = await renderMenu();
+
+		await userEvent.click(trigger);
+
+		// No waitFor and no timer flush: a deferred (rAF) focus fails here, which
+		// is the point of the assertion.
+		expect(firstMenuItem(container)).toBe(document.activeElement);
+	});
+
+	it('moves focus into the menu when a hover-open is confirmed by click', async () => {
+		const { trigger, container } = await renderMenu();
+
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+		expect(firstMenuItem(container)).not.toBe(document.activeElement);
+
+		await userEvent.click(trigger);
+		expect(firstMenuItem(container)).toBe(document.activeElement);
+	});
+
+	it('returns focus to the trigger when a click closes the menu', async () => {
+		const { trigger, container } = await renderMenu();
+
+		await userEvent.click(trigger);
+		expect(firstMenuItem(container)).toBe(document.activeElement);
+
+		await userEvent.click(trigger);
+		expect(document.activeElement).toBe(trigger);
+	});
+
+	it('returns focus to the trigger on Escape', async () => {
+		const { trigger, container } = await renderMenu();
+
+		await userEvent.click(trigger);
+		expect(firstMenuItem(container)).toBe(document.activeElement);
+
+		await userEvent.keyboard('{Escape}');
+		expect(expanded(trigger)).toBe('false');
+		expect(document.activeElement).toBe(trigger);
+	});
+});
+
+describe('useMenuHover — keyboard activation', () => {
+	it('opens on Enter and moves focus into the menu', async () => {
+		const { trigger, container } = await renderMenu();
+		trigger.focus();
+
+		await userEvent.keyboard('{Enter}');
+
+		expect(expanded(trigger)).toBe('true');
+		expect(firstMenuItem(container)).toBe(document.activeElement);
+	});
+
+	it('opens on Space', async () => {
+		const { trigger } = await renderMenu();
+		trigger.focus();
+
+		await userEvent.keyboard(' ');
+
+		expect(expanded(trigger)).toBe('true');
+	});
+
+	it('never toggles an open menu closed — it moves focus in instead', async () => {
+		const { trigger, container } = await renderMenu();
+
+		// A hover-open is the only state where a keyboard user can activate the
+		// trigger of an open menu; closing on Enter would strand them.
+		hover(trigger);
+		await vi.waitFor(() => {
+			expect(expanded(trigger)).toBe('true');
+		});
+		trigger.focus();
+
+		await userEvent.keyboard('{Enter}');
+
+		expect(expanded(trigger)).toBe('true');
+		expect(firstMenuItem(container)).toBe(document.activeElement);
+	});
+
+	it('arrow keys walk the menu items', async () => {
+		const { trigger, container } = await renderMenu();
+
+		await userEvent.click(trigger);
+		const walked = menuItems(container);
+		expect(walked[0]).toBe(document.activeElement);
+
+		await userEvent.keyboard('{ArrowDown}');
+		expect(walked[1]).toBe(document.activeElement);
+	});
+});
+
+describe('useMenuHover — devices without hover', () => {
+	it('does not open on a synthetic mouseenter from a tap', async () => {
+		mockPointerlessDevice();
+		const { trigger } = await renderMenu();
+
+		// Taps emit a compatibility mouseenter; opening on it leaves a menu
+		// hanging open behind the tap.
+		hover(trigger);
+		await wait(SHOW_DELAY + 100);
+		expect(expanded(trigger)).toBe('false');
+	});
+
+	it('still opens and closes on click', async () => {
+		mockPointerlessDevice();
+		const { trigger } = await renderMenu();
+
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('true');
+		await userEvent.click(trigger);
+		expect(expanded(trigger)).toBe('false');
+	});
+});
+
+describe('useMenuHover — native invoker wiring', () => {
+	it('registers the trigger as the panel it controls', async () => {
+		const { trigger } = await renderMenu();
+
+		// Upstream notes jsdom implements neither light dismiss nor invokers, so
+		// its version asserts the wiring only. The same assertion holds here and is
+		// backed by a real implementation rather than standing in for one.
+		expect(trigger.getAttribute('popovertarget')).toBe(trigger.getAttribute('aria-controls'));
+	});
+});

--- a/packages/core/src/tests/park-pointer.ts
+++ b/packages/core/src/tests/park-pointer.ts
@@ -1,0 +1,31 @@
+import { userEvent } from 'vitest/browser';
+
+/**
+ * Move the real pointer off the fixture, and leave it there.
+ *
+ * Hover-menu suites need this and it is not incidental. `setup-stylex` parks
+ * Playwright's physical cursor at the viewport's top-right corner, which is
+ * inside any full-width nav row a fixture renders there. Chromium re-hit-tests
+ * hover after every render, so the row receives `mouseenter` with no interaction
+ * at all — a menu with `showDelay: 0` opens on its own, and, worse, *reopens the
+ * instant a test closes it*, which reads exactly like a broken dismiss.
+ *
+ * Hovering a throwaway element moves the real cursor to it; removing the element
+ * leaves the cursor over bare `document.body`. `absolute` at a large offset
+ * rather than `fixed` at the bottom edge, for the reason `setup-stylex` records:
+ * a tall test iframe puts a `fixed; bottom: 0` element outside the visible
+ * window, where Playwright refuses to hover it.
+ *
+ * `side-nav.svelte.test.ts`'s `openMenu` is where this technique was first
+ * written down; this is that helper, shared.
+ */
+export async function parkPointer(): Promise<void> {
+	const spot = document.createElement('div');
+	spot.style.cssText = 'position:absolute;top:400px;left:0;width:4px;height:4px;z-index:2147483647';
+	document.body.append(spot);
+	try {
+		await userEvent.hover(spot);
+	} finally {
+		spot.remove();
+	}
+}

--- a/packages/core/src/tests/shared-focus-ring.ts
+++ b/packages/core/src/tests/shared-focus-ring.ts
@@ -1,0 +1,36 @@
+import { expect } from 'vitest';
+import { focusOutlineProps } from '$lib/utils/focus-outline.stylex.js';
+
+/**
+ * Upstream's `expectSharedFocusRing`, shared here rather than redeclared per
+ * suite because three suites assert it.
+ *
+ * `focusOutlineProps.focusVisible()` is this port's `stylex.props(...)` adapter,
+ * so its `class` is the same atomic class list upstream splits off
+ * `stylex.props(focusOutlineStyles.focusVisible).className`. The assertion is
+ * that the element carries every one of them — a real check, not a tautology:
+ * an element wired with a bare `sx(...)` instead of the focus-visible composer
+ * carries none of them.
+ */
+export function expectSharedFocusRing(el: Element): void {
+	const expected = (focusOutlineProps.focusVisible().class ?? '').split(' ').filter(Boolean);
+	expect(expected.length).toBeGreaterThan(0);
+	const classes = el.className.split(' ');
+	for (const c of expected) {
+		expect(classes).toContain(c);
+	}
+}
+
+/**
+ * The negative of `expectSharedFocusRing`. Upstream's, and load-bearing in the
+ * split-action case: a row holding two independent tab stops must not be ringed
+ * itself, or focusing either one paints a second outline around the whole row.
+ */
+export function expectNoSharedFocusRing(el: Element): void {
+	const expected = (focusOutlineProps.focusVisible().class ?? '').split(' ').filter(Boolean);
+	expect(expected.length).toBeGreaterThan(0);
+	const classes = el.className.split(' ');
+	for (const c of expected) {
+		expect(classes).not.toContain(c);
+	}
+}

--- a/packages/core/src/tests/side-nav.svelte.test.ts
+++ b/packages/core/src/tests/side-nav.svelte.test.ts
@@ -9,15 +9,42 @@ import HeadingFixture from './fixtures/side-nav-heading-fixture.svelte';
 import IntegrationFixture from './fixtures/side-nav-integration-fixture.svelte';
 import ItemFixture from './fixtures/side-nav-item-fixture.svelte';
 import SectionFixture from './fixtures/side-nav-section-fixture.svelte';
+import { expectNoSharedFocusRing, expectSharedFocusRing } from './shared-focus-ring.js';
+import SizeRefFixture from './fixtures/button-size-reference.svelte';
+import CollapseButtonScope from './fixtures/side-nav-collapse-button-scope.svelte';
 
 /**
- * Ported from Astryx's `SideNav/SideNav.test.tsx` — **all 99 of its `it` cases**
- * at v0.3.0, across the thirteen describe blocks it covers.
+ * Ported from Astryx's `SideNav/SideNav.test.tsx`. Upstream declares **144**
+ * cases at v0.4.2 (it had 99 at v0.3.0 and 101 at v0.4.1); **116 are here**.
  *
- * ## The count, re-derived from the tag (the previous header was wrong)
+ * ## The 0.4.2 delta, stated rather than implied
  *
- * This header used to read "all 94 of its `it` cases … nothing dropped".
- * Upstream has **99**; the five that were absent are the heading-menu popup
+ * The hardening pass added 43 cases. **Seventeen are here**, chosen as the ones
+ * that verify what that pass actually changed:
+ *
+ * - `menu hover/click guard` (4) — the #3121 `useMenuHover` consolidation, which
+ *   this port rewrote from scratch in the same batch.
+ * - `SideNav focus ring (A15)` (8) — every focusable row draws the *shared* ring,
+ *   including each half of a split-action row and not the row itself.
+ * - `SideNav size cascade` (5) — the sidenav publishes its row size to the parts
+ *   of its own output that did not size themselves, which is what
+ *   `internal/size-scope.svelte` (upstream's `SizeProvider`) exists for.
+ *
+ * **Twenty-six are not**: the forced-colors compiled-output assertions, the
+ * flyout hover-intent and coarse-pointer gates, the collapsed-submenu keyboard
+ * path, Tab order, and the catalog-named submenu dialog. Named individually in
+ * `port/debts.md`. They are behaviour this suite does exercise in other shapes,
+ * and porting them properly is a batch of its own — a hurried pass produces
+ * assertions weakened to fit, which is the failure the 0.4.2 audits caught.
+ *
+ * ## The count, re-derived from the tag (an earlier header was wrong twice)
+ *
+ * This header has twice stated a count that was true of no upstream tag —
+ * first "all 94", then "all 99 … at v0.3.0" while the pin had moved to 0.4.2.
+ * The count is a contract against *upstream's file at the current pin*, so it
+ * is re-derived here rather than carried forward.
+ *
+ * Of the five absent at the v0.3.0 re-derivation: they were the heading-menu popup
  * semantics assertions (the APG "a popup menu is not a dialog" block plus its
  * collapsed-mode sibling), and they are here now. They needed one fixture
  * addition — `side-nav-heading-fixture`'s `menuItems`, which fills the `menu`
@@ -570,6 +597,113 @@ describe('SideNavHeading', () => {
 			for (const child of Array.from(menu!.children)) {
 				expect(child).toHaveAttribute('role', 'menuitem');
 			}
+		});
+	});
+
+	/**
+	 * Upstream's four `SideNavHeading` cases for the #3121 `useMenuHover`
+	 * consolidation, added at 0.4.2. All four are here.
+	 *
+	 * Timing translation is the same one `menu-hover.svelte.test.ts` documents:
+	 * upstream drives fake timers and `act()`, these wait out real ones. The
+	 * hover is dispatched synthetically rather than through Playwright for the
+	 * reason `openMenu` above records at length — the popup deliberately covers
+	 * its own trigger, so a real pointer press hit-tests into the popup.
+	 * `SideNavHeading` passes `showDelay: 0`, so a hover-open needs only a tick.
+	 */
+	describe('menu hover/click guard (#3121)', () => {
+		const menuItems = ['Alpha', 'Beta'];
+		/** The hook's `DEFAULT_CLICK_GUARD_MS`. */
+		const CLICK_GUARD_MS = 500;
+
+		async function renderHeading() {
+			const screen = await render(HeadingFixture, {
+				props: { props: { heading: 'My App' }, menuItems, menuItemsFocusable: true }
+			});
+			return {
+				screen,
+				trigger: screen.getByRole('button', { name: 'Open menu' }).element() as HTMLElement
+			};
+		}
+
+		/**
+		 * `mouseenter` does not bubble, and with no hrefs the *whole heading* is the
+		 * trigger — the handler is on the root `<div>`, not on the chevron button
+		 * upstream names. A real pointer entering the button fires `mouseenter` on
+		 * every element it enters, so the synthetic form walks the same chain.
+		 */
+		function hover(el: HTMLElement, root: HTMLElement): void {
+			for (let node: HTMLElement | null = el; node; node = node.parentElement) {
+				node.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+				if (node === root) {
+					break;
+				}
+			}
+		}
+
+		it('keeps the menu open when a hover-open is immediately clicked', async () => {
+			const { screen, trigger } = await renderHeading();
+
+			hover(trigger, screen.container);
+			await vi.waitFor(() => {
+				expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			});
+
+			trigger.click();
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		it('closes on a click that lands well after the hover-open', async () => {
+			const { screen, trigger } = await renderHeading();
+
+			hover(trigger, screen.container);
+			await vi.waitFor(() => {
+				expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			});
+			// Past the guard: a deliberate dismissal, not a follow-on.
+			await new Promise((resolve) => setTimeout(resolve, CLICK_GUARD_MS + 100));
+
+			trigger.click();
+			// Awaited where upstream asserts synchronously: its `await user.click()`
+			// already gave React a render, while a native `.click()` returns before
+			// Svelte has flushed the `$state` write to the attribute.
+			await vi.waitFor(() => {
+				expect(trigger).toHaveAttribute('aria-expanded', 'false');
+			});
+		});
+
+		it('leaves focus on the trigger for a hover-open, and moves it in on click', async () => {
+			const { screen, trigger } = await renderHeading();
+
+			hover(trigger, screen.container);
+			await vi.waitFor(() => {
+				expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			});
+			const firstItem = screen.container.querySelector<HTMLElement>('[role="menuitem"]');
+			expect(firstItem).not.toBeNull();
+			expect(document.activeElement).not.toBe(firstItem);
+
+			trigger.click();
+			await vi.waitFor(() => {
+				expect(document.activeElement).toBe(firstItem);
+			});
+		});
+
+		it('returns focus to the trigger on Escape', async () => {
+			const { screen, trigger } = await renderHeading();
+
+			trigger.click();
+			await vi.waitFor(() => {
+				expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			});
+
+			const menu = screen.container.querySelector('[role="menu"]') as HTMLElement;
+			menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+			await vi.waitFor(() => {
+				expect(trigger).toHaveAttribute('aria-expanded', 'false');
+				expect(document.activeElement).toBe(trigger);
+			});
 		});
 	});
 });
@@ -1444,5 +1578,187 @@ describe('SideNavItem — mobile drawer close-on-activate', () => {
 		});
 		await userEvent.click(screen.getByTestId('item'));
 		expect(closeMobileNav).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * Upstream's `describe('SideNav focus ring (A15)')`, all eight cases, new at
+ * 0.4.2 with the hardening pass. Every focusable row in the sidenav draws the
+ * *shared* ring rather than a per-component one, so a theme that restyles focus
+ * restyles all of them together.
+ *
+ * `expectSharedFocusRing` / `expectNoSharedFocusRing` live in
+ * `shared-focus-ring.ts` because the TopNav suites assert the same thing.
+ */
+describe('SideNav focus ring (A15)', () => {
+	it('draws the shared ring on a link item', async () => {
+		const screen = await render(ItemFixture, {
+			props: { item: { props: { label: 'Dashboard', href: '/dashboard' } } }
+		});
+		expectSharedFocusRing(screen.getByRole('link', { name: 'Dashboard' }).element());
+	});
+
+	it('draws the shared ring on a button item', async () => {
+		const screen = await render(ItemFixture, {
+			props: { item: { props: { label: 'Dashboard', onclick: () => {} } } }
+		});
+		expectSharedFocusRing(screen.getByRole('button', { name: 'Dashboard' }).element());
+	});
+
+	it('draws the shared ring on a collapsed icon-only item', async () => {
+		const screen = await render(ItemFixture, {
+			props: {
+				collapse: 'collapsed',
+				item: { props: { label: 'Dashboard', href: '/dashboard' }, hasStubIcon: true }
+			}
+		});
+		expectSharedFocusRing(screen.getByRole('link', { name: 'Dashboard' }).element());
+	});
+
+	it('draws the shared ring on a collapsed submenu trigger', async () => {
+		const screen = await render(ItemFixture, {
+			props: {
+				collapse: 'collapsed',
+				item: {
+					props: { label: 'Settings' },
+					hasStubIcon: true,
+					children: [{ props: { label: 'General', href: '/settings/general' } }]
+				}
+			}
+		});
+		expectSharedFocusRing(screen.getByRole('button', { name: 'Settings' }).element());
+	});
+
+	it('rings each focusable of a split-action row, and not the row itself', async () => {
+		const screen = await render(ItemFixture, {
+			props: {
+				item: {
+					props: { label: 'Settings', href: '/settings', collapsible: true },
+					children: [{ props: { label: 'General', href: '/settings/general' } }]
+				}
+			}
+		});
+
+		const link = screen.getByRole('link', { name: 'Settings', exact: true }).element();
+		const toggle = screen.getByRole('button', { name: 'Collapse Settings' }).element();
+		expectSharedFocusRing(link);
+		expectSharedFocusRing(toggle);
+
+		// A presentational <div> holding two independent tab stops; ringing it too
+		// would paint a second outline around the whole row.
+		const row = link.parentElement!;
+		expect(row.tagName).toBe('DIV');
+		expect(row.contains(toggle)).toBe(true);
+		expectNoSharedFocusRing(row);
+	});
+
+	it('draws the shared ring on a heading rendered as one link', async () => {
+		const screen = await render(HeadingFixture, {
+			props: { props: { heading: 'My App', headingHref: '/' } }
+		});
+		expectSharedFocusRing(screen.getByRole('link', { name: /My App/ }).element());
+	});
+
+	it('draws the shared ring on a collapsed heading link', async () => {
+		const screen = await render(HeadingFixture, {
+			props: {
+				collapsed: true,
+				props: { heading: 'My App', headingHref: '/' },
+				icon: { text: 'i' }
+			}
+		});
+		expectSharedFocusRing(screen.getByRole('link', { name: 'My App' }).element());
+	});
+
+	it('draws the shared ring on the heading menu trigger', async () => {
+		const screen = await render(HeadingFixture, {
+			props: { props: { heading: 'My App' }, menu: 'menu' }
+		});
+		expectSharedFocusRing(screen.getByRole('button', { name: 'Open menu' }).element());
+	});
+});
+
+/**
+ * Upstream's size-cascade cases, new at 0.4.2: the sidenav publishes its row
+ * size to the parts of its own output that did not size themselves, which is
+ * what `internal/size-scope.svelte` (upstream's `SizeProvider`) exists for.
+ * All five.
+ */
+describe('SideNav size cascade', () => {
+	/**
+	 * Upstream's `sizeOnlyClasses`: the atomic classes a `size` compiles to that
+	 * `md` does not. Comparing against the `md` reference rather than asserting a
+	 * literal class keeps this independent of StyleX's hashing, and the
+	 * `length > 0` guard is upstream's own — if two sizes compiled identically
+	 * every check below would hold vacuously.
+	 */
+	async function sizeOnlyClasses(size: 'sm' | 'lg'): Promise<string[]> {
+		const screen = await render(SizeRefFixture, { props: { size } });
+		const sized = new Set(screen.getByTestId('sized-ref').element().classList);
+		const md = new Set(screen.getByTestId('md-ref').element().classList);
+		const only = [...sized].filter((c) => !md.has(c));
+		expect(only.length).toBeGreaterThan(0);
+		return only;
+	}
+
+	function expectHasAll(el: Element, classes: string[]): void {
+		for (const className of classes) {
+			expect(el.className.split(' ')).toContain(className);
+		}
+	}
+
+	it('renders the built-in collapse button at the row size, not the Button default', async () => {
+		const smClasses = await sizeOnlyClasses('sm');
+		const screen = await render(Fixture, {
+			props: { props: { collapsible: true }, content: { text: 'Dashboard' } }
+		});
+		const collapseButton = screen.getByRole('button', { name: /collapse sidebar/i }).element();
+		expectHasAll(collapseButton, smClasses);
+	});
+
+	it('cascades the same size to footerIcons the consumer did not size', async () => {
+		const smClasses = await sizeOnlyClasses('sm');
+		const screen = await render(Fixture, {
+			props: {
+				props: { collapsible: true },
+				footerIconButton: { testid: 'help' },
+				content: { text: 'Dashboard' }
+			}
+		});
+		expectHasAll(screen.getByTestId('help').element(), smClasses);
+	});
+
+	it('lets an explicit size on a footer icon win over the cascade', async () => {
+		const lgClasses = await sizeOnlyClasses('lg');
+		const screen = await render(Fixture, {
+			props: {
+				props: { collapsible: true },
+				footerIconButton: { testid: 'help', size: 'lg' },
+				content: { text: 'Dashboard' }
+			}
+		});
+		expectHasAll(screen.getByTestId('help').element(), lgClasses);
+	});
+
+	it('honours an explicit size on SideNavCollapseButton outside the nav', async () => {
+		const lgClasses = await sizeOnlyClasses('lg');
+		const screen = await render(CollapseButtonScope, {
+			props: { buttonProps: { size: 'lg', 'data-testid': 'collapse' } }
+		});
+		expectHasAll(screen.getByTestId('collapse').element(), lgClasses);
+	});
+
+	it('centres the chevron instead of seating it on a text baseline', async () => {
+		const screen = await render(CollapseButtonScope, {
+			props: { buttonProps: { 'data-testid': 'collapse' } }
+		});
+		// Icon renders its own `astryx-icon` span around the svg; the RTL-mirror
+		// wrapper this component adds is that span's parent.
+		const iconSpan = screen.getByTestId('collapse').element().querySelector('span.astryx-icon');
+		const mirror = iconSpan?.parentElement;
+		expect(mirror).not.toBeNull();
+		// The RTL-mirror wrapper is a flex item of Button's icon slot, so it takes
+		// its cross-axis position from the slot rather than from a text baseline.
+		expect(getComputedStyle(mirror!).alignSelf).not.toBe('baseline');
 	});
 });

--- a/packages/core/src/tests/slider.svelte.test.ts
+++ b/packages/core/src/tests/slider.svelte.test.ts
@@ -5,10 +5,32 @@ import Slider from '$lib/components/slider/slider.svelte';
 import SliderForm from './fixtures/slider-form.svelte';
 
 /**
- * Astryx's `Slider/Slider.test.tsx`, ported case for case — 32 upstream cases
- * (21 top-level, 8 `disabledMessage`, 3 `form participation`), 32 here. Nothing
- * dropped, nothing added. Upstream has no `displayName` case and no `ref` case,
- * so there is nothing here that is structurally unportable.
+ * Astryx's `Slider/Slider.test.tsx` at v0.4.2, which declares **47 blocks**
+ * (44 `it` + 3 `it.each`). **35 are here** — 32 plain plus the three `it.each`
+ * blocks that pin #5051's thumb inset.
+ *
+ * This header previously claimed "32 upstream cases … nothing dropped", which
+ * was never true of any upstream tag — upstream has had ≥45 since v0.2.0. The
+ * count is a contract against *upstream's* file, so the twelve that are still
+ * missing are named here rather than left implied:
+ *
+ * - `single mode renders the label as a group label naming the thumb`
+ * - `range mode labels the slider group via aria-labelledby`
+ * - `range thumb bounds update after moving a thumb`
+ * - `range thumb bounds include the minStepsBetweenThumbs gap`
+ * - `conveys required state through the accessible description`
+ * - `conveys required state on both thumbs of a range slider`
+ * - `combines required with other describedby parts in the description`
+ * - `does not mention required without isRequired`
+ * - `emits exact decimal values for fractional steps on keyboard`
+ * - `emits exact decimal values for fractional steps in range mode`
+ * - `maps a track click to the LTR value in the default direction`
+ * - (plus upstream's third `it.each` arm counted above)
+ *
+ * They cover `isRequired`, `minStepsBetweenThumbs` and RTL pointer mirroring —
+ * behaviours this suite does not exercise at all. Recorded in `port/debts.md`;
+ * the gap predates the 0.4.2 tracking batch. Upstream has no `displayName` case
+ * and no `ref` case, so nothing here is structurally unportable.
  *
  * Three environment differences, each noted again at the case that meets it:
  *
@@ -390,6 +412,57 @@ describe('Slider', () => {
 		await userEvent.keyboard('{ArrowLeft}');
 		expect(handleChange).toHaveBeenCalledWith(0);
 	});
+
+	/**
+	 * Upstream's `clamps a controlled value of $value to $expectedValue`, an
+	 * `it.each` pair. It asserts the clamped `aria-valuenow` *and* the thumb's
+	 * inset position, which is where #5051's `THUMB_INSET` becomes observable.
+	 *
+	 * Read off the CSSOM rather than the style attribute: the component writes
+	 * `inset-inline-start:calc(…)` and Chromium round-trips `calc()` through its
+	 * own serialiser, so the attribute text is not stable across engines while the
+	 * parsed property is.
+	 */
+	it.each([
+		{ value: 150, expectedValue: 100, expectedPosition: 'calc(100% - 10px)' },
+		{ value: -50, expectedValue: 0, expectedPosition: 'calc(0% + 10px)' }
+	])(
+		'clamps a controlled value of $value to $expectedValue',
+		async ({ value, expectedValue, expectedPosition }) => {
+			const screen = await render(Slider, {
+				props: { label: 'Volume', value, min: 0, max: 100 }
+			});
+			const slider = thumbIn(screen.container);
+			expect(slider.getAttribute('aria-valuenow')).toBe(String(expectedValue));
+			expect(slider.style.getPropertyValue('inset-inline-start')).toBe(expectedPosition);
+		}
+	);
+
+	// Regression: #5050 — at min/max the thumb centred on the container edge, so
+	// half of it (10px of a 20px thumb) hung outside the component.
+	it.each([
+		{ value: 0, position: 'calc(0% + 10px)' },
+		{ value: 50, position: 'calc(50% + 0px)' },
+		{ value: 100, position: 'calc(100% - 10px)' }
+	])('insets the thumb at value $value so it stays in bounds', async ({ value, position }) => {
+		const screen = await render(Slider, {
+			props: { label: 'Volume', value, min: 0, max: 100 }
+		});
+		expect(thumbIn(screen.container).style.getPropertyValue('inset-inline-start')).toBe(position);
+	});
+
+	it.each([
+		{ value: 0, position: 'calc(0% + 10px)' },
+		{ value: 100, position: 'calc(100% - 10px)' }
+	])(
+		'insets a vertical thumb at value $value so it stays in bounds',
+		async ({ value, position }) => {
+			const screen = await render(Slider, {
+				props: { label: 'Volume', value, min: 0, max: 100, orientation: 'vertical' }
+			});
+			expect(thumbIn(screen.container).style.getPropertyValue('bottom')).toBe(position);
+		}
+	);
 
 	describe('disabledMessage', () => {
 		// Upstream's `h = {hidden: true}` (a closed popover is invisible to jsdom's

--- a/packages/core/src/tests/table-context-menu.svelte.test.ts
+++ b/packages/core/src/tests/table-context-menu.svelte.test.ts
@@ -150,7 +150,15 @@ describe('Table body context menu', () => {
 		// Right-click the first body cell (Alice).
 		const alice = screen.getByText('Alice', { exact: true }).element();
 		rightClick(alice);
-		const items = menuItems(alice.closest('td')!, 'Delete row');
+		// Scoped to the render container, not the `<td>`, as every other case here
+		// is. Upstream 0.4.2's corrective portal (#5039) hosts a context layer
+		// outside ancestors that cannot legally contain it, and a `<td>` inside
+		// `<tr>`/`<tbody>`/`<table>` is four of them — a menu left in a table row is
+		// markup the parser reparents. Only the right-clicked cell's menu is open,
+		// so the container query still returns exactly Alice's (the "no plugin
+		// contributes actions" case above is what pins that: a closed cell
+		// contributes no menuitem at all).
+		const items = menuItems(screen.container, 'Delete row');
 		expect(items.length).toBeGreaterThan(0);
 		items[0].click();
 		expect(onSelect).toHaveBeenCalledWith('1');

--- a/packages/core/src/tests/theme.test.ts
+++ b/packages/core/src/tests/theme.test.ts
@@ -284,6 +284,75 @@ describe('defineTheme extends', () => {
 	});
 });
 
+/**
+ * Upstream's `describe('typography weight derivation')` (`theme/defineTheme.test.ts`),
+ * all six cases. New here rather than restated: this port had no role-level
+ * `weight` at all until it was added, which `port/debts.md` recorded as an
+ * `api-divergence` — `typography: {heading: {weight: 'semibold'}}` typechecked
+ * and was silently ignored.
+ *
+ * Read from `resolvedTokens`, not `tokens`: this port keeps the raw input map on
+ * `tokens` and the generated map on `resolvedTokens`, where upstream merges both
+ * into `tokens`. These assert on *generated* tokens, so the wrong map would make
+ * every one of them vacuous — the same note the two typography cases above carry.
+ */
+describe('typography weight derivation', () => {
+	it('applies heading weight from typography role', () => {
+		const theme = defineTheme({
+			name: 'heading-weight',
+			typography: { scale: { base: 14, ratio: 1.2 }, heading: { weight: 'bold' } }
+		});
+		// All heading levels should get bold weight
+		expect(theme.resolvedTokens['--text-heading-1-weight']).toBe('var(--font-weight-bold)');
+		expect(theme.resolvedTokens['--text-heading-4-weight']).toBe('var(--font-weight-bold)');
+	});
+
+	it('per-level heading weights override default heading weight', () => {
+		const theme = defineTheme({
+			name: 'per-level',
+			typography: {
+				scale: { base: 14, ratio: 1.2 },
+				heading: { weight: 'semibold', weights: { 3: 'bold', 4: 'bold' } }
+			}
+		});
+		expect(theme.resolvedTokens['--text-heading-1-weight']).toBe('var(--font-weight-semibold)');
+		expect(theme.resolvedTokens['--text-heading-3-weight']).toBe('var(--font-weight-bold)');
+		expect(theme.resolvedTokens['--text-heading-4-weight']).toBe('var(--font-weight-bold)');
+	});
+
+	it('body weight flows to text body token', () => {
+		const theme = defineTheme({
+			name: 'body-weight',
+			typography: { scale: { base: 14, ratio: 1.2 }, body: { weight: 'medium' } }
+		});
+		expect(theme.resolvedTokens['--text-body-weight']).toBe('var(--font-weight-medium)');
+	});
+
+	it('code weight flows to text code token', () => {
+		const theme = defineTheme({
+			name: 'code-weight',
+			typography: { scale: { base: 14, ratio: 1.2 }, code: { weight: 'medium' } }
+		});
+		expect(theme.resolvedTokens['--text-code-weight']).toBe('var(--font-weight-medium)');
+	});
+
+	it('named weight maps to var reference', () => {
+		const theme = defineTheme({
+			name: 'named-weight',
+			typography: { scale: { base: 14, ratio: 1.2 }, heading: { weight: 'normal' } }
+		});
+		expect(theme.resolvedTokens['--text-heading-1-weight']).toBe('var(--font-weight-normal)');
+	});
+
+	it('raw CSS weight value passes through', () => {
+		const theme = defineTheme({
+			name: 'raw-weight',
+			typography: { scale: { base: 14, ratio: 1.2 }, heading: { weight: '900' } }
+		});
+		expect(theme.resolvedTokens['--text-heading-1-weight']).toBe('900');
+	});
+});
+
 describe('generateThemeCss', () => {
 	const theme = defineTheme({
 		name: 'demo',

--- a/packages/core/src/tests/timestamp.svelte.test.ts
+++ b/packages/core/src/tests/timestamp.svelte.test.ts
@@ -6,7 +6,6 @@ import Timestamp from '$lib/components/timestamp/timestamp.svelte';
 import { formatTooltipLines } from '$lib/components/timestamp/tooltip-entries.js';
 import { __resetLiveRegionsForTest } from '$lib/hooks/use-announce.js';
 import TimestampI18nProbe from './fixtures/timestamp-i18n-probe.svelte';
-import { whenWired } from './trigger-wiring.js';
 
 /**
  * Astryx v0.3.0's `Timestamp/Timestamp.test.tsx`, ported case for case — 69
@@ -111,8 +110,44 @@ function cardIn(container: HTMLElement): HTMLElement {
 	return el;
 }
 
-/** Waits for the lazily-imported hover card to mount, then returns its layer. */
+/**
+ * Opens the hover card, waits for its layer to mount, and returns it.
+ *
+ * **It has to open it.** `HoverCard` opts into `useLayer`'s `lazyMount` as of
+ * upstream 0.4.2 (#5039), so a closed card is an inert `<template>` marker and
+ * nothing else — the layer these cases inspect does not exist until something
+ * asks for it. Before that it was mounted from the first render and every case
+ * could reach it cold.
+ *
+ * Hover is the opener, because it is the trigger these cases are about. The
+ * keyboard-reachability case does not come through here at all: it drives a real
+ * `userEvent.tab()`, which is the interaction *it* is about, and a helper that
+ * focused the trigger directly would be asserting something weaker.
+ */
 async function awaitCard(container: HTMLElement): Promise<HTMLElement> {
+	// Not `tsIn`: several of these cases render without a `data-testid`. The
+	// trigger's own `<time>` is the only one in the container before the card
+	// opens (the card renders one of its own).
+	//
+	// `HoverCard` wires whichever element it *found*, so the listeners and the
+	// `aria-describedby` land on the `<time>` or on the `display: contents`
+	// wrapper depending on how the caller nested it. Wait for the attribute
+	// wherever it appears, then drive that same element — dispatching into the
+	// other one is dropped on the floor (see `trigger-wiring.ts`).
+	const time = container.querySelector('time');
+	if (!(time instanceof HTMLElement)) {
+		throw new Error('expected a timestamp element');
+	}
+	await vi.waitFor(() => {
+		expect(container.querySelector('[aria-describedby]')).not.toBeNull();
+	});
+	const trigger =
+		time.closest<HTMLElement>('[aria-describedby]') ??
+		container.querySelector<HTMLElement>('[aria-describedby]');
+	if (!trigger) {
+		throw new Error('expected a wired trigger');
+	}
+	trigger.dispatchEvent(new MouseEvent('mouseenter'));
 	await vi.waitFor(() => cardIn(container));
 	return cardIn(container);
 }
@@ -142,19 +177,6 @@ function copyButtonIn(card: HTMLElement): HTMLButtonElement {
 	const el = card.querySelector('button');
 	if (!(el instanceof HTMLButtonElement)) {
 		throw new Error('expected a copy button');
-	}
-	return el;
-}
-
-/**
- * The element `HoverCard` actually wires. It attaches to the first *element*
- * child of its `display: contents` wrapper, which here is `Text`'s span — the
- * `<time>`'s parent — not the `<time>` itself.
- */
-function triggerFor(time: HTMLElement): HTMLElement {
-	const el = time.parentElement;
-	if (!(el instanceof HTMLElement)) {
-		throw new Error('expected a wired trigger');
 	}
 	return el;
 }
@@ -733,35 +755,25 @@ describe('Timestamp', () => {
 			const screen = await render(Timestamp, {
 				props: { value: Date.now() / 1000 - 3600, format: 'relative', 'data-testid': 'ts' }
 			});
-			// The card layer mounts inline and carries the full absolute time in its
-			// visible form (short timezone abbreviation) as its single default
-			// copyable row. The aria-label spells the timezone out in full
-			// (WCAG 3.1.4), so the two strings intentionally differ — compare the
-			// card against an independently formatted short-form string.
-			// Compare with normalized whitespace: Intl output can contain narrow
-			// no-break spaces the matcher's own normalization would break on.
-			const card = await awaitCard(screen.container);
-			// Re-read the `<time>` only now: `{#await}`'s pending branch — the
-			// `Suspense` fallback — renders a `<time>` of its own, and the `:then`
-			// branch replaces it with a new node inside the card's wrapper. Upstream
-			// never sees that swap, because a `React.lazy` whose promise is already
-			// resolved (its `beforeAll` warms it) renders without suspending at all.
-			const el = tsIn(screen.container);
-			const datetime = new Date(el.getAttribute('datetime') ?? '');
-			const expected = new Intl.DateTimeFormat(undefined, {
-				year: 'numeric',
-				month: 'long',
-				day: 'numeric',
-				hour: 'numeric',
-				minute: '2-digit',
-				second: '2-digit',
-				timeZoneName: 'short'
-			}).format(datetime);
-			expect(normalize(card.textContent ?? '')).toContain(normalize(expected));
 
-			// The layer having mounted does not mean the trigger is wired — those
-			// are separate effects, and focusing an unwired trigger shows nothing.
-			await whenWired(triggerFor(el));
+			// Restated at upstream 0.4.2. This case used to mount the card first and
+			// compare its text before tabbing, which only worked because the layer
+			// existed while closed; `HoverCard` now opts into `lazyMount` (#5039), so
+			// there is nothing to read until something opens it — and opening it here
+			// by hand is precisely what this case must not do. The content comparison
+			// therefore moves to the end, after the tab has opened the card, which is
+			// exactly how upstream restated its own copy.
+			//
+			// The `<time>` is re-read after the wiring settles, never before: the
+			// trigger is wired by `watchFirstElementChild`, and a node captured
+			// earlier can be a replaced one that looks identical and is not the
+			// element focus lands on.
+
+			// The trigger being present does not mean it is wired — those are
+			// separate effects, and focusing an unwired trigger shows nothing.
+			await vi.waitFor(() => {
+				expect(screen.container.querySelector('[aria-describedby]')).not.toBeNull();
+			});
 
 			// Reset the sequential-navigation starting point. Earlier cases in this
 			// file focus elements that are then unmounted, which leaves Chromium's
@@ -771,14 +783,37 @@ describe('Timestamp', () => {
 			document.body.tabIndex = -1;
 			document.body.focus();
 
-			// Tab onto the timestamp — the only tab stop in the document (the card's
-			// copy button lives inside a closed, `display: none` popover).
+			// Tab onto the timestamp — the only tab stop in the document while the
+			// card is unmounted.
 			await userEvent.tab();
-			expect(el).toHaveFocus();
+			expect(tsIn(screen.container)).toHaveFocus();
 
+			// Focus alone both mounts the card and opens it.
 			await vi.waitFor(() => {
 				expect(cardIn(screen.container).matches(':popover-open')).toBe(true);
 			});
+
+			// Upstream keeps this comparison at 0.4.2 — it *moves* it after the tab,
+			// which is what opens the card, rather than dropping it. Under
+			// `lazyMount` it is not redundant with `renders the unified copyable card
+			// with a single default absolute row`: that case reads a *hover*-mounted
+			// layer, and this is the only place a *focus*-mounted one's content is
+			// read. The card's visible row carries the short timezone abbreviation
+			// while the aria-label spells it out in full (WCAG 3.1.4), so the two
+			// strings intentionally differ — compare against an independently
+			// formatted short-form string, whitespace normalised (Intl emits narrow
+			// no-break spaces).
+			const datetime = new Date(tsIn(screen.container).getAttribute('datetime') ?? '');
+			const expected = new Intl.DateTimeFormat(undefined, {
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+				hour: 'numeric',
+				minute: '2-digit',
+				second: '2-digit',
+				timeZoneName: 'short'
+			}).format(datetime);
+			expect(normalize(cardIn(screen.container).textContent ?? '')).toContain(normalize(expected));
 		});
 
 		it('does not add a tab stop when the hover card is disabled', async () => {

--- a/packages/core/src/tests/toolbar.svelte.test.ts
+++ b/packages/core/src/tests/toolbar.svelte.test.ts
@@ -73,9 +73,9 @@ describe('Toolbar', () => {
 		await expect.element(screen.getByTestId('end')).toBeInTheDocument();
 
 		// Three-slot layout produces 3 child divs (plus the aria-hidden
-		// keyboard-hint popover, which is excluded here as an implementation detail)
+		// keyboard-hint layer infrastructure, excluded as an implementation detail)
 		const toolbar = screen.getByRole('toolbar').element();
-		expect(toolbar.querySelectorAll(':scope > :not([popover])')).toHaveLength(3);
+		expect(toolbar.querySelectorAll(':scope > :not([popover]):not(template)')).toHaveLength(3);
 	});
 
 	it('renders two-slot layout without centerContent', async () => {
@@ -86,7 +86,7 @@ describe('Toolbar', () => {
 		await expect.element(screen.getByTestId('end')).toBeInTheDocument();
 
 		const toolbar = screen.getByRole('toolbar').element();
-		expect(toolbar.querySelectorAll(':scope > :not([popover])')).toHaveLength(2);
+		expect(toolbar.querySelectorAll(':scope > :not([popover]):not(template)')).toHaveLength(2);
 	});
 
 	it('renders start-only layout', async () => {
@@ -95,7 +95,7 @@ describe('Toolbar', () => {
 		});
 		await expect.element(screen.getByTestId('start')).toBeInTheDocument();
 		const toolbar = screen.getByRole('toolbar').element();
-		expect(toolbar.querySelectorAll(':scope > :not([popover])')).toHaveLength(1);
+		expect(toolbar.querySelectorAll(':scope > :not([popover]):not(template)')).toHaveLength(1);
 	});
 
 	it('renders end-only layout', async () => {
@@ -104,7 +104,7 @@ describe('Toolbar', () => {
 		});
 		await expect.element(screen.getByTestId('end')).toBeInTheDocument();
 		const toolbar = screen.getByRole('toolbar').element();
-		expect(toolbar.querySelectorAll(':scope > :not([popover])')).toHaveLength(1);
+		expect(toolbar.querySelectorAll(':scope > :not([popover]):not(template)')).toHaveLength(1);
 	});
 
 	it('sets aria-orientation to horizontal by default', async () => {

--- a/packages/core/src/tests/top-nav-mega-menu.svelte.test.ts
+++ b/packages/core/src/tests/top-nav-mega-menu.svelte.test.ts
@@ -4,6 +4,7 @@ import { render } from 'vitest-browser-svelte';
 import TopNavMegaMenuItem from '$lib/components/top-nav/top-nav-mega-menu-item.svelte';
 import MegaMenu from './fixtures/top-nav-mega-menu-fixture.svelte';
 import { TIMER_BUDGET } from './timer-budget.js';
+import { expectSharedFocusRing } from './shared-focus-ring.js';
 
 /**
  * Ported from Astryx's `TopNav/TopNavMegaMenu.test.tsx` — **all 37 of its `it`
@@ -818,5 +819,37 @@ describe('TopNavMegaMenuItem', () => {
 			props: { mode: 'drawer', item: { title: 'Analytics', href: '/analytics' } }
 		});
 		await expect.element(screen.getByRole('link', { name: /Analytics/ })).toBeInTheDocument();
+	});
+});
+
+/**
+ * Upstream's `describe('TopNavMegaMenu — drawer focus ring')`, both cases, new at
+ * 0.4.2. They are the two that catch the defect the 0.4.2 closing audits found:
+ * `megaMenuItemDrawerAttrs` composed a bare `sx(...)` where upstream composes
+ * `focusOutlineProps.focusVisible(...)`, so a keyboard user got no visible focus
+ * anywhere in the mobile drawer.
+ *
+ * `expectSharedFocusRing` transcribes: `stylex.props(focusOutlineStyles.focusVisible)`
+ * yields the atomic classes the shared ring compiles to, and the assertion is
+ * that the element carries every one of them. That is a real check rather than a
+ * tautology — reverting the fix drops them and this goes red.
+ */
+describe('TopNavMegaMenu — drawer focus ring', () => {
+	it('draws the shared ring on the drawer section header', async () => {
+		const screen = await render(MegaMenu, {
+			props: {
+				mode: 'drawer',
+				menu: { label: 'Products' },
+				items: [{ title: 'Analytics', href: '/analytics' }]
+			}
+		});
+		expectSharedFocusRing(screen.getByRole('button', { name: 'Products' }).element());
+	});
+
+	it('draws the shared ring on a drawer item', async () => {
+		const screen = await render(MegaMenu, {
+			props: { mode: 'drawer', item: { title: 'Analytics', href: '/analytics' } }
+		});
+		expectSharedFocusRing(screen.getByRole('link', { name: /Analytics/ }).element());
 	});
 });

--- a/packages/core/src/tests/top-nav-menu.svelte.test.ts
+++ b/packages/core/src/tests/top-nav-menu.svelte.test.ts
@@ -3,6 +3,7 @@ import { render } from 'vitest-browser-svelte';
 import { userEvent } from 'vitest/browser';
 import type { LocatorSelectors } from 'vitest/browser';
 import TopNavMenuFixture, { type TopNavMenuItemSpec } from './fixtures/top-nav-menu-fixture.svelte';
+import { expectSharedFocusRing } from './shared-focus-ring.js';
 
 /**
  * Ported from Astryx's `TopNav/TopNavMenu.test.tsx` — all 12 of its `it` cases,
@@ -255,5 +256,31 @@ describe('keyboard navigation (APG menu pattern)', () => {
 		// attribute is rendered from `popover.isOpen`, and Svelte flushes that write
 		// on a microtask rather than inside the dispatch. The assertion is unchanged.
 		await expect.element(trigger).toHaveAttribute('aria-expanded', 'false');
+	});
+});
+
+/**
+ * Upstream's `describe('TopNavMenu — drawer focus ring')`, both cases, new at
+ * 0.4.2 alongside the identical pair on `TopNavMegaMenu`. `TopNavMenu`'s half of
+ * that change *was* ported when the batch landed; the mega menu's was not, which
+ * is why only the mega menu's pair goes red without its fix.
+ */
+describe('TopNavMenu — drawer focus ring', () => {
+	const drawerItems: TopNavMenuItemSpec[] = [
+		{ title: 'Analytics', description: 'Track user behavior', href: '/analytics' }
+	];
+
+	it('draws the shared ring on the drawer section header', async () => {
+		const screen = await render(TopNavMenuFixture, {
+			props: { mode: 'drawer', props: { label: 'Products' }, items: drawerItems }
+		});
+		expectSharedFocusRing(screen.getByRole('button', { name: /Products/ }).element());
+	});
+
+	it('draws the shared ring on a drawer item', async () => {
+		const screen = await render(TopNavMenuFixture, {
+			props: { mode: 'drawer', props: { label: 'Products' }, items: drawerItems }
+		});
+		expectSharedFocusRing(screen.getByRole('link', { name: /Analytics/ }).element());
 	});
 });

--- a/packages/core/src/tests/top-nav.svelte.test.ts
+++ b/packages/core/src/tests/top-nav.svelte.test.ts
@@ -14,6 +14,7 @@ import AnotherLink from './fixtures/another-link.svelte';
 import SlotProbe from './fixtures/slot-probe.svelte';
 import TopNavFixture from './fixtures/top-nav-fixture.svelte';
 import TopNavHeadingFixture from './fixtures/top-nav-heading-fixture.svelte';
+import { parkPointer } from './park-pointer.js';
 import TopNavItemFixture from './fixtures/top-nav-item-fixture.svelte';
 
 /**
@@ -599,6 +600,110 @@ describe('TopNavItem', () => {
 			const card = screen.getByTestId('featured-card');
 			await expect.element(card).toHaveAttribute('id', 'card-1');
 			await expect.element(card).toHaveAttribute('aria-label', 'Featured');
+		});
+	});
+});
+
+/**
+ * Upstream's `describe('TopNavHeading hover/click guard')`, all four cases, new
+ * at 0.4.2 with the #3121 `useMenuHover` consolidation — `TopNavHeading` gained
+ * the guard it never had.
+ *
+ * Timing translation is `menu-hover.svelte.test.ts`'s: upstream drives fake
+ * timers and `act()`, these wait out real ones. The hover is dispatched
+ * synthetically rather than through Playwright because the popup deliberately
+ * overlaps its own trigger, so a real pointer press hit-tests into the popup —
+ * the seam `side-nav.svelte.test.ts`'s `openMenu` records at length.
+ */
+describe('TopNavHeading hover/click guard', () => {
+	const menuItems = ['Alpha', 'Beta'];
+	/** The hook's `DEFAULT_CLICK_GUARD_MS`. */
+	const CLICK_GUARD_MS = 500;
+
+	async function renderHeading() {
+		const screen = await render(TopNavHeadingFixture, {
+			props: { props: { heading: 'My App' }, menuItems }
+		});
+		// The heading is a full-width row under Playwright's parked cursor, so a
+		// close springs straight back open without this. See `park-pointer.ts`.
+		await parkPointer();
+		return {
+			screen,
+			trigger: screen.getByRole('button', { name: 'Open menu' }).element() as HTMLElement
+		};
+	}
+
+	/** `mouseenter` does not bubble; walk the chain a real pointer would enter. */
+	function hover(el: HTMLElement, root: HTMLElement): void {
+		for (let node: HTMLElement | null = el; node; node = node.parentElement) {
+			node.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+			if (node === root) {
+				break;
+			}
+		}
+	}
+
+	it('keeps the menu open when a hover-open is immediately clicked', async () => {
+		const { screen, trigger } = await renderHeading();
+
+		hover(trigger, screen.container);
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		trigger.click();
+		expect(trigger).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	it('closes on a click that lands well after the hover-open', async () => {
+		const { screen, trigger } = await renderHeading();
+
+		hover(trigger, screen.container);
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+		// Past the guard: a deliberate dismissal, not a follow-on.
+		await new Promise((resolve) => setTimeout(resolve, CLICK_GUARD_MS + 100));
+
+		trigger.click();
+		// Awaited where upstream asserts synchronously: `await user.click()` gave
+		// React a render, while a native `.click()` returns before Svelte flushes.
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'false');
+		});
+	});
+
+	it('leaves focus on the trigger for a hover-open, and moves it in on click', async () => {
+		const { screen, trigger } = await renderHeading();
+
+		hover(trigger, screen.container);
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+		const firstItem = screen.container.querySelector<HTMLElement>('[role="menuitem"]');
+		expect(firstItem).not.toBeNull();
+		expect(document.activeElement).not.toBe(firstItem);
+
+		trigger.click();
+		await vi.waitFor(() => {
+			expect(document.activeElement).toBe(firstItem);
+		});
+	});
+
+	it('returns focus to the trigger on Escape', async () => {
+		const { screen, trigger } = await renderHeading();
+
+		trigger.click();
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		const menu = screen.container.querySelector('[role="menu"]') as HTMLElement;
+		menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(trigger).toHaveAttribute('aria-expanded', 'false');
+			expect(document.activeElement).toBe(trigger);
 		});
 	});
 });

--- a/packages/core/src/tests/trigger-rewire.svelte.test.ts
+++ b/packages/core/src/tests/trigger-rewire.svelte.test.ts
@@ -151,25 +151,26 @@ describe('trigger re-wiring when the wrapper’s first element child is swapped'
 	});
 
 	describe('HoverCard', () => {
-		function layerIn(container: HTMLElement): HTMLElement {
-			const el = container.querySelector('[popover]');
-			if (!(el instanceof HTMLElement)) {
-				throw new Error('expected a hover card layer');
-			}
-			return el;
-		}
+		// No `layerIn` helper here, where the Tooltip block above has one:
+		// `HoverCard` opts into `lazyMount` (#5039), so a closed card has no layer
+		// to find, and every case below reads its wiring off the trigger instead.
 
 		it('moves aria-describedby onto the new trigger element', async () => {
+			// Read off the outgoing trigger rather than off the layer. `HoverCard`
+			// opts into `useLayer`'s `lazyMount` as of upstream 0.4.2 (#5039), so a
+			// closed card has no layer element to take an id from — while the
+			// wiring under test, which is the hook's id either way, is on the
+			// trigger from the first render.
 			const screen = await render(HoverCardTriggerSwap);
-			const layer = layerIn(screen.container);
 			const button = screen.getByTestId('button-trigger').element() as HTMLElement;
-			expect(button.getAttribute('aria-describedby')).toBe(layer.id);
+			const describedBy = button.getAttribute('aria-describedby');
+			expect(describedBy).toBeTruthy();
 
 			screen.component.swap();
 
 			await vi.waitFor(() => {
 				const link = screen.getByTestId('link-trigger').element() as HTMLElement;
-				expect(link.getAttribute('aria-describedby')).toBe(layer.id);
+				expect(link.getAttribute('aria-describedby')).toBe(describedBy);
 			});
 		});
 
@@ -204,11 +205,14 @@ describe('trigger re-wiring when the wrapper’s first element child is swapped'
 		});
 
 		it('moves the anchor name onto the new trigger element', async () => {
+			// The anchor is read off the outgoing trigger, not off the layer's
+			// `position-anchor` — see the `aria-describedby` case above for why the
+			// layer is not there to read. The two are the same string by
+			// construction (`useLayer`'s `--astryx-layer-${id}`), and it is the
+			// trigger's copy this case is about.
 			const screen = await render(HoverCardTriggerSwap);
-			const layer = layerIn(screen.container);
 			const button = screen.getByTestId('button-trigger').element() as HTMLElement;
-			const anchor = positionAnchorOf(layer);
-			expect(soleAnchorName(button)).toBe(anchor);
+			const anchor = soleAnchorName(button);
 
 			screen.component.swap();
 

--- a/packages/themes/butter/package.json
+++ b/packages/themes/butter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-butter",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Butter theme for astryx-svelte — warm, creamy yellows with a friendly blue accent.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-butter": "0.4.1",
+		"@astryxdesign/theme-butter": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/packages/themes/butter/src/butter-theme.ts
+++ b/packages/themes/butter/src/butter-theme.ts
@@ -205,8 +205,11 @@ export const butterTheme = defineTheme({
 		// Radius
 		//   --radius-element drives buttons, badges, inputs — 8px per design
 		//   --radius-container drives cards, banners, popovers — 12px per design
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.375rem',
 		'--radius-element': '0.5rem', // 8px
 		'--radius-container': '0.75rem', // 12px

--- a/packages/themes/chocolate/package.json
+++ b/packages/themes/chocolate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-chocolate",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Chocolate theme for astryx-svelte — rich, cozy browns with Fraunces headings.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-chocolate": "0.4.1",
+		"@astryxdesign/theme-chocolate": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/packages/themes/chocolate/src/chocolate-theme.ts
+++ b/packages/themes/chocolate/src/chocolate-theme.ts
@@ -184,8 +184,11 @@ export const chocolateTheme = defineTheme({
 
 		// =========================================================================
 		// Radius — soft and rounded
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.375rem',
 		'--radius-element': '0.625rem',
 		'--radius-container': '0.75rem',

--- a/packages/themes/gothic/package.json
+++ b/packages/themes/gothic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-gothic",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Gothic theme for astryx-svelte — deep blue-grays and a signature display serif.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-gothic": "0.4.1",
+		"@astryxdesign/theme-gothic": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/packages/themes/gothic/src/gothic-theme.ts
+++ b/packages/themes/gothic/src/gothic-theme.ts
@@ -205,8 +205,11 @@ export const gothicTheme = defineTheme({
 
 		// =========================================================================
 		// Radius — subtle rounding (original gothic)
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.25rem',
 		'--radius-element': '0.5rem',
 		'--radius-container': '0.75rem',

--- a/packages/themes/liquid-glass/package.json
+++ b/packages/themes/liquid-glass/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-liquid-glass",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Liquid Glass theme for astryx-svelte — macOS translucent materials, capsule controls and the Apple system palette. Has no upstream Astryx counterpart.",
 	"license": "MIT",
 	"repository": {

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-matcha",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Matcha theme for astryx-svelte — earthy greens with a calm, organic feel.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-matcha": "0.4.1",
+		"@astryxdesign/theme-matcha": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-neutral",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Neutral theme for astryx-svelte — the default Astryx look.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-neutral": "0.4.1",
+		"@astryxdesign/theme-neutral": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/packages/themes/stone/package.json
+++ b/packages/themes/stone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-stone",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Stone theme for astryx-svelte — warm stone and slate, earthy and understated.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-stone": "0.4.1",
+		"@astryxdesign/theme-stone": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/packages/themes/stone/src/stone-theme.ts
+++ b/packages/themes/stone/src/stone-theme.ts
@@ -222,8 +222,11 @@ export const stoneTheme = defineTheme({
 
 		// =========================================================================
 		// Radius — clean and subtle
+		//   --radius-none and --radius-full are always fixed and must never be
+		//   scaled by a theme (see defineTheme's radius config docs) — 0 and
+		//   9999px respectively, matching @astryxdesign/core's own defaults.
 		// =========================================================================
-		'--radius-none': '0.125rem',
+		'--radius-none': '0px',
 		'--radius-inner': '0.25rem',
 		'--radius-element': '0.5rem',
 		'--radius-container': '0.75rem',

--- a/packages/themes/y2k/package.json
+++ b/packages/themes/y2k/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@astryx-svelte/theme-y2k",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Y2K theme for astryx-svelte — hot pinks, lime greens, and Poppins.",
 	"license": "MIT",
 	"repository": {
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"@astryx-svelte/core": "workspace:*",
-		"@astryxdesign/theme-y2k": "0.4.1",
+		"@astryxdesign/theme-y2k": "0.4.2",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
 		"svelte": "^5.56.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,11 +49,11 @@ importers:
         version: 0.19.0
     devDependencies:
       '@astryxdesign/cli':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@astryxdesign/theme-neutral@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(gpt-tokenizer@3.4.0)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@astryxdesign/theme-neutral@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(gpt-tokenizer@3.4.0)
       '@astryxdesign/core':
-        specifier: 0.4.1
-        version: 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0(jiti@2.7.0))
@@ -180,8 +180,8 @@ importers:
         version: 11.2.12
     devDependencies:
       '@astryxdesign/core':
-        specifier: 0.4.1
-        version: 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@babel/core':
         specifier: ^7.29.7
         version: 7.29.7
@@ -277,8 +277,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-butter':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -302,8 +302,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-chocolate':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -327,8 +327,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-gothic':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -374,8 +374,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-matcha':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -399,8 +399,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-neutral':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -427,8 +427,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-stone':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -452,8 +452,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@astryxdesign/theme-y2k':
-        specifier: 0.4.1
-        version: 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 0.4.2
+        version: 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.3
         version: 3.9.6
@@ -469,8 +469,8 @@ importers:
 
 packages:
 
-  '@astryxdesign/cli@0.4.1':
-    resolution: {integrity: sha512-G0QrLa58+kDPbN0HipEqOHN2YkqL+zgx00AfyK8+lGfG7tFoPg4BWR66pbaGc1TC8fOeIO5F5pif/82ZqfmrDA==}
+  '@astryxdesign/cli@0.4.2':
+    resolution: {integrity: sha512-vRYwT72e0sIeApFWS/XUpoe9MQ1tfeQBXY0HTo2k5Hi0G/BTtkK9yogxMXxMjCzsAxZ63N/hn9fX4lgZuLi+uw==}
     hasBin: true
     peerDependencies:
       '@astryxdesign/charts': '*'
@@ -488,53 +488,53 @@ packages:
       '@astryxdesign/theme-neutral':
         optional: true
 
-  '@astryxdesign/core@0.4.1':
-    resolution: {integrity: sha512-C+FFfmCVqfvO2orLQqIXIdC4mJncdXl1CtyvLThfo3HUnr2wc3swq6MYtv8qqDEBhz40MythHChpsGv17LROUg==}
+  '@astryxdesign/core@0.4.2':
+    resolution: {integrity: sha512-maKoWTx460x6GLICUOFmYey5FbSTxeGuHHZ45+oWgxvN8NmGzHev8/skPVf5YhvC5Afeki0fRZ+dCy4vAlNINA==}
     peerDependencies:
       '@stylexjs/stylex': ^0.19.0
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@astryxdesign/theme-butter@0.4.1':
-    resolution: {integrity: sha512-7z8nCK/DO0BZO+dSvia24g1HQMQ4lEJcBFpffME2jGoV7AnuEjDQA1c/nlhRNvsnN+kHY9a7gQz5oHm3+AffLw==}
+  '@astryxdesign/theme-butter@0.4.2':
+    resolution: {integrity: sha512-pXW+6DRJMjQYTrcp+EhMHvYGTlRdaPoROTKkgLugP5dCUCNTRyGsGQnq3mfFUzY9OABywfiv3jm2TbYiHBTBXA==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
-  '@astryxdesign/theme-chocolate@0.4.1':
-    resolution: {integrity: sha512-9nngY7s13Us8WeLlJ8qLU7ynkFxOHtZsMWxXb+6gUbZOEhSCJMUhMT0SqmyQDydo9xHCmJuy62CJQ4+PiOw5hg==}
+  '@astryxdesign/theme-chocolate@0.4.2':
+    resolution: {integrity: sha512-wMk0FYlRA0ob16HP/HLyZMG0FCGbiNK1OUzLIOVyKaIvIj2iozHBo/um/NzG0q9n6+YsY80hfWQzSJMTu7xBtg==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
-  '@astryxdesign/theme-gothic@0.4.1':
-    resolution: {integrity: sha512-888Fh7GdWhoXNb0fF9L2xC7E74CzJEXUmbfmgb2uqyb3IBwZJ6+5q+Rp7KlPGLJAljtP5P/MaGp9ZXFSfhFupg==}
+  '@astryxdesign/theme-gothic@0.4.2':
+    resolution: {integrity: sha512-grZ+uFZviX+FeSe5P8SxnsLlwPNqn3oiPy8yXylWFrL2q/5F4pjqPpkCfsvH3Q1tkGWWC1ppaL8j5ieCvaHKMw==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
-  '@astryxdesign/theme-matcha@0.4.1':
-    resolution: {integrity: sha512-OnKz2iLlFTb3d9IQkPJ1SVn9kFu9YnS4ND/7sTLLOd04Ip/r3+nJw0u6FfzL0g6/pGIhxVqbJE6EvXavGoYq7w==}
+  '@astryxdesign/theme-matcha@0.4.2':
+    resolution: {integrity: sha512-zKeNlJ7UmoH8aHLvyh7LTcFNUwgvC37qWcKXavv0caSYDMtP3JRTjWEfQs7UbB5F4w1jVmGsgGR48WQGvGFAeA==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
-  '@astryxdesign/theme-neutral@0.4.1':
-    resolution: {integrity: sha512-pZx3tfNODG6x8QD4NUkZxGa3PWab/E2XvfAqDcQz7k7kFx3jq90DMUtU5/fd4zLJMWVlu5Xyh0e63ldnmLi4eQ==}
+  '@astryxdesign/theme-neutral@0.4.2':
+    resolution: {integrity: sha512-lVCHNtertak3egsBdriXWpiascOj1odpCZZcUvg3e9kht29Zciow3n+AkqFoADWlR/ZGZJ10t8vSTAuZSwElpw==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
-  '@astryxdesign/theme-stone@0.4.1':
-    resolution: {integrity: sha512-kXRHEZuT8dkrxJfW1vXdlG/HySTgOxVtYeim/ucnxMTjc9pY9GI2of47MC86unFYU/XFx0Qrj6Exmkj9aKaQCw==}
+  '@astryxdesign/theme-stone@0.4.2':
+    resolution: {integrity: sha512-yw47kHqLzOpGuNLinGWTQ394HMkLPE86km+kJMj7tXiIaSkdLDgw1YZQchIrKqxVfv5Icyj7kaKYoY6xNIHYGg==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
-  '@astryxdesign/theme-y2k@0.4.1':
-    resolution: {integrity: sha512-tO2fltNDgMWHvgrC7H9NJMqGKqFMrjJ7s+enhDRt6P490IyhL4B98F6EcA8iILF+KfYoCufGMouYuzf1szkMgA==}
+  '@astryxdesign/theme-y2k@0.4.2':
+    resolution: {integrity: sha512-+RFZiRiRunwUJv414f46vYHeRsnqGPHLd2k0JNZBSc3tWpifNrer/TQ45ILdKec80Hle05B51TTbNKjv6ecANQ==}
     peerDependencies:
-      '@astryxdesign/core': 0.4.1
+      '@astryxdesign/core': 0.4.2
       react: '>=19'
 
   '@babel/code-frame@7.29.7':
@@ -2445,7 +2445,7 @@ packages:
 
 snapshots:
 
-  '@astryxdesign/cli@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@astryxdesign/theme-neutral@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(gpt-tokenizer@3.4.0)':
+  '@astryxdesign/cli@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@astryxdesign/theme-neutral@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(gpt-tokenizer@3.4.0)':
     dependencies:
       commander: 12.1.0
       gpt-tokenizer: 3.4.0
@@ -2453,58 +2453,58 @@ snapshots:
       jscodeshift: 17.4.0
       zod: 4.4.3
     optionalDependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@astryxdesign/theme-neutral': 0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/theme-neutral': 0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@stylexjs/stylex': 0.19.0
       intl-messageformat: 11.2.12
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@astryxdesign/theme-butter@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-butter@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 
-  '@astryxdesign/theme-chocolate@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-chocolate@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 
-  '@astryxdesign/theme-gothic@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-gothic@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 
-  '@astryxdesign/theme-matcha@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-matcha@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 
-  '@astryxdesign/theme-neutral@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-neutral@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 
-  '@astryxdesign/theme-stone@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-stone@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 
-  '@astryxdesign/theme-y2k@0.4.1(@astryxdesign/core@0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/theme-y2k@0.4.2(@astryxdesign/core@0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@astryxdesign/core': 0.4.1(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/core': 0.4.2(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react: 1.25.0(react@19.2.7)
       react: 19.2.7
 

--- a/port/debts.md
+++ b/port/debts.md
@@ -471,24 +471,6 @@ Every icon slot here is already a `Snippet`, nothing to dispatch on (Svelte-obvi
 
 Upstream slices `Children.toArray(children)` into a visible subset and a hidden measurement copy; a Svelte snippet is one opaque unit that can be rendered twice but never _sliced_, so the visible row is data-driven (exactly the shape `useOverflow`'s docstring anticipates). `overflowRenderer` is a `Snippet<[OverflowItem<T>[]]>` and `OverflowItem<T>` carries `{ value, index }` where upstream's carries `{ child: ReactElement, index }`. Rendered DOM, classes (byte-identical, oracle-clean) and fit behaviour are otherwise identical. Same forced-snippet-translation family as `Popover`/`Tooltip` above. This resolves the "**`Children.toArray` rendered twice**" blocking design decision (§Blocking design decisions) in favour of candidate (a) — the single hidden measurement container is kept, not given up. **Test suite ported** in `src/tests/overflow-list.svelte.test.ts` (14 of upstream's 15 `it` cases; `exposes a displayName` dropped — Svelte has no such surface; `forwards a ref` ported as an attachment counterpart; three `textContent`/`toBeEmptyDOMElement` cases restated to tolerate Svelte's `{#if}`/`{#each}` anchor comments + whitespace, which are `display:none` in the flex container). Runs in the **client** (Chromium) project with upstream's exact `offsetWidth`/`ResizeObserver` monkeypatch — the `server` node project has no DOM to mount into
 
-### `Timestamp` warns from an `$effect` (client-only); upstream warns during render (server too)
-
-- **units:** Timestamp, Field
-- **kind:** deliberate-divergence
-- **retires:** when `Timestamp` moves to `Field`'s init-time-warning shape
-
-Render behaviour identical. `Field` takes the better shape — an init-time body statement warns under SSR too, but only once per instance. Worth moving `Timestamp` to `Field`'s shape
-
-### `{...rest}` is spread first here, where upstream spreads `{...props}` last
-
-- **units:** Collapsible, MobileNav, ChatComposerDrawer, CodeBlock
-- **kind:** deliberate-divergence
-- **retires:** when the remaining four components are flipped to upstream's per-component position for their `data-*` reflections
-
-A settled repo-wide convention (`avatar.svelte`, `card.svelte`, `collapsible.svelte`, `kbd.svelte`, `lightbox.svelte`, …), not a per-component slip, so it is recorded once rather than per component. It inverts precedence for any attribute the component also sets itself: upstream lets a caller's value win, ours lets the component's win. Mostly invisible, because the props a component sets are usually destructured out of rest. Where it bites, ours is arguably the safer order — in `Lightbox` upstream's order lets a caller-supplied `oncancel` _replace_ `handleCancel`, so Escape stops calling `onOpenChange(false)`. The cost is that a caller-supplied `aria-label`/`oncancel` is silently dropped instead of honoured. Revisit as one decision across all components rather than flipping any single one, which would only make the set inconsistent.
-
-**17c flipped five and the entry needs restating.** `ChatSendButton`, `CommandPalette`, `DropdownMenu`, `CommandPaletteGroup` and `TopNavItem` moved to upstream's per-component position, each because the precedence was **observable** — those elements write `role`/`aria-label`/`aria-current` themselves, so the order decides whether a consumer can override them. That is exactly the inconsistent state this entry warned about, so the convention is now **per-component where checked, first elsewhere**. The residue is measured rather than estimated: upstream spreads rest **last** in eleven components and **first** in fifteen, and all fifteen already match. Of the eleven, five are done and four more (`Collapsible`, `MobileNav`, `ChatComposerDrawer`, `CodeBlock`) invert precedence for `data-*` reflections only — worth closing as one set. `TopNavItem` also shows what the flip costs: `href`/`target` had to be destructured out of rest first, which is why upstream names them
-
 ### `Switch` omits an upstream leading-whitespace text node
 
 - **units:** Switch
@@ -521,20 +503,45 @@ Verified a bug in source _and_ `dist/`; intent is unambiguous (aimed at the popo
 
 Upstream publishes `./Button`, `./Card`, … (~110). We ship `.`, `./theme`, `./theme/syntax`, `./utils`, `./i18n`, `./hooks`, `./naming`, `./base.css`. Defensible while the barrel is small, but a real surface difference
 
-### Repo-wide surface drift, found by the batch-5 `astryx-surface` sweep
+### Repo-wide surface drift — missing exports closed, over-exports sanctioned under a written rule
 
 - **units:** -
 - **kind:** api-divergence
-- **retires:** when `FormLayoutContext`, `useTruncation` (+ its two types) and `SizeProvider` land, and the over-export set is swept
+- **retires:** partially retired at 0.4.2 polish; the `./naming` duplication and the four inline-union aliases remain
 
-All of it _predates_ batch 5 — the batch's own units are clean — but it is now measured, so it should be worked a directory at a time rather than rediscovered. **9 missing exports**: `ButtonVariantMap` (the only one of upstream's 12 augmentation interfaces we lack, so a consumer cannot add a Button variant the way `BadgeVariantMap` allows), `DropdownMenuContext`, `FormLayoutContext`, `useTruncation` + its two types, `SizeProvider` (name drift — `setSizeContext` stands in). **`TextXStyleAllowed` and `ProseElement`
-are now landed**, with the Prose-defaults item that had been holding them: both are declared in
-`theme/types.ts` on both sides and published from the **root** barrel, where upstream's
-`Text/index.ts` publishes them — not from `./theme`, whose barrel does not carry them either.
-Both are published-but-unapplied upstream too (nothing in Astryx's own `src/` references
-`TextXStyleAllowed`; its `Text`/`Heading` type `xstyle` the ordinary way), so they are ported
-as surface rather than imposed on our props, which would narrow an API upstream leaves open.
-**6 missing exports remain** (`TableContext` was the seventh and was fixed at batch-11 close). **37 over-exports** in five patterns — the count grew by five rather than shrinking, and the batch-11 sweep is why the number is now trustworthy: it diffed against upstream's **source** barrels rather than its published `dist/`, which lags (`DropdownMenu/index.d.ts` is missing three names its source exports, and a dist-based diff would have invented three false over-exports). The five patterns: `Layer`'s four anchor-name helpers + `getPositionTryFallbacks` (module-public upstream, barrel-absent — the `focusableSelector` rule); four named aliases for unions upstream inlines (`CarouselGap`, `DividerOrientation`, `ProgressBarFillVariant`, `AbsoluteTimestampFormat` — the same class as the three removed this batch); ten context provider/reader wrappers that duplicate an already-public `Context` object, contradicting the convention our own barrel states three times (the batch-12 sweep re-derived this sub-count as **twelve**, not ten — seven setters, four readers and `MetadataListContextValue`; the headline 37 was right, only the breakdown was off); the seven `./naming` symbols duplicated at the root, which upstream keeps off the root entirely; and **eight** Svelte-only state types that are legitimate but undocumented (`LinkifySegment`, `MediaQueryState`, `ImageModeState`, `ScrollOverflow`, `OutlineFromDOMState`, and from batch 11 `StreamingTextState`, `BaseTablePlugins`, `OutlineFromMarkdownState`), plus `LightboxTriggerProps`, a named alias for a shape upstream inlines twice — the same class as the four aliases above, missed when `Lightbox` landed. **The state-type family is one decision, not eight findings, and it grows by roughly one per hook ported**: each is the object wrapper a Svelte hook needs so a value upstream returns plain can stay live across a component's lifetime. Two coherent resolutions — promote it to sanctioned Svelte-only surface beside `LayerProps`/`StyleArg`/`TooltipLayer` under one written rule, or keep the interfaces module-public and off the barrel (a caller writing `const s = useStreamingText(…)` still gets the type structurally; only naming it in a signature becomes impossible). Publishing them _while_ documenting `LayerProps` and not these is the one option that is not defensible. Worth settling before the next hook lands
+**The 9 missing exports are 0.** `ButtonVariantMap`, `DropdownMenuContext`, `TableContext`,
+`TextXStyleAllowed` and `ProseElement` closed in earlier batches. The last three closed here:
+
+- **`FormLayoutContext`** — the `Context` object itself is now published, as upstream's
+  `FormLayout/index.ts` publishes it and as `RadioListContext` and `SizeContext` already were.
+  `setFormLayoutContext`/`useFormLayout` are the Svelte wrappers _around_ it, never a substitute.
+- **`SizeProvider`** — `internal/size-scope.svelte`, published under upstream's name. Its own
+  docstring had argued against exporting it, on the grounds that `setSizeContext` was already
+  the counterpart. That was wrong, and the paragraph directly above it said why: `setSizeContext`
+  cascades to a component's _whole_ subtree, where `SizeProvider` scopes to _part_ of one. They
+  are different capabilities and only one of them can express upstream's.
+- **`useTruncation`, `UseTruncationOptions`, `UseTruncationReturn`** — the hook existed as
+  `createTruncation`/`Truncation` in `internal/`, module-private and under a name upstream does
+  not use. Renamed to upstream's and published; `attach` stands in for upstream's `ref`, which is
+  the standing ref-callback→attachment mapping.
+
+**The 37 over-exports resolve into a stated rule rather than a sweep.** The entry's own reading
+was that the eight-strong Svelte-only state-type family "is one decision, not eight findings",
+that it grows by roughly one per hook ported, and that publishing some while documenting
+`LayerProps` and withholding others "is the one option that is not defensible". The decision is
+made and written at the head of `src/lib/index.ts`: **a Svelte-only name is published when it
+appears on an already-published signature, and stays module-public otherwise.** That is the
+argument the `BaseTablePlugins` / `TableContextProvider` and `TableFilterFieldRef` notes were
+already making case by case; all eight members satisfy it, so nothing is removed and the
+inconsistency was the absent rule rather than the exports.
+
+Still open, and deliberately not swept during a release: the seven `./naming` symbols duplicated
+at the root (upstream keeps them off the root entirely), the four named aliases for unions
+upstream inlines (`CarouselGap`, `DividerOrientation`, `ProgressBarFillVariant`,
+`AbsoluteTimestampFormat`) plus `LightboxTriggerProps`, the ten-to-twelve context
+provider/reader wrappers, and `Layer`'s anchor-name helpers. Every one of those is a _removal_
+from a surface that has shipped, which is a breaking change and belongs at a minor, not in the
+polish pass before a patch.
 
 ### `./theme` barrel drift, pre-existing, surfaced by the same sweep
 
@@ -543,21 +550,6 @@ as surface rather than imposed on our props, which would narrow an API upstream 
 - **retires:** when `generateThemeCss`/`generateOnMediaCss` and `ThemeConfig`/`ComponentOverrides` are renamed to match upstream, and the remaining `theme/types.ts` + over-exports are swept
 
 ~90 names upstream's `theme/index.ts` publishes that ours does not. **Batch 8 closed the `Theme`/`useTheme` family** (`Theme`, `ThemeContext`, `ThemeContextValue`, `useTheme`, `UseThemeReturn`, `ThemeMode`, `ResolvedThemeMode`, `resolveThemeToken(s)`, the two options types, `tokenVar`, `tokenVars`, `tokenDefaults`) and started `theme/types.ts`, which now holds `ThemeMode` alone — the prose-theming types in it land with the Prose-defaults item. What remains is chiefly the per-group token `*Vars`/`*Defaults` exports and the rest of `theme/types.ts` — plus 13 over-exports and two name drifts (`generateThemeCss`/`generateOnMediaCss` vs upstream's `…CSS`; `ThemeConfig`/`ComponentOverrides` vs `DefineThemeInput`/`ComponentStyleMap`)
-
-### Ten `./utils` symbols sit on the wrong subpath
-
-- **units:** -
-- **kind:** api-divergence
-- **retires:** when `SizeValue`, `parseStyleKey`, `themeProps`, `themeDataAttributes`, `ClassProps`, `ClassValue`, `ThemeProps`, `ThemeDataAttributes`, `observeResize` and `unobserveResize` move to `./utils`
-
-(batch-7 sweep). Upstream's `utils/index.ts`
-publishes `SizeValue`, `parseStyleKey`, `themeProps`, `themeDataAttributes`, `ClassProps`,
-`ClassValue`, `ThemeProps`, `ThemeDataAttributes`, `observeResize` and `unobserveResize`; ours
-are all reachable but from the _root_ (or, for `parseStyleKey`, from `./theme`). This is the
-consumer-visible half of the Phase 1 "consolidate two homes for one upstream dir" item, which
-until now was recorded only as an internal-imports problem: `import {themeProps} from
-'@astryx-svelte/core/utils'` fails here where upstream's succeeds. Placement, not absence — one
-directory to fix
 
 ### Three `./theme` names have no upstream counterpart or the wrong one
 
@@ -607,21 +599,6 @@ So `HoverCard`'s `server markup matches first client render` case is dropped (a 
 - **retires:** when SvelteKit's Vite plugin can wrap a dynamic import under the vitest browser provider
 
 The lazy-`Tooltip` code split (`Text`/`Heading`/`Timestamp`); SvelteKit's Vite plugin can't wrap a dynamic import under the vitest browser provider. Non-fatal, but the split path isn't exercised as in a real build
-
-### `ButtonGroup` drops 2 of 26 cases, whose blocker has since landed unreflected
-
-- **units:** ButtonGroup
-- **kind:** unported
-- **retires:** when `button-group.svelte.test.ts` is updated to add the two `DropdownMenu`-trigger cases now that `DropdownMenu` has landed
-
-`ButtonGroup` drops 2 of 26 cases (`rounds a trailing DropdownMenu trigger`) — `DropdownMenu` unported
-
-> **Re-verified 2026-08-15 while routing this file.** `DropdownMenu` has since been ported in full
-> (`packages/core/src/lib/components/dropdown-menu/`, exported from the root barrel, wired into the
-> class oracle), but `button-group.svelte.test.ts`'s own header still reads "**Dropped:** the two
-> `rounds a trailing DropdownMenu trigger` cases… `DropdownMenu` is not ported" and the suite is
-> still 23 declarations / 26 of 28 cases. The named blocker cleared without the cases being
-> restored — a real, standing coverage gap, just no longer for the reason the file states.
 
 ### `Icon` demo hand-draws an SVG for component mode
 
@@ -1040,3 +1017,172 @@ registry entry belongs to this port's own codemods, written against the `magic-s
 `template --list` shows nothing from core and `init --features template` returns `skipped`. The page
 template _content_ has separately landed as demo and docs assets — 42 of them — so this is the CLI's
 own scaffolding catalog rather than the templates themselves.
+
+### `SideNavItem` puts `xstyle`/`class`/`style` on its wrapper, where upstream's collapsed branch takes neither
+
+- **units:** SideNavItem
+- **kind:** api-divergence
+- **retires:** never, unless upstream gives the wrapper those props
+
+`{...rest}` moved onto the item element at 0.4.2 (#5048's sibling hardening pass), which is where
+upstream lands it and where a consumer's `aria-*`, `title` or handler belongs — that half now
+matches. The styling props did not move: upstream's collapsed-with-children branch renders
+`<div {...stylex.props(styles.root, xstyle)}>` and drops `className`/`style` entirely, so a
+consumer's class is discarded there. Ours applies all three to the wrapper. Forwarding is the
+better behaviour and dropping it to match would be a regression, so the divergence is recorded
+rather than closed.
+
+### The 0.4.2 test delta — mostly closed; 26 SideNav and 12 Slider cases remain
+
+- **units:** SideNav, Slider
+- **kind:** unported
+- **retires:** when both suites' counts match upstream's at the current pin
+
+The 0.4.2 tracking batch tracked implementation drift and did not track the **test** delta.
+Upstream added roughly 90 cases at that tag; the batch ported 21. The closing audits found it,
+and the polish pass closed most of it — **about 105 cases added** across thirteen suites:
+
+| Suite                    | Added         | Covers                                                                                                                  |
+| ------------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `menu-hover`             | 21 (new file) | the whole `useMenuHover` suite, for a hook the batch rewrote and this port had no suite for at all                      |
+| `side-nav`               | 17            | the `useMenuHover` guard, the eight shared-focus-ring cases, the five size-cascade cases                                |
+| `layer`                  | 14            | the nine `context hosting` cases, the five `offset` cases absent since before 0.4.0, and one beyond-upstream regression |
+| `top-nav` (x3 files)     | 8             | `TopNavHeading`'s hover guard and both drawer focus-ring pairs                                                          |
+| `slider`                 | 7             | the three `THUMB_INSET` `it.each` blocks (#5051)                                                                        |
+| `avatar`                 | 6             | the box moving to the theme target, and whitespace-only name/alt                                                        |
+| `container-reveal`       | 5             | `hoverDelay`, `forceState`, `forceVisibility` (#5084)                                                                   |
+| `chat-message`           | 4             | ghost alignment and the `width` cap (#2574)                                                                             |
+| `dropdown-menu-sub-menu` | 3             | the hover/click guard                                                                                                   |
+| `hover-card`             | 2             | the nested-theme portal and live custom properties                                                                      |
+| `button-group`           | 2             | the two `DropdownMenu` cases whose stated blocker had cleared                                                           |
+| `focus-trap`             | 1             | a trap with no tabbable controls (#5023)                                                                                |
+
+The mega-menu focus-ring case is **mutation-checked**: reverting `megaMenuItemDrawerAttrs` to its
+bare `sx(...)` turns it red, so it genuinely catches the defect the audits found rather than
+passing either way.
+
+**What remains, named rather than implied:**
+
+- **SideNav — 26 of the 43.** The forced-colors compiled-output pair, the flyout hover-intent and
+  coarse-pointer gates, the collapsed-submenu keyboard path and its focus restore, Tab order and
+  disabled-item skipping, the catalog-named submenu dialog and its translation, prop forwarding on
+  `SideNavItem`, and the hidden section header. The seventeen that _are_ ported were chosen as the
+  ones verifying what the 0.4.2 hardening pass changed.
+- **Slider — 12 blocks**, listed in `src/tests/slider.svelte.test.ts`'s header: `isRequired`,
+  `minStepsBetweenThumbs` and RTL pointer mirroring, three behaviours the suite does not exercise
+  at all. Predates 0.4.2 — the header claimed "nothing dropped" at 32 while upstream has had >=45
+  since v0.2.0.
+
+**The rule this earns:** a tracked release's test delta is part of its scope, not a follow-up. The
+batch's own headline change — `THUMB_INSET` — shipped with zero coverage while the ledger described
+it as transcribed and routed, and `useLayer`'s unported `context hosting` block is precisely what
+would have caught the two Layer defects the idiom audit found instead.
+
+## Retired
+
+Closed, kept as the record. **Nothing below counts as an open debt** — `scripts/status.mjs` stops
+tallying at this heading, and `astryx-parity` must not find a retired entry when it greps for
+"is this drift already known?", or it would skip live drift.
+
+### `{...rest}` position now matches upstream everywhere it is observable
+
+- **units:** Breadcrumbs, Heading, Lightbox, SideNav, TopNav, Collapsible, MobileNav, ChatComposerDrawer, CodeBlock, Text
+- **kind:** deliberate-divergence
+- **retires:** retired — kept as the record of how the measurement was wrong
+
+**Closed.** The entry previously read "upstream spreads rest **last** in eleven components and
+**first** in fifteen … four more (`Collapsible`, `MobileNav`, `ChatComposerDrawer`, `CodeBlock`)
+invert precedence for `data-*` reflections only". Both halves were wrong. Re-measured
+mechanically against `v0.4.2` — every `.svelte` under `components/` whose `{...rest}` is followed
+by an attribute the component writes itself (`aria-*`, `role`, `title`, `data-*`, a handler),
+cross-checked against whether the upstream counterpart's root spread is trailing:
+
+- The four named were **not** in the observable set at all. They are pure `data-*` reflection
+  cases, flipped here for consistency.
+- The observable set was **five**, and the entry named none of them: `Breadcrumbs` (`aria-label`),
+  `Heading` (`aria-level`, `title`), `SideNav` (`aria-label`, `role`), `TopNav` (the same, on both
+  its branches) and `Lightbox` (`oncancel`, `onclick`). A consumer could not override any of them.
+- `Text` was a sixth, found by the 0.4.2 parity audit rather than by the sweep: it writes
+  `title={tooltipEnabled ? … : undefined}` _after_ the spread, and a later `undefined` **removes**
+  an attribute — so a consumer's own `title` was discarded on every untruncated `Text`.
+
+All ten now match upstream's position, and the sweep reports **0 drift**.
+
+`Lightbox` was the entry's stated reason for leaving the set alone ("upstream's order lets a
+caller-supplied `oncancel` _replace_ `handleCancel`, so Escape stops calling `onOpenChange(false)`").
+That is a real upstream bug, and it is not an argument for the wrong spread order — it is an
+argument for the rule `CLAUDE.md` already carries: an event the component handles itself is
+destructured out of `$props()` and invoked explicitly. `oncancel` is now composed the way `onclick`
+and `onkeydown` already were, so the consumer is heard, `preventDefault()` still pins the dialog
+open, and the spread's position stops mattering.
+
+**The rule this earns:** a debt that states a count is as rotten as a test header that states one.
+This one had been carried across three batches on an estimate nobody re-measured, and it named
+four components that were never the problem while missing all five that were.
+
+### `TypeRole` takes no `weight` — retired
+
+- **units:** theme/expand-type-scale.ts, cli (assets/theme.template.ts)
+- **kind:** api-divergence
+- **retires:** retired at 0.4.2 polish
+
+**Closed.** `TypeRole` now declares `weight` alongside `weights`, and
+`expandTypeScale` resolves it exactly as upstream's `defineTheme` does: on `heading` it fills
+every level `weights` does not name, on `body` and `code` it sets that text role's token
+directly, and `weights` wins where both apply. `TypeWeight` also widened to
+`… | (string & {})` to match upstream's `FontWeight`, which documents raw CSS values as a
+deliberate escape hatch — and a new `resolveWeight` keeps the named/raw split upstream's
+`resolveFontWeight` draws, so `'bold'` becomes `var(--font-weight-bold)` while `'900'`
+passes through.
+
+Upstream's six-case `describe('typography weight derivation')` is ported into
+`src/tests/theme.test.ts`, reading `resolvedTokens` rather than `tokens` because this port
+keeps the raw input map separate — against the wrong map every one of them would pass
+vacuously.
+
+The annotated theme template documents `weight` now instead of naming this entry as the
+reason not to; `packages/cli/scripts/check-theme-template.test.mjs` still passes 7/7, which
+is what keeps the two in step.
+
+### `Timestamp` expanded `useDevWarning` inline — retired, and the entry's premise was wrong
+
+- **units:** Timestamp, Field, hooks/useDevWarning
+- **kind:** deliberate-divergence
+- **retires:** retired at 0.4.2 polish
+
+**Closed, but not the way the entry described.** It read "`Timestamp` warns from an `$effect`
+(client-only); upstream warns during render (server too)" and proposed moving `Timestamp` to
+`Field`'s shape. Both halves were wrong, and checking upstream is what showed it: upstream's
+`useDevWarning` is `useRef` + **`useEffect`**, so it does not warn during SSR either, and
+`Field` reaches it through this port's own `useDevWarning`, which is an `$effect` — the two
+shapes were already identical and neither warned on the server. There was no SSR difference to
+close.
+
+The real divergence was narrower and is now fixed: this port's `useDevWarning` took `message`
+as a plain string captured at init, where upstream's is an ordinary argument re-evaluated each
+render and listed in the effect's dependency array. `Timestamp` interpolates the value that
+failed to parse, so a captured string would have reported the mount-time value — which is
+exactly why it expanded the hook inline instead of calling it. `message` now accepts
+`string | (() => string)`, and `Timestamp` calls the hook like every other consumer.
+
+**The rule this earns:** a debt that asserts what upstream does is worth re-reading against
+upstream before acting on it. This one would have had us "fix" a difference that did not exist
+while leaving the one that did.
+
+### Ten `./utils` symbols sat on the wrong subpath — retired
+
+- **units:** -
+- **kind:** api-divergence
+- **retires:** retired at 0.4.2 polish
+
+**Closed.** `SizeValue`, `parseStyleKey`, `themeProps`, `themeDataAttributes`, `ClassProps`,
+`ClassValue`, `ThemeProps`, `ThemeDataAttributes`, `observeResize` and `unobserveResize` are all
+on `./utils` now, so `import {themeProps} from '@astryx-svelte/core/utils'` resolves here as it
+does upstream.
+
+Two things deliberately did **not** move. The _files_ stay in `internal/` and `theme/`: they are
+imported by name across the tree and relocating them is whole-tree churn with no
+consumer-visible effect — that half of the "two homes for one upstream dir" item stays open in
+`port/todo.md` as the internal-imports problem it always was. And the root re-exports stay,
+because they have shipped since 0.3.1 and removing one to tidy a barrel would break a consumer
+for no gain. This was placement, and adding the missing placement is the whole fix.

--- a/port/ledger/009-batch-8.md
+++ b/port/ledger/009-batch-8.md
@@ -85,7 +85,11 @@ Not recorded separately from the component notes above.
       the first unmount deletes — leaving the survivor unstyled with nothing to re-inject it. Ours
       counts, and removes the tag at zero. Invisible for `__built` themes, which is every theme this
       repo ships, and that is exactly why it was worth fixing rather than waiting for a report
-- [ ] **Upstream bug (documented, not replicated-away): `tokenDefaults` omits `borderDefaults`.**
+- [x] **Upstream bug (documented, not replicated-away): `tokenDefaults` omits `borderDefaults`.**
+      ~~See below.~~ **Retired at upstream 0.4.2** (#5026), which folded `borderDefaults` into
+      `CoreTokenName` and `tokenDefaults`. This port followed in `028-upstream-0.4.2.md`, and
+      `focusDefaults` — missing here but present upstream since before 0.4.1 — landed in the same
+      pass. The original entry follows.
       Upstream ships the group, publishes a `BorderVarName` type for it, and then leaves it out of
       the flat map — so `tokenVars` and every `useTheme().tokens` is missing `--border-width`. Ours
       matches the omission, because the parity rule puts upstream bugs here rather than in the code:

--- a/port/ledger/028-upstream-0.4.2.md
+++ b/port/ledger/028-upstream-0.4.2.md
@@ -1,0 +1,405 @@
+---
+seq: 28
+title: Upstream 0.4.2 — the SideNav/useMenuHover consolidation, Layer's template marker, and coarse-pointer targets
+upstream: 0.4.2
+date: 2026-08-16
+units:
+  [
+    Avatar,
+    AvatarGroup,
+    Button,
+    ButtonGroup,
+    Card,
+    Chat,
+    CheckboxInput,
+    CodeBlock,
+    CommandPalette,
+    DateTimeInput,
+    DropdownMenu,
+    HoverCard,
+    InputGroup,
+    Item,
+    Layer,
+    MobileNav,
+    NavItem,
+    RadioList,
+    SideNav,
+    Slider,
+    Switch,
+    TabList,
+    Text,
+    Thumbnail,
+    Timestamp,
+    Toolbar,
+    TopNav,
+    TreeList,
+    hooks/useContainerReveal,
+    hooks/useFocusTrap,
+    hooks/useMenuHover,
+    theme/derivedVarRegistry,
+    theme/defineTheme,
+    theme/tokens,
+    locales/en,
+    themes/butter,
+    themes/chocolate,
+    themes/gothic,
+    themes/stone,
+    cli
+  ]
+upstream-prs:
+  [
+    2574,
+    3121,
+    4363,
+    4506,
+    4546,
+    4555,
+    4654,
+    4783,
+    4963,
+    4964,
+    4967,
+    5015,
+    5016,
+    5023,
+    5026,
+    5030,
+    5039,
+    5046,
+    5047,
+    5048,
+    5051,
+    5064
+  ]
+---
+
+## Scope
+
+Track Astryx `0.4.2` (tagged 2026-08-15) from the `0.4.1` pin. No component directory was added,
+deleted or renamed upstream, so the surface count is unchanged; the whole batch is drift inside
+directories this port already ships. 28 `packages/core/src` component directories changed, plus
+three hooks, the theme internals and the `en` locale catalog. All 28 are ported here, so nothing in
+the delta lands as "not yet ported".
+
+**Deliberately excluded**, each already a standing entry rather than a new decision:
+
+- `packages/lab` (`ListInput`, `TransferList`) and `packages/richtext` — unstarted fronts. The
+  `@astryx.listInput.*` namespace #4967 added **is** in scope, because the catalog is core's, not
+  lab's; it ports as catalog keys with no consumer here.
+- `assets/templates/pages/ai-chat` and the new `ChatMessageBubbleCustomContent` block — the CLI's
+  page-template scaffolding catalog, deferred by `debts.md` → "Upstream's template assets stay
+  deferred from the CLI's own catalog".
+- `clients/cli/commands/*.doc.mjs`, `api/theme/themeTemplate.doc.mjs` and
+  `foundation/response/response-types.doc.mjs` — this port's CLI describes its commands through
+  Commander rather than per-command doc modules, so those three upstream files have no counterpart.
+- `scripts/check-portable-scripts.mjs` and `scripts/score-ledger.mjs` — upstream's own repo
+  tooling, with no relationship to this tree.
+
+## Themes
+
+`--radius-none` moved from `0.125rem` to `0px` in butter, chocolate, gothic and stone: it is fixed
+by contract alongside `--radius-full` and must never be scaled by a theme. `neutral` already carried
+both the value and the comment, which is where upstream's propagated text came from. All seven
+theme oracles report `mismatch: 0` at the new pin — and the four that changed are exactly the four
+that had a mismatch beforehand, which is a pleasant confirmation that the oracle sees theme drift
+precisely.
+
+## Tokens, re-derived rather than carried forward
+
+`borderDefaults` and `focusDefaults` both joined `tokenDefaults`: upstream folded the first in at
+0.4.2 (#5026), and the second had simply been missed on this side since before 0.4.1. With both in,
+our flat token map is **exactly upstream's minus the domain group** — same families, same counts,
+nothing extra on either side, and the only absentees the `--color-data-*` / `--color-syntax-*`
+tokens this port does not ship. That is the whole check track-upstream asks for, and it is the first
+time the two maps have agreed family for family.
+
+## InputGroup / Button — one selector, three call sites
+
+`button groupStyles.horizontal`, `groupStyles.vertical` and `group-styles groupStyles.inGroup` all
+mismatched for one reason, and it is the Layer change below rather than anything about groups:
+`IS_LAST_ITEM` has to skip the inert `<template>` marker as well as the popover, so
+`:not(:has(~ *:not([popover])))` became `:not(:has(~ *:not([popover]):not(template)))`. Upstream
+also collapsed `group-styles`' older `:last-child` + two `:has(+ [popover]…)` variants onto the same
+const. Seven CSS-oracle rules closed with them.
+
+`InputGroupText` keeps a plain `:first-child`/`:last-child` pair — a text addon owns no layer — and
+its docstring now says so in those terms rather than naming the deleted variants.
+
+## Coarse-pointer targets (#4963, #4964)
+
+WCAG 2.5.8 AA. Five components, three shapes:
+
+- `Switch`, `CheckboxInput`, `RadioListItem` — the visually-hidden `<input>` **is** the tappable
+  target, so it floors to 24×24 and centres on the control under `@media (pointer: coarse)`. One
+  identical block in three modules, applied as such.
+- `Thumbnail` — a `::after` overlay driven by a new private `--_thumbnail-hit-inset`, documented in
+  `theming.vars[]` because #4963 landing it undocumented is what left upstream's derived-var guard
+  red on `main`.
+- `Slider` — the track is clickable along its whole length but only 20px tall, so its block size
+  floors to 24px on touch.
+
+Only the invisible tappable area changes in every case; rails, thumbs and glyphs stay put.
+
+## Slider — thumb inset (#5051)
+
+Thumb travel is inset by half a thumb at each end, which is the geometry a native
+`input[type=range]` uses: at `min`/`max` the thumb no longer overhangs the component box by 10px.
+`insetPosition`, `insetSpan` and `travelFraction` transcribe unchanged, and the fill, the marks and
+the pointer-to-value mapping all route through them, so the thumb stays under the pointer that
+grabbed it. `THUMB_SIZE` had to become an export: upstream is one file and reads a module-private
+const, and the number has to cross this port's `.stylex.ts` / `.svelte` boundary rather than be
+written down twice.
+
+## Avatar (#5030)
+
+The avatar's box moved from the content circle onto the wrapper — the element carrying the
+`astryx-avatar` theme target — so a theme rule on the documented `size` axis resizes the whole
+avatar instead of growing a wrapper around a fixed-size circle. A whitespace-only `name`/`alt` is
+now treated as absent (`meaningfulName`/`meaningfulAlt`), which stops an empty plate rendering
+behind a blank accessible name.
+
+**The bare `console.warn` finally moved.** This port kept it verbatim through three batches with a
+comment explaining that upstream's `Avatar.tsx` was the one site still writing one; 0.4.2 moved
+upstream's onto `useDevWarning`, so ours moved in the same pass and the comment became history
+rather than justification.
+
+## Layer (#5039, #5064) — the largest unit
+
+A context layer now renders an inert `<template>` marker at its position in the template, and the
+marker's parent decides where the real container mounts: inline when that parent is safe, or
+portaled to the nearest element outside every unsafe ancestor when it is not. `layerHost.ts` — the
+pure function that walks the chain — transcribes unchanged, along with its 19-case suite.
+
+Two things about the Svelte translation:
+
+- **There is no `createPortal`.** The container renders in place and an attachment moves it, which
+  is the device `ChatComposerInput` already uses. **The cleanup is load-bearing here, where that one
+  needs none** — see "Rules promoted".
+- **`setTriggerEl` stopped being dead.** This port had dropped it, with a note that upstream's
+  `triggerElRef` was written and never read. 0.4.2 reads it: `showPopover({source: triggerRef})`
+  passes the trigger as the popover's invoker so a hosted-away layer still takes its focus order
+  from the trigger. It came back as `attachTrigger`, and the note came out.
+
+`lazyMount` defers mounting until `show()`, and `HoverCard` opts in so rich content never enters an
+invalid paragraph even briefly — which is also why its content element went from `<span>` back to
+`<div>`. #5064 gave every layer its own `font-size`/`line-height` rather than inheriting the
+trigger's, so the same Tooltip no longer renders at 13px from a caption and 20px from a lede.
+
+## useMenuHover (#3121) — five adopters, one machine
+
+The hover→click guard, the time-bounded reopen suppression, synchronous focus, keyboard activation
+that always opens, and focus restoration all moved into the shared hook. `TopNavMegaMenu` lost its
+private copy (#4555's original home) and `SideNavItem` lost its hand-rolled timers; `TopNavMenu`,
+`TopNavHeading`, `SideNavHeading` and `DropdownMenuSubMenu` gained the guard they never had.
+
+**The one-shot flag becoming a timestamp forced a real observer.** This port had translated
+upstream's `useIsomorphicLayoutEffect` on `[isOpen]` into a lazy `syncHoverMode()` at the top of
+each handler, and documented the narrow gap that left. That works for a boolean and is wrong for
+`closedAt`: stamping lazily records the time of the _re-hover_, not of the close, so a deliberate
+re-hover seconds later would be suppressed. It is now an `$effect` keyed on an `isOpen` `$derived`,
+which is the same "notify only when the value changes" the dependency list meant.
+
+## SideNav — 17 of the 27 class-oracle mismatches
+
+The hardening pass, in one commit upstream and one unit here: forced-colors `Highlight`/
+`HighlightText` on the selected row (a 6% background tint flattens away entirely under forced
+colors, leaving the current page unmarked); the shared focus ring on every focusable row, with the
+link and the chevron ringed individually in a split-action row; reduced-motion guards on three
+transitions; the flyout's second square-cornered surface removed and its gap moved to the positioned
+layer where `DropdownMenu` keeps it; `alignSelf: stretch` so the primary action fills the row rather
+than collapsing to a 20px line box.
+
+Four consumer-visible changes came with it: `footerIcons` cascade a `sm` size through `SizeContext`;
+`SideNavCollapseButton` takes a `size`; it takes the controlled `collapsible` config, which is how a
+button outside the sidenav stays in step without an imperative handle (`handleRef` is deprecated in
+its favour); and the collapsed flyout's hover is gated on `(hover: hover)`.
+
+`SideNavSection`'s hand-rolled clip rectangle became `VisuallyHidden`, and the two branches are
+separate elements rather than one element with a conditional style, as upstream's are. The shared
+header body moved into a snippet so they cannot drift.
+
+**`SizeProvider` had no counterpart.** `setSizeContext` cascades to a component's _whole_ subtree,
+which is what `Toolbar` wants; upstream wraps _part_ of `SideNav`'s output. `internal/size-scope.svelte`
+is the boundary component that makes that possible — the device `side-nav-collapse-scope.svelte`
+already established, unexported for the same reason.
+
+## The rest
+
+- **`useContainerReveal`** grew `hoverDelay` (a dwell gate, mouse-only, surviving reduced motion
+  because an intent gate is timing rather than motion), `forceState` on the container and
+  `forceVisibility` on a single element. Every remaining CSS-oracle rule closed with it.
+- **`useFocusTrap`** (#5023): a modal surface with no tabbable controls keeps its programmatic focus
+  target instead of letting Tab escape. `hasActiveFocusTrapEscape` and `isImeKeyEvent` joined the
+  `./hooks` barrel — this port already had both, module-private, with a note that upstream's barrel
+  named neither.
+- **`ChatMessageBubble.width`** (#2574), so ghost-bubble custom content can span the full message
+  column instead of the `max(80%, 280px)` cap.
+- **i18n**: the whole `en` catalog was adopted verbatim (263 → 284 keys — it was already a
+  byte-identical subsequence of upstream's). `CommandPaletteFooter`'s three keyboard hints and
+  `DateTimeInput`'s two time placeholders stopped being hardcoded English.
+- **`derivedVarRegistry`** gained `context-menu`, whose `ContextMenu.doc.mjs` mapping had been dead
+  since it was written.
+- **Heading's `type`** is a documented theming target, which stops `theme build` warning
+  `Unknown prop "type"` on every theme that sets a type scale.
+
+## Oracle bookkeeping
+
+| Oracle          | Before | After                                |
+| --------------- | -----: | ------------------------------------ |
+| Class parity    |     30 | 0 (1621 keys, 515 inline call sites) |
+| CSS parity      |     37 | 0 (5937 rules, 10 skips)             |
+| Theme parity ×7 |      4 | 0                                    |
+
+Three mode flips, all one mechanism — a call site that starts going through
+`focusOutlineProps.focusVisible(...)` passes its styles through a runtime function StyleX cannot
+fold, so the keys stay objects and the inline claim has to be deleted rather than repaired:
+`side-nav-heading` lost three (`heading+headingLink`, `chevron+interactive`, `popoverHeading`) and
+`side-nav-item` two (`expandToggle`, `splitAction`). The reverse happened once: `avatar`'s `content`
+stopped taking a dynamic size, started folding, and needed an inline entry it never had.
+
+No skips were added, and none retired.
+
+## What the closing audits caught
+
+Six agents across the four axes (parity split three ways over 24 changed component dirs, plus
+idiom, test-parity and the repo-wide surface sweep). They found **one release blocker and six
+defects**, and the blocker was in the batch's own headline feature.
+
+**First, the audits were nearly run against the wrong tree.** `reference/astryx-upstream`'s
+worktree was still checked out at `v0.4.1` — the batch was built by diffing tags, which reads
+fetched refs and never touches the worktree, so nothing had forced it forward. Every agent would
+have reported the entire batch as invented drift. Checked out to `v0.4.2` first; `port/status.md`
+regenerated identically against it, which is consistent with 0.4.2 adding, deleting and renaming
+no component directory.
+
+### The blocker: every `HoverCard` in an unsafe host mounted hidden
+
+`<p>`, `<a>`, `<td>`, `<li>` — the exact positions #5039's corrective portal exists to serve. The
+card opened, was evicted from the top layer, and never came back. Reproduced in Chromium
+(`:popover-open === false`, `display: none`), with a safe-host control passing.
+
+Three faults compounded, and each is now a rule in `astryx-idiom.md`:
+
+1. **`attachSentinel` read `isOpen` — a `$state` — where upstream reads `isOpenRef.current`.** A
+   ref read cannot subscribe; a `$state` read inside an attachment does. Opening the layer
+   re-ran the attachment. The docstring immediately above said "Reading `lazyMount` is the only
+   tracked read here", which is true only while `lazyMount` is false — the short-circuit means
+   the reads after it are still reached.
+2. **`requestContextMount` always allocated a fresh object**, so `contextMount`'s identity changed
+   even when its contents did not, and `{@attach intoPortal(...)}` — keyed on that identity —
+   tore down and re-appended. React is immune: an equal `contextMount` re-renders into the same
+   `createPortal` container and moves no DOM. Here the identity change _is_ the move.
+3. **`intoPortal` treated a `null` target as a no-op**, so a render call moving from a `<p>` into a
+   `<section>` removed the container and never put it back. Svelte will not re-insert a node it
+   considers already rendered.
+
+A fourth followed from fixing the third: `attachPopover` is a stable function, so it never re-ran
+on a mount change and its own "changing a portal target remounts the container" re-show branch
+could not fire. `<Layer>` now threads the mount through it.
+
+**Every one of these lived in the nine `useLayer` `describe('context hosting')` cases upstream
+added in the same release, and none had been ported.**
+
+### The other defects
+
+| Defect                                                                                                                                 | Origin                       |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `SideNavHeading`'s collapsed flyout heading button still wired to `triggerProps.onclick`, not `close` — Enter/Space never dismissed it | missed 0.4.2 change          |
+| The collapsed heading trigger never registered with `useMenuHover`, so Escape restored focus to nothing                                | missed 0.4.2 change          |
+| `TopNavMegaMenuItem`'s drawer row drew no focus ring — `sx(...)` where upstream composes `focusOutlineProps.focusVisible(...)`         | missed 0.4.2 change          |
+| `AvatarGroupOverflow` omitted `size` from `themeProps`                                                                                 | **introduced by this batch** |
+| `Switch` omitted `size` from both `themeProps` calls                                                                                   | pre-existing                 |
+| `TreeList` had no `hasExpandableItems`, so a wholly flat tree indented every row                                                       | pre-existing (#4540)         |
+
+The two `size` gaps share a shape worth naming: the `.doc.mjs` regeneration ran and published
+`visualProps: ['size']` on both targets while the components never followed, so the port
+**documented theming axes it did not emit**. Neither oracle can see it — the class oracle walks
+upstream's keys, and `data-size` is not a style.
+
+Surface was comparatively clean: two missing exports (`BreadcrumbMenuDividerProps`,
+`ContextMenuDividerProps` — we shipped five of six aliases in each family) and three CLI barrel
+over-exports (`buildHelp`, `buildKit`, `importSpecifier`, all module-private upstream). Every
+symbol _this batch_ added was correct. The three `Indicator` props aliases the sweep flagged were
+left in place and are covered by the existing "named aliases for what upstream inlines" entry —
+they follow this port's own `<script module>` convention and removing them would break a surface
+that shipped at 0.4.1.
+
+One agent claim did not verify: a stray `zz-temp-idiom-probe.svelte.test.ts`. No such file exists.
+
+### The systemic finding
+
+**The batch tracked implementation drift and did not track the test delta.** Upstream added ~90
+cases at 0.4.2; the batch ported 21. Four suite headers asserted counts that were false — one
+("32 upstream cases … nothing dropped") had never been true of any tag. Closed here: `useLayer`'s
+nine hosting cases plus one beyond-upstream regression, the whole 21-case `useMenuHover` suite
+(new upstream; this port had none for a hook the batch rewrote), Slider's three `THUMB_INSET`
+blocks, HoverCard's two portal cases, SideNav's four `useMenuHover` cases, and `button-group`'s
+two `DropdownMenu` cases whose stated reason ("not ported") had expired batches ago. The
+remainder is a debt with the full list.
+
+## What the audits caught during the batch
+
+- **The generated `.doc.mjs` files were hand-edited first.** Twelve of them, before noticing the
+  `@generated by docs/scripts/emit-core-docs.mjs — do not edit` header at the top of each. Reverted;
+  `pnpm -r build && pnpm -F docs emit-core-docs` then landed all 17 correctly, including the nine
+  this batch had not got to. Promoted to `CLAUDE.md`.
+- **`{#if}` teardown does not follow a moved node.** Caught by a test, not by review: the
+  `portals block content before showing and restores the marker after hiding` case timed out with
+  the layer still in the DOM after hiding. See "Rules promoted".
+- **The theme template's `weight` claim was a lie**, caught by writing the template against our own
+  `TypeRole` rather than transcribing upstream's example. Recorded in `debts.md` and the template
+  now documents `weights` alone.
+- **Four suites read a layer that no longer exists while closed**, all of them HoverCard's, and
+  every one restated the way upstream restated its own: `timestamp` (15 cases — its `awaitCard`
+  helper now opens the card, and the keyboard-reachability case dropped a content comparison that
+  only ever worked because the layer was mounted cold), `trigger-rewire` (2 — the wiring is read
+  off the trigger, where it has always been, rather than off the layer), and `hover-card` itself
+  (5 restated, 3 SSR). `table-context-menu` is the corrective portal rather than `lazyMount`: a
+  `<td>` sits inside four unsafe hosts, so scoping a menu query to the cell finds nothing.
+- **Two test suites were marker-blind.** `button-group` and `toolbar` count group members with
+  `:scope > *:not([popover])`; the marker made four cases fail. Upstream restated the same
+  selectors in the same release, which is a good sign the seam is real rather than ours.
+- **The CLI's bundled theme copies went stale** the moment the theme sources changed —
+  `test:themes-bundle` caught it, and `pnpm -F @astryx-svelte/cli generate-themes` is the fix.
+
+## Rules promoted
+
+From the closing audits:
+
+- `.claude/agents/astryx-idiom.md` — three new rules, all from the Layer blocker: a portal
+  attachment must handle the move _back_ (a `null` target is a move, not a no-op); an attachment
+  keyed on a per-resolve object needs an equality bail-out **and** its inverse checked (an
+  attachment that must re-run on change gets nothing from a stable function reference); and a
+  React `ref` read is non-tracking where a `$state` read is not, so a sampled read needs
+  `untrack` — with the note that a docstring claiming "X is the only tracked read here" is a
+  claim to verify, since short-circuits still reach the reads after it.
+- `.claude/skills/track-upstream/SKILL.md` — new step 5b: diff the **test** delta and treat it as
+  scope, with an added test _file_ as the loudest signal; then re-derive every suite header's
+  count against the new tag.
+- `CLAUDE.md` § Testing — the count is a contract against upstream's file _at the current pin_, so
+  a version bump invalidates every header that states one; and a dropped case's stated reason
+  expires too (`button-group` carried "`DropdownMenu` is not ported" for three batches after it
+  was).
+
+From the batch itself:
+
+- `CLAUDE.md` § The docs site — `packages/core/src/lib/**/*.doc.mjs` are generated by
+  `docs/scripts/emit-core-docs.mjs`; a version bump lands the whole prose delta with one command,
+  and hand-editing them is a mistake the header already warns about.
+- `.claude/agents/astryx-idiom.md` — a node moved out of an `{#if}` block survives its own unmount,
+  because teardown clears the range between the block's anchors in the _original_ parent; a portal
+  attachment must return `() => node.remove()`.
+- `.claude/agents/astryx-oracle.md` — a call site that starts going through a runtime helper flips
+  inline → object (and back), with the "upstream has no matching call site" tell and both 0.4.2
+  examples.
+
+## Debts opened
+
+- `TypeRole` takes no `weight`, so a theme cannot set one default weight per role
+- `SideNavItem` puts `xstyle`/`class`/`style` on its wrapper, where upstream's collapsed branch
+  takes neither
+- The 0.4.2 test delta is only partly ported: 39 SideNav cases and 12 Slider cases are absent
+  (opened by the closing audits, with the full per-suite list)
+
+**Retired:** `009-batch-8.md`'s `tokenDefaults` omits `borderDefaults` — upstream folded it in at
+0.4.2 (#5026), and `focusDefaults`, missing on this side only, landed with it.

--- a/port/status.md
+++ b/port/status.md
@@ -13,15 +13,15 @@
 | Missing here              | none                                                                     |
 | Not in upstream           | none                                                                     |
 | Theme packages            | 8 — butter, chocolate, gothic, liquid-glass, matcha, neutral, stone, y2k |
-| Upstream pin              | `@astryxdesign/core` 0.4.1                                               |
-| Ledger entries            | 28                                                                       |
+| Upstream pin              | `@astryxdesign/core` 0.4.2                                               |
+| Ledger entries            | 29                                                                       |
 
 ## Debts
 
 | Kind                  | Count  |
 | --------------------- | ------ |
 | api-divergence        | 27     |
-| deliberate-divergence | 44     |
+| deliberate-divergence | 42     |
 | unported              | 11     |
 | upstream-lag          | 12     |
-| **total**             | **94** |
+| **total**             | **92** |

--- a/port/todo.md
+++ b/port/todo.md
@@ -12,12 +12,16 @@ The first npm release shipped as `0.3.1` (porting Astryx `0.3.0` — the port's 
 can't express a release of its own, so it took the next free patch number instead of `0.3.0`
 itself). Since then the goal has been continuous upstream tracking rather than a one-time port:
 pull each Astryx release, close the class-oracle and theme-oracle drift it introduces, and cut a
-matching release of this port. The pin is currently Astryx `0.4.1` — see
-[`status.md`](./status.md) for the live count of what that leaves open. Set 2026-08-15.
+matching release of this port. The pin is currently Astryx `0.4.2` — see
+[`status.md`](./status.md) for the live count of what that leaves open. Set 2026-08-16.
 
 ## Next
 
 - [ ] Push the release tag for the current pin once its gate is green (see Open work → Release)
+- [ ] Finish the 0.4.2 test delta — 39 SideNav cases and 12 Slider cases, plus smaller counts in
+      Avatar, TopNav, ChatMessageBubble, useContainerReveal, DropdownMenuSubMenu and useFocusTrap.
+      The release-blocking part is done (useLayer's hosting block, the whole useMenuHover suite,
+      Slider's inset blocks, HoverCard's portal pair); `debts.md` carries the per-suite list
 - [ ] Re-sweep the demo route against upstream now that later batches have landed
 - [ ] Build `ThemesPreview`/`TemplatesPreview`, the two landing-page bento tiles — both were
       blocked on page templates, which have since landed in full

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -122,7 +122,12 @@ const pin =
 
 // --- Debts by kind ---------------------------------------------------------
 
-const debtsText = existsSync('port/debts.md') ? readFileSync('port/debts.md', 'utf8') : '';
+const debtsFile = existsSync('port/debts.md') ? readFileSync('port/debts.md', 'utf8') : '';
+// Stop at `## Retired`: entries below it are closed and kept only as the record.
+// Counting them would report a debt that no longer exists, and the same heads are
+// what `astryx-parity` greps to ask whether drift is already known.
+const retiredAt = debtsFile.indexOf('\n## Retired');
+const debtsText = retiredAt === -1 ? debtsFile : debtsFile.slice(0, retiredAt);
 const debtKinds = {};
 for (const match of debtsText.matchAll(/^- \*\*kind:\*\* (.+)$/gm)) {
 	const kind = match[1].trim();


### PR DESCRIPTION
Ports Astryx **0.4.2**, and fixes what the closing audits found.

No component was added, deleted or renamed upstream, so this is drift inside directories the port already shipped: 28 component directories, three hooks, the theme internals, the `en` catalog, and the new `theme template` CLI command.

## The blocker

**A `HoverCard` inside a `<p>`, `<a>`, `<td>` or `<li>` mounted hidden and never appeared** — the exact positions #5039's corrective portal exists to serve. Reproduced in Chromium (`:popover-open === false`), with a safe-host control passing.

Three faults compounded, each now a rule in `.claude/agents/astryx-idiom.md`:

1. `attachSentinel` read the `isOpen` `$state` where upstream reads `isOpenRef.current`. A ref read cannot subscribe; a `$state` read inside an attachment does, so opening the layer re-ran the attachment.
2. `requestContextMount` reallocated an equal mount object, and `{@attach intoPortal(...)}` is keyed on that object's identity — so it tore down and re-appended. React is immune here: an equal `contextMount` re-renders into the same `createPortal` container and moves no DOM. In Svelte the identity change **is** the move.
3. `intoPortal` treated a `null` target as a no-op, so a render call moving from a `<p>` into a `<section>` lost its container permanently.

Removing a showing popover evicts it from the top layer without firing `toggle`. Fixing (3) exposed a fourth: `attachPopover` is a stable function reference, so it never re-ran on a mount change and its own re-show branch could not fire.

## Five more defects

| Defect | Origin |
| --- | --- |
| `SideNavHeading`'s collapsed flyout could not be dismissed from the keyboard, and restored focus to nothing | missed 0.4.2 change |
| `TopNavMegaMenuItem`'s drawer row drew no focus ring | missed 0.4.2 change |
| `AvatarGroupOverflow` omitted `size` from `themeProps` | introduced by this batch |
| `Switch` omitted `size` from both `themeProps` calls | pre-existing |
| `TreeList` had no `hasExpandableItems`, so a flat tree indented every row | pre-existing |

The two `size` gaps share a shape: the `.doc.mjs` regeneration published `visualProps: ['size']` while the components never followed, so the port **documented theming axes it did not emit**. Neither oracle can see that — the class oracle walks upstream's keys, and `data-size` is not a style.

## Why it happened

**The batch tracked implementation drift and did not track the test delta.** Upstream added ~90 cases at this tag; the first pass ported 21 — including none of the nine `useLayer` `context hosting` cases that exercise exactly the paths that broke.

~105 cases have since landed across thirteen suites, including the whole 21-case `useMenuHover` suite, which this port had never had for a hook it rewrote from scratch. Four suite headers stated counts true of no upstream tag.

The mega-menu focus-ring case is **mutation-checked**: reverting the fix turns it red.

## Debts

Seven retired. Two were not merely stale but **wrong**:

- The `{...rest}` entry named four components that were never the problem and missed all five that were. On `Text`, a consumer's `title` was discarded on every untruncated instance — `title={… : undefined}` sat after the spread, and a later `undefined` removes an attribute.
- The `Timestamp` entry asserted upstream "warns during render (server too)". Upstream's `useDevWarning` is `useEffect`-based; there was no SSR difference. The real divergence was our hook capturing `message` at init.

Retired entries moved under a `## Retired` heading, and `scripts/status.mjs` now stops tallying there — a closed debt was being counted as open, and `astryx-parity` greps those same heads to ask whether drift is already known.

## Verified

- Both fidelity oracles at zero: 1,621 style keys, 515 inline call sites, **no skips**; `astryx.css` matches upstream across 1,504 shared classes; all seven theme oracles clean.
- The token map matches upstream family for family for the first time.
- 165 client files / 4,621 cases, plus 854 server cases.
- `pnpm check:publish --version 0.4.2` green on all ten publishable packages.

## Not in scope

26 SideNav and 12 Slider cases remain unported, named individually in `port/debts.md`. They cover behaviour this release did not change; porting them properly is a batch of its own.

**This does not tag.** The manifests and CHANGELOG are at 0.4.2, but publishing still needs the `workflow_dispatch` dry-run and then the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
