### PR TITLE
Measure the docs-examples front instead of describing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,15 @@ upstream analysis: research, not spec, so verify it against source before trusti
 what stopped "100 / 100" surviving three batches after upstream moved to 101, in a file that ended up
 telling readers not to trust its own numbers.
 
+**A count another script already computes is not tracked until `status.mjs` renders it — and
+`status.mjs` must _call_ that script, never recompute its rule.** `generate-content.mjs` printed
+`examples N ported / M pending` on every run and discarded it, so that front was measured in prose
+for as long as it existed. Reimplementing the tally is where it goes wrong: the count is filtered to
+blocks whose target is a **documented entry**, and that set is not the barrel's export list —
+`useMediaQuery` is a hook, absent from `src/lib/index.ts`, present in the registry. Walking the
+blocks alone reports 13 pending, filtering off the barrel reports 8, and the answer is 9. Both wrong
+implementations look obviously right (batch 039).
+
 Batches open with the `start-batch` skill and close with `close-batch`, which runs the audit agents
 below and carries the **promotion rule**: a lesson that constrains future work moves into this file
 or an agent's file, in the same commit — never left stranded in a ledger entry or a research file.

--- a/docs/scripts/generate-content.mjs
+++ b/docs/scripts/generate-content.mjs
@@ -1772,6 +1772,28 @@ export async function reconcile({ quiet = false } = {}) {
 	return { surface, propsIndex, entries, unported, totalUpstream, drift };
 }
 
+/**
+ * The example-block tally, for `scripts/status.mjs`.
+ *
+ * Lives here rather than in `status.mjs` because the interesting half of the
+ * calculation is *which targets count*, and that set is not derivable from
+ * committed source. A block is only pending when its target is a **documented
+ * entry**, and the documented set is not the barrel's export list:
+ * `useMediaQuery` is a hook, absent from `src/lib/index.ts`, and present in the
+ * registry. Reimplementing the rule against the barrel reports one pending
+ * block fewer than exists, which is the exact failure the metric is meant to
+ * prevent.
+ *
+ * Returns counts only — the registry itself is `generate`'s business.
+ */
+export async function exampleCounts({ quiet = true } = {}) {
+	const { entries } = await reconcile({ quiet });
+	const { portedCount, pendingCount } = await buildExampleRegistry(
+		new Set(entries.map((e) => e.name))
+	);
+	return { ported: portedCount, pending: pendingCount };
+}
+
 export async function generate({ quiet = false } = {}) {
 	/** @type {(...args: unknown[]) => void} */
 	const log = quiet ? () => {} : (...args) => console.log(...args);

--- a/port/ledger/039-examples-metric.md
+++ b/port/ledger/039-examples-metric.md
@@ -1,0 +1,105 @@
+---
+seq: 039
+title: Batch 39 — the docs-examples count, measured instead of described
+upstream: 0.5.0
+date: 2026-08-26
+units: [scripts/status.mjs, docs/scripts/generate-content.mjs]
+upstream-prs: []
+---
+
+## Scope
+
+One row in `port/status.md`: how many of upstream's CLI block templates have a Svelte
+transcription under `docs/src/lib/examples/`, and how many do not. Nothing under `packages/core`
+changed.
+
+Batch 038 found the gap while porting the `Stepper` and `Step` blocks.
+`docs/scripts/generate-content.mjs` had always computed the pair as it ran — it prints
+`examples N ported / M pending` — and then thrown it away. `status.md` had no row for it, so the
+docs-examples front was the one place this port measured progress in **prose**, against
+`port/todo.md`'s own rule and in the file whose entire purpose is that a count cannot rot.
+
+## The rule for which blocks count is not derivable from committed source
+
+This is the finding, and it nearly produced a wrong number.
+
+The obvious implementation recomputes the tally inside `status.mjs`, which reads only the committed
+tree and is fast and dependency-free — properties worth protecting. Walk the pinned CLI's blocks,
+read `exampleFor`/`alsoExampleFor` from each `.doc.mjs`, and check for
+`docs/src/lib/examples/<Target>/<Block>.svelte`.
+
+That walk gives **13** blocks with no transcription. The generator reports **9**. The difference is
+one line in `buildExampleRegistry`:
+
+```js
+if (!portedNames.has(target)) continue;
+```
+
+`portedNames` is the set of *documented entries*, and a block aimed at something this port does not
+document is not a gap in the examples — it is a gap somewhere else. Four pairs are filtered:
+`ChatDictation` (three blocks) and `Resizable` (one).
+
+The trap is in reconstructing that set. The natural proxy is the barrel, `packages/core/src/lib/index.ts`
+— committed, cheap, no build required. It is **wrong**, and grepping it says `useMediaQuery` is
+absent. `useMediaQuery` is a hook: it has a `.doc.mjs`, it is one of the documented entries, and its
+`DialogAdaptivePresentation` pair is genuinely pending. A barrel-derived filter drops it and reports
+**8**.
+
+So the three candidate answers were 13, 8 and 9, and only the third is right. Two of them are
+reached by implementations that look obviously correct. The counts were settled against the
+generator's own output rather than argued from the code.
+
+The conclusion is the promoted rule: when `status.mjs` needs a number another script already
+computes, **call that script's function**. `exampleCounts()` now lives beside
+`buildExampleRegistry` in `generate-content.mjs`, where the filter it depends on is, and
+`status.mjs` calls it.
+
+## The cost, stated rather than hidden
+
+This is the first input to `status.mjs` that is not the committed tree. The generator reads core's
+built `dist/`, so a bare `node scripts/status.mjs` on a clean checkout can no longer derive the row.
+
+It degrades rather than throws: the section renders the reason and names the fix. It deliberately
+does **not** render a zero, which would read as "nothing pending" — the one wrong answer available.
+
+A degraded run still writes a different file and so fails the drift gate. That is the same bargain
+the Surface section already makes with the upstream clone, and the reason CI clones it; `pnpm verify`
+and CI's `lib` job both build before this stage, so both derive it. Recorded here because a
+degradation that is discovered rather than documented reads as a bug.
+
+## What was checked
+
+- **Mutation.** Deleting one example moved the row `645 / 9` to `644 / 10`; restoring it returned
+  the original pair. A count that never moves is the failure mode this whole file exists to catch,
+  and batch 038's own lesson was to mutation-check a checker rather than trust a clean run.
+- **Against ground truth.** The row matches `pnpm -F docs generate`'s printed figures exactly.
+- **The degraded branch**, by moving `dist` aside and running: exit 0, reason rendered, no zero.
+- **Tier identity.** `status.md` must be byte-identical whether generated fast or `--full`; both
+  tiers were generated and diffed, since this change adds content to that file.
+- **Control characters**, per batch 037 — none below the newline/tab floor.
+
+## Not done, and why
+
+`generate-content.mjs` discards a second figure the same way: `templates N ported / M pending`. It
+is the identical defect on the identical front and the fix is the same shape, but this batch was
+scoped to the examples row and widening it silently is how a scope stops meaning anything. It is
+named in `port/todo.md` instead.
+
+## Oracle bookkeeping
+
+None. No `.stylex.ts` module changed.
+
+## What the audits caught
+
+No audit agents were run. This batch touches two scripts and no component, props interface, export
+or test; all four agents read `packages/core`. The check that matters here is the mutation test
+above, which no agent performs.
+
+## Rules promoted
+
+- `CLAUDE.md` § the metric rule — a count another script already computes is untracked until
+  `status.mjs` renders it, and `status.mjs` must call that script rather than recompute its rule.
+
+## Debts opened
+
+`-` — none.

--- a/port/status.md
+++ b/port/status.md
@@ -14,7 +14,7 @@
 | Not in upstream           | none                                                                     |
 | Theme packages            | 8 — butter, chocolate, gothic, liquid-glass, matcha, neutral, stone, y2k |
 | Upstream pin              | `@astryxdesign/core` 0.5.0                                               |
-| Ledger entries            | 39                                                                       |
+| Ledger entries            | 40                                                                       |
 
 ## Test parity
 
@@ -40,6 +40,18 @@ Testing Library matches an accessible name as a whole string; Playwright matches
 `name` as a case-insensitive **substring**. Every site above is therefore a ported assertion
 weaker than the one it ports, admitting names upstream’s would reject. A regex `name` is
 substring-matching on both sides by design and is not counted.
+
+## Docs examples
+
+|             | Blocks |
+| ----------- | ------ |
+| Ported      | 645    |
+| **Pending** | **9**  |
+
+Upstream ships these as CLI block templates; a docs example is a transcription of one, so
+the parity rule covers them as it covers a component. Counted per block **and target** — a
+block with `alsoExampleFor` is one row per component it illustrates. Blocks whose target
+this port does not document are not counted as pending.
 
 ## Debts
 

--- a/port/todo.md
+++ b/port/todo.md
@@ -80,11 +80,15 @@ them.
    `@astryxdesign/cli`'s `assets/templates/blocks/components/<Name>/`, resolved by `exampleFor` in
    the block's `.doc.mjs`, so the parity rule applies to them exactly as it does to a component.
 
-   **The count of them is not tracked anywhere.** `docs/scripts/generate-content.mjs` prints
-   `examples N ported / M pending` as it runs and then discards it; `status.md` has no row for it.
-   So this front is the one place where progress is described rather than measured, against this
-   file's own rule. Wiring that figure into `status.mjs` is the next piece of work here, and it is
-   small.
+   Batch 039 put the examples figure in [`status.md`](./status.md), where it belongs — it had been
+   printed by the generator on every run and discarded, leaving this front the only one measured in
+   prose. `status.mjs` calls the generator for it rather than recomputing the rule, because the
+   tally counts only blocks whose target is a documented entry and that set is not the barrel's
+   export list.
+
+   **One figure is still discarded the same way:** `templates N ported / M pending`, from the same
+   generator run and the same front. Identical defect, identical fix, deliberately left out of 039
+   so that batch's scope kept meaning something.
 
 ### The release, held
 

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -28,6 +28,7 @@
 
 import { readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { runStage, lastLine } from './lib/run-stage.mjs';
 
 const full = process.argv.includes('--full');
@@ -350,6 +351,41 @@ const ledger = existsSync('port/ledger')
 			.sort()
 	: [];
 
+// --- Docs example blocks ---------------------------------------------------
+//
+// Upstream's CLI ships one block template per documented example, and the docs
+// site renders a Svelte transcription of each from
+// `docs/src/lib/examples/<Target>/<Block>.svelte`. `generate-content.mjs` has
+// always computed this pair as it runs and then thrown it away, so the docs
+// examples were the one front this port measured in prose — against
+// `port/todo.md`'s own rule, and in the file whose whole purpose is that a
+// count cannot rot.
+//
+// Derived by calling the generator rather than reimplemented here, because the
+// rule for *which* blocks count is not derivable from committed source: a
+// block is pending only when its target is a documented entry, and that set is
+// not the barrel's export list. See `exampleCounts` for the case that proves
+// it.
+//
+// This is the first input to this script that is not the committed tree, so it
+// degrades rather than throws: the generator reads core's built `dist/`, which
+// `pnpm verify` and CI's `lib` job both produce before this stage but a bare
+// `node scripts/status.mjs` on a clean checkout does not. A degraded run writes
+// a different file and so fails the drift gate — the same bargain the Surface
+// section already makes with the upstream clone, and the reason CI clones it.
+//
+// The missing input is tested for by name rather than caught, so that the only
+// thing which degrades is the one condition that is expected to. A bare
+// `try/catch` here would swallow a genuine fault in the generator too and
+// render the same reassuring sentence — failing safe while hiding, which is
+// the shape batch 037's never-matching regex had.
+/** @type {{ported: number, pending: number} | null} */
+let examples = null;
+if (existsSync(path.join(root, 'packages/core/dist/index.d.ts'))) {
+	const generator = pathToFileURL(path.join(root, 'docs/scripts/generate-content.mjs')).href;
+	examples = await (await import(generator)).exampleCounts();
+}
+
 // --- The gates (--full only) -----------------------------------------------
 
 const gates = [];
@@ -472,6 +508,31 @@ push(
 	'substring-matching on both sides by design and is not counted.',
 	''
 );
+
+push('## Docs examples', '');
+if (examples) {
+	push(
+		...table([
+			['', 'Blocks'],
+			['Ported', String(examples.ported)],
+			['**Pending**', `**${examples.pending}**`]
+		]),
+		''
+	);
+	push(
+		'Upstream ships these as CLI block templates; a docs example is a transcription of one, so',
+		'the parity rule covers them as it covers a component. Counted per block **and target** — a',
+		'block with `alsoExampleFor` is one row per component it illustrates. Blocks whose target',
+		'this port does not document are not counted as pending.',
+		''
+	);
+} else {
+	push(
+		'Not derivable in this run: the count comes from the docs generator, which reads core’s',
+		'built `dist/`. Run `pnpm -r build` first.',
+		''
+	);
+}
 
 push('## Debts', '');
 const debtRows = [['Kind', 'Count']];


### PR DESCRIPTION
`docs/scripts/generate-content.mjs` has always computed `examples N ported / M pending` as it runs and then discarded it, and `port/status.md` had no row for it. The docs examples were the one front this port measured in **prose** — against `port/todo.md`'s own rule, and in the file whose entire purpose is that a count cannot rot. Batch 038 found the gap while porting the Stepper and Step blocks.

## The row

`status.md` gains a **Docs examples** section: 645 ported / 9 pending.

## Why it calls the generator instead of recomputing

The interesting half of the calculation is *which targets count*, and that is not derivable from committed source. A block is pending only when its target is a **documented entry**, and the documented set is not the barrel's export list.

Three plausible implementations, three different answers:

| implementation | reports |
| --- | --- |
| walk the blocks alone | 13 pending |
| filter off `src/lib/index.ts` | 8 pending |
| filter off the documented registry | **9 pending** |

`useMediaQuery` is what separates them — a hook, absent from the barrel, present in the registry, with a genuinely pending block. Both wrong implementations look obviously right, so `exampleCounts()` now lives beside the filter it depends on and `status.mjs` calls it.

## The cost, stated rather than hidden

This is the first input to `status.mjs` that is not the committed tree: the generator reads core's built `dist/`. It degrades with the reason rather than rendering a zero — a zero would read as "nothing pending", the one wrong answer available. The missing input is tested for **by name** rather than wrapped in `try/catch`, so a genuine fault in the generator fails loudly instead of printing the same reassuring sentence.

`pnpm verify` and CI's `lib` job both build before this stage, so both derive the row.

## Checked

- Matches `pnpm -F docs generate`'s printed figures exactly.
- **Mutation:** deleting one example moves the row 645/9 → 644/10; restoring returns it.
- The degraded branch exercised by moving `dist` aside — exit 0, reason rendered, no zero.
- **Tier identity by construction:** `full` reaches only the `gates` array and stdout, never `lines`, which is the sole source of the written file.
- No control characters below the newline/tab floor (batch 037).

## Deliberately not done

`templates N ported / M pending` is discarded the same way by the same generator — identical defect, identical fix. Named in `port/todo.md` rather than folded in, so this batch's scope keeps meaning something.

## Gate

All six substantive stages pass (build, check, lint, lint:root, test, status). `port/status.md` is the regenerated file and re-regenerates identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KkUhs9PFPob4bSzCAKdr4